### PR TITLE
Improve complex switch handling, avoid possible var name collisions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 node_modules/
 package-lock.json
 .vscode
+**/__*
+examples/cli/*.h
+*.gch
+*.ir.json

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+# Generated C/C++ is on the scale of MBs; unnecessary in the npm package
+.github
+examples
+test

--- a/examples/mcpc-protocol/build/pc1_18_handshaking_toClient.h
+++ b/examples/mcpc-protocol/build/pc1_18_handshaking_toClient.h
@@ -231,10 +231,10 @@ size_t command_node(pdef::Stream &stream, const pdef::pc1_18_handshaking_toClien
 size_t packet(pdef::Stream &stream, const pdef::pc1_18_handshaking_toClient::packet &obj);
   size_t slot(pdef::Stream &stream, const pdef::pc1_18_handshaking_toClient::slot &obj) {
     size_t len = 0;
-    const bool &present = obj.present; /*0.1*/
-    if (present == false) { /*8.1*/
+    const bool &V_present = obj.present; /*0.1*/
+    if (V_present == false) { /*8.1*/
     }
-    else if (present == true) { /*8.1*/
+    else if (V_present == true) { /*8.1*/
         len += stream.sizeOfVarInt(obj.itemId); /*0.2*/
         len += 1; /*0.2*/
         len += 1; /*0.2*/
@@ -243,23 +243,23 @@ size_t packet(pdef::Stream &stream, const pdef::pc1_18_handshaking_toClient::pac
   }
   size_t particle(pdef::Stream &stream, const pdef::pc1_18_handshaking_toClient::particle &obj) {
     size_t len = 0;
-    const int &particleId = obj.particleId; /*0.1*/
-    if (particleId == 2) { /*8.2*/
+    const int &V_particleId = obj.particleId; /*0.1*/
+    if (V_particleId == 2) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_2_or_3_or_24); const pdef::pc1_18_handshaking_toClient::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.6*/
         len += stream.sizeOfVarInt(v2.blockState); /*0.2*/
     }
-    else if (particleId == 3) { /*8.2*/
+    else if (V_particleId == 3) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_2_or_3_or_24); const pdef::pc1_18_handshaking_toClient::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.6*/
         len += stream.sizeOfVarInt(v2.blockState); /*0.2*/
     }
-    else if (particleId == 14) { /*8.2*/
+    else if (V_particleId == 14) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_14); const pdef::pc1_18_handshaking_toClient::particle::Data14 &v2 = *obj.data_14; /*8.6*/
         len += 4; /*0.2*/
         len += 4; /*0.2*/
         len += 4; /*0.2*/
         len += 4; /*0.2*/
     }
-    else if (particleId == 15) { /*8.2*/
+    else if (V_particleId == 15) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_15); const pdef::pc1_18_handshaking_toClient::particle::Data15 &v2 = *obj.data_15; /*8.6*/
         len += 4; /*0.2*/
         len += 4; /*0.2*/
@@ -269,24 +269,24 @@ size_t packet(pdef::Stream &stream, const pdef::pc1_18_handshaking_toClient::pac
         len += 4; /*0.2*/
         len += 4; /*0.2*/
     }
-    else if (particleId == 24) { /*8.2*/
+    else if (V_particleId == 24) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_2_or_3_or_24); const pdef::pc1_18_handshaking_toClient::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.6*/
         len += stream.sizeOfVarInt(v2.blockState); /*0.2*/
     }
-    else if (particleId == 35) { /*8.2*/
+    else if (V_particleId == 35) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_35); const pdef::pc1_18_handshaking_toClient::particle::Data35 &v2 = *obj.data_35; /*8.6*/
         len += 1; /*0.2*/
     }
-    else if (particleId == 36) { /*8.2*/
+    else if (V_particleId == 36) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_36); const pdef::pc1_18_handshaking_toClient::particle::Data36 &v2 = *obj.data_36; /*8.6*/
         len += 1; /*origin: bitfield*/ /*4.1*/
         len += stream.sizeOfVarInt(v2.positionType.length());
         len += v2.positionType.length(); /*positionType^: pstring*/ /*4.1*/
-        const std::string &positionType = v2.positionType; /*4.7*/
-        if (positionType == "minecraft:block") { /*8.0*/
+        const std::string &V_positionType = v2.positionType; /*4.7*/
+        if (V_positionType == "minecraft:block") { /*8.0*/
           len += 1; /*destination: bitfield*/ /*4.1*/
         }
-        else if (positionType == "minecraft:entity") { /*8.0*/
+        else if (V_positionType == "minecraft:entity") { /*8.0*/
           len += stream.sizeOfVarInt(v2.destination_varint); /*0.2*/
         }
         len += stream.sizeOfVarInt(v2.ticks); /*0.2*/
@@ -298,7 +298,7 @@ size_t packet(pdef::Stream &stream, const pdef::pc1_18_handshaking_toClient::pac
     len += stream.sizeOfVarInt(obj.group.length());
     len += obj.group.length(); /*group: pstring*/ /*4.1*/
     len += stream.sizeOfVarInt(obj.ingredient.size()); /*1.3*/
-    for (const auto &v2 : obj.ingredient) {
+    for (const auto &v2 : obj.ingredient) { /*3.2*/
       len += 1; /*0.2*/
     }
     len += 1; /*0.2*/
@@ -311,7 +311,7 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_handshaking_toClient::tags 
     len += stream.sizeOfVarInt(obj.tagName.length());
     len += obj.tagName.length(); /*tagName: pstring*/ /*4.1*/
     len += stream.sizeOfVarInt(obj.entries.size()); /*1.3*/
-    for (const auto &v2 : obj.entries) {
+    for (const auto &v2 : obj.entries) { /*3.2*/
       len += stream.sizeOfVarInt(v2); /*0.2*/
     }
   PDEF_SIZE_DBG; return len;
@@ -327,169 +327,169 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_handshaking_toClient::tags 
   size_t command_node(pdef::Stream &stream, const pdef::pc1_18_handshaking_toClient::command_node &obj) {
     size_t len = 0;
     len += 1; /*flags^: bitfield*/ /*4.1*/
-    const pdef::pc1_18_handshaking_toClient::command_node::flags_t &flags = obj.flags; /*4.7*/
+    const pdef::pc1_18_handshaking_toClient::command_node::flags_t &V_flags = obj.flags; /*4.7*/
     len += stream.sizeOfVarInt(obj.children.size()); /*1.3*/
-    for (const auto &v2 : obj.children) {
+    for (const auto &v2 : obj.children) { /*3.2*/
       len += stream.sizeOfVarInt(v2); /*0.2*/
     }
-    if (flags.has_redirect_node == 1) { /*8.2*/
+    if (V_flags.has_redirect_node == 1) { /*8.2*/
       len += stream.sizeOfVarInt(obj.redirectNode); /*0.2*/
     }
-    if (flags.command_node_type == 0) { /*8.2*/
+    if (V_flags.command_node_type == 0) { /*8.2*/
     }
-    else if (flags.command_node_type == 1) { /*8.2*/
+    else if (V_flags.command_node_type == 1) { /*8.2*/
         EXPECT_OR_BAIL(obj.extraNodeData_1); const pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData1 &v2 = *obj.extraNodeData_1; /*8.6*/
         len += stream.sizeOfVarInt(v2.name.length());
         len += v2.name.length(); /*name: pstring*/ /*4.1*/
     }
-    else if (flags.command_node_type == 2) { /*8.2*/
+    else if (V_flags.command_node_type == 2) { /*8.2*/
         EXPECT_OR_BAIL(obj.extraNodeData_2); const pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData2 &v2 = *obj.extraNodeData_2; /*8.6*/
         len += stream.sizeOfVarInt(v2.name.length());
         len += v2.name.length(); /*name: pstring*/ /*4.1*/
         len += stream.sizeOfVarInt(v2.parser.length());
         len += v2.parser.length(); /*parser^: pstring*/ /*4.1*/
-        const std::string &parser = v2.parser; /*4.7*/
-        if (parser == "brigadier:bool") { /*8.0*/
+        const std::string &V_parser = v2.parser; /*4.7*/
+        if (V_parser == "brigadier:bool") { /*8.0*/
         }
-        else if (parser == "brigadier:float") { /*8.0*/
+        else if (V_parser == "brigadier:float") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_brigadier_float); const pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData2::PropertiesBrigadierFloat &v4 = *v2.properties_brigadier_float; /*8.6*/
             len += 1; /*flags^: bitfield*/ /*4.1*/
-            const pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData2::PropertiesBrigadierFloat::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData2::PropertiesBrigadierFloat::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               len += 4; /*0.2*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               len += 4; /*0.2*/
             }
         }
-        else if (parser == "brigadier:double") { /*8.0*/
+        else if (V_parser == "brigadier:double") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_brigadier_double); const pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData2::PropertiesBrigadierDouble &v4 = *v2.properties_brigadier_double; /*8.6*/
             len += 1; /*flags^: bitfield*/ /*4.1*/
-            const pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData2::PropertiesBrigadierDouble::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData2::PropertiesBrigadierDouble::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               len += 8; /*0.2*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               len += 8; /*0.2*/
             }
         }
-        else if (parser == "brigadier:integer") { /*8.0*/
+        else if (V_parser == "brigadier:integer") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_brigadier_integer); const pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData2::PropertiesBrigadierInteger &v4 = *v2.properties_brigadier_integer; /*8.6*/
             len += 1; /*flags^: bitfield*/ /*4.1*/
-            const pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData2::PropertiesBrigadierInteger::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData2::PropertiesBrigadierInteger::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               len += 4; /*0.2*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               len += 4; /*0.2*/
             }
         }
-        else if (parser == "brigadier:long") { /*8.0*/
+        else if (V_parser == "brigadier:long") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_brigadier_long); const pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData2::PropertiesBrigadierLong &v4 = *v2.properties_brigadier_long; /*8.6*/
             len += 1; /*flags^: bitfield*/ /*4.1*/
-            const pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData2::PropertiesBrigadierLong::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData2::PropertiesBrigadierLong::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               len += 8; /*0.2*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               len += 8; /*0.2*/
             }
         }
-        else if (parser == "brigadier:string") { /*8.0*/
+        else if (V_parser == "brigadier:string") { /*8.0*/
         }
-        else if (parser == "minecraft:entity") { /*8.0*/
+        else if (V_parser == "minecraft:entity") { /*8.0*/
           len += 1; /*properties: bitfield*/ /*4.1*/
         }
-        else if (parser == "minecraft:game_profile") { /*8.0*/
+        else if (V_parser == "minecraft:game_profile") { /*8.0*/
         }
-        else if (parser == "minecraft:block_pos") { /*8.0*/
+        else if (V_parser == "minecraft:block_pos") { /*8.0*/
         }
-        else if (parser == "minecraft:column_pos") { /*8.0*/
+        else if (V_parser == "minecraft:column_pos") { /*8.0*/
         }
-        else if (parser == "minecraft:vec3") { /*8.0*/
+        else if (V_parser == "minecraft:vec3") { /*8.0*/
         }
-        else if (parser == "minecraft:vec2") { /*8.0*/
+        else if (V_parser == "minecraft:vec2") { /*8.0*/
         }
-        else if (parser == "minecraft:block_state") { /*8.0*/
+        else if (V_parser == "minecraft:block_state") { /*8.0*/
         }
-        else if (parser == "minecraft:block_predicate") { /*8.0*/
+        else if (V_parser == "minecraft:block_predicate") { /*8.0*/
         }
-        else if (parser == "minecraft:item_stack") { /*8.0*/
+        else if (V_parser == "minecraft:item_stack") { /*8.0*/
         }
-        else if (parser == "minecraft:item_predicate") { /*8.0*/
+        else if (V_parser == "minecraft:item_predicate") { /*8.0*/
         }
-        else if (parser == "minecraft:color") { /*8.0*/
+        else if (V_parser == "minecraft:color") { /*8.0*/
         }
-        else if (parser == "minecraft:component") { /*8.0*/
+        else if (V_parser == "minecraft:component") { /*8.0*/
         }
-        else if (parser == "minecraft:message") { /*8.0*/
+        else if (V_parser == "minecraft:message") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt") { /*8.0*/
+        else if (V_parser == "minecraft:nbt") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt_path") { /*8.0*/
+        else if (V_parser == "minecraft:nbt_path") { /*8.0*/
         }
-        else if (parser == "minecraft:objective") { /*8.0*/
+        else if (V_parser == "minecraft:objective") { /*8.0*/
         }
-        else if (parser == "minecraft:objective_criteria") { /*8.0*/
+        else if (V_parser == "minecraft:objective_criteria") { /*8.0*/
         }
-        else if (parser == "minecraft:operation") { /*8.0*/
+        else if (V_parser == "minecraft:operation") { /*8.0*/
         }
-        else if (parser == "minecraft:particle") { /*8.0*/
+        else if (V_parser == "minecraft:particle") { /*8.0*/
         }
-        else if (parser == "minecraft:angle") { /*8.0*/
+        else if (V_parser == "minecraft:angle") { /*8.0*/
         }
-        else if (parser == "minecraft:rotation") { /*8.0*/
+        else if (V_parser == "minecraft:rotation") { /*8.0*/
         }
-        else if (parser == "minecraft:scoreboard_slot") { /*8.0*/
+        else if (V_parser == "minecraft:scoreboard_slot") { /*8.0*/
         }
-        else if (parser == "minecraft:score_holder") { /*8.0*/
+        else if (V_parser == "minecraft:score_holder") { /*8.0*/
           len += 1; /*properties: bitfield*/ /*4.1*/
         }
-        else if (parser == "minecraft:swizzle") { /*8.0*/
+        else if (V_parser == "minecraft:swizzle") { /*8.0*/
         }
-        else if (parser == "minecraft:team") { /*8.0*/
+        else if (V_parser == "minecraft:team") { /*8.0*/
         }
-        else if (parser == "minecraft:item_slot") { /*8.0*/
+        else if (V_parser == "minecraft:item_slot") { /*8.0*/
         }
-        else if (parser == "minecraft:resource_location") { /*8.0*/
+        else if (V_parser == "minecraft:resource_location") { /*8.0*/
         }
-        else if (parser == "minecraft:mob_effect") { /*8.0*/
+        else if (V_parser == "minecraft:mob_effect") { /*8.0*/
         }
-        else if (parser == "minecraft:function") { /*8.0*/
+        else if (V_parser == "minecraft:function") { /*8.0*/
         }
-        else if (parser == "minecraft:entity_anchor") { /*8.0*/
+        else if (V_parser == "minecraft:entity_anchor") { /*8.0*/
         }
-        else if (parser == "minecraft:range") { /*8.0*/
+        else if (V_parser == "minecraft:range") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_minecraft_range); const pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData2::PropertiesMinecraftRange &v4 = *v2.properties_minecraft_range; /*8.6*/
             len += 1; /*0.2*/
         }
-        else if (parser == "minecraft:int_range") { /*8.0*/
+        else if (V_parser == "minecraft:int_range") { /*8.0*/
         }
-        else if (parser == "minecraft:float_range") { /*8.0*/
+        else if (V_parser == "minecraft:float_range") { /*8.0*/
         }
-        else if (parser == "minecraft:item_enchantment") { /*8.0*/
+        else if (V_parser == "minecraft:item_enchantment") { /*8.0*/
         }
-        else if (parser == "minecraft:entity_summon") { /*8.0*/
+        else if (V_parser == "minecraft:entity_summon") { /*8.0*/
         }
-        else if (parser == "minecraft:dimension") { /*8.0*/
+        else if (V_parser == "minecraft:dimension") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt_compound_tag") { /*8.0*/
+        else if (V_parser == "minecraft:nbt_compound_tag") { /*8.0*/
         }
-        else if (parser == "minecraft:time") { /*8.0*/
+        else if (V_parser == "minecraft:time") { /*8.0*/
         }
-        else if (parser == "minecraft:resource_or_tag") { /*8.0*/
+        else if (V_parser == "minecraft:resource_or_tag") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_minecraft_resource_or_tag_or_minecraft_resource); const pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData2::PropertiesMinecraftResourceOrTagOrMinecraftResource &v4 = *v2.properties_minecraft_resource_or_tag_or_minecraft_resource; /*8.6*/
             len += stream.sizeOfVarInt(v4.registry.length());
             len += v4.registry.length(); /*registry: pstring*/ /*4.1*/
         }
-        else if (parser == "minecraft:resource") { /*8.0*/
+        else if (V_parser == "minecraft:resource") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_minecraft_resource_or_tag_or_minecraft_resource); const pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData2::PropertiesMinecraftResourceOrTagOrMinecraftResource &v4 = *v2.properties_minecraft_resource_or_tag_or_minecraft_resource; /*8.6*/
             len += stream.sizeOfVarInt(v4.registry.length());
             len += v4.registry.length(); /*registry: pstring*/ /*4.1*/
         }
-        else if (parser == "minecraft:uuid") { /*8.0*/
+        else if (V_parser == "minecraft:uuid") { /*8.0*/
         }
-        if (flags.has_custom_suggestions == 1) { /*8.2*/
+        if (V_flags.has_custom_suggestions == 1) { /*8.2*/
           len += stream.sizeOfVarInt(v2.suggestionType.length());
           len += v2.suggestionType.length(); /*suggestionType: pstring*/ /*4.1*/
         }
@@ -498,7 +498,7 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_handshaking_toClient::tags 
   }
   size_t packet(pdef::Stream &stream, const pdef::pc1_18_handshaking_toClient::packet &obj) {
     size_t len = 0;
-    const pdef::pc1_18_handshaking_toClient::packet::Name &name = obj.name; /*0.3*/
+    const pdef::pc1_18_handshaking_toClient::packet::Name &V_name = obj.name; /*0.3*/
     len += stream.sizeOfVarInt((int&)obj.name); /*name^: varint*/ /*7.0*/
     PDEF_SIZE_DBG; return len;
   }
@@ -514,11 +514,11 @@ bool command_node(pdef::Stream &stream, const pdef::pc1_18_handshaking_toClient:
 bool packet(pdef::Stream &stream, const pdef::pc1_18_handshaking_toClient::packet &obj, bool allocate);
   bool slot(pdef::Stream &stream, const pdef::pc1_18_handshaking_toClient::slot &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::pc1_18_handshaking_toClient::size::slot(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const bool &present = obj.present; /*0.1*/
+    const bool &V_present = obj.present; /*0.1*/
     WRITE_OR_BAIL(writeBool, (bool)obj.present); /*0.4*/
-    if (present == false) { /*8.1*/
+    if (V_present == false) { /*8.1*/
     }
-    else if (present == true) { /*8.1*/
+    else if (V_present == true) { /*8.1*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.itemId); /*0.4*/
         WRITE_OR_BAIL(writeByte, (int8_t)obj.itemCount); /*0.4*/
         WRITE_OR_BAIL(writeByte, (int8_t)obj.nbtData); /*0.4*/
@@ -527,24 +527,24 @@ bool packet(pdef::Stream &stream, const pdef::pc1_18_handshaking_toClient::packe
   }
   bool particle(pdef::Stream &stream, const pdef::pc1_18_handshaking_toClient::particle &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::pc1_18_handshaking_toClient::size::particle(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const int &particleId = obj.particleId; /*0.1*/
+    const int &V_particleId = obj.particleId; /*0.1*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.particleId); /*0.4*/
-    if (particleId == 2) { /*8.2*/
+    if (V_particleId == 2) { /*8.2*/
         const pdef::pc1_18_handshaking_toClient::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.5*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.blockState); /*0.4*/
     }
-    else if (particleId == 3) { /*8.2*/
+    else if (V_particleId == 3) { /*8.2*/
         const pdef::pc1_18_handshaking_toClient::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.5*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.blockState); /*0.4*/
     }
-    else if (particleId == 14) { /*8.2*/
+    else if (V_particleId == 14) { /*8.2*/
         const pdef::pc1_18_handshaking_toClient::particle::Data14 &v2 = *obj.data_14; /*8.5*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.red); /*0.4*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.green); /*0.4*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.blue); /*0.4*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.scale); /*0.4*/
     }
-    else if (particleId == 15) { /*8.2*/
+    else if (V_particleId == 15) { /*8.2*/
         const pdef::pc1_18_handshaking_toClient::particle::Data15 &v2 = *obj.data_15; /*8.5*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.fromRed); /*0.4*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.fromGreen); /*0.4*/
@@ -554,15 +554,15 @@ bool packet(pdef::Stream &stream, const pdef::pc1_18_handshaking_toClient::packe
         WRITE_OR_BAIL(writeFloatBE, (float)v2.toGreen); /*0.4*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.toBlue); /*0.4*/
     }
-    else if (particleId == 24) { /*8.2*/
+    else if (V_particleId == 24) { /*8.2*/
         const pdef::pc1_18_handshaking_toClient::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.5*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.blockState); /*0.4*/
     }
-    else if (particleId == 35) { /*8.2*/
+    else if (V_particleId == 35) { /*8.2*/
         const pdef::pc1_18_handshaking_toClient::particle::Data35 &v2 = *obj.data_35; /*8.5*/
         WRITE_OR_BAIL(writeByte, (int8_t)v2.item); /*0.4*/
     }
-    else if (particleId == 36) { /*8.2*/
+    else if (V_particleId == 36) { /*8.2*/
         const pdef::pc1_18_handshaking_toClient::particle::Data36 &v2 = *obj.data_36; /*8.5*/
         uint64_t origin_val = 0;
         origin_val |= (uint64_t)v2.origin.x << 0;
@@ -571,15 +571,15 @@ bool packet(pdef::Stream &stream, const pdef::pc1_18_handshaking_toClient::packe
         WRITE_OR_BAIL(writeULongBE, origin_val); /*origin: bitfield*/ /*4.2*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.positionType.length());
         WRITE_OR_BAIL(writeString, v2.positionType); /*positionType: pstring*/ /*4.2*/
-        const std::string &positionType = v2.positionType; /*4.7*/
-        if (positionType == "minecraft:block") { /*8.0*/
+        const std::string &V_positionType = v2.positionType; /*4.7*/
+        if (V_positionType == "minecraft:block") { /*8.0*/
           uint64_t destination_position_val = 0;
           destination_position_val |= (uint64_t)v2.destination_position.x << 0;
           destination_position_val |= (uint64_t)v2.destination_position.z << 26;
           destination_position_val |= (uint64_t)v2.destination_position.y << 52;
           WRITE_OR_BAIL(writeULongBE, destination_position_val); /*destination_position: bitfield*/ /*4.2*/
         }
-        else if (positionType == "minecraft:entity") { /*8.0*/
+        else if (V_positionType == "minecraft:entity") { /*8.0*/
           WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.destination_varint); /*0.4*/
         }
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.ticks); /*0.4*/
@@ -629,192 +629,192 @@ bool tags(pdef::Stream &stream, const pdef::pc1_18_handshaking_toClient::tags &o
     flags_val |= (uint8_t)obj.flags.has_command << 5;
     flags_val |= (uint8_t)obj.flags.command_node_type << 6;
     WRITE_OR_BAIL(writeUByte, flags_val); /*flags: bitfield*/ /*4.2*/
-    const pdef::pc1_18_handshaking_toClient::command_node::flags_t &flags = obj.flags; /*4.7*/
+    const pdef::pc1_18_handshaking_toClient::command_node::flags_t &V_flags = obj.flags; /*4.7*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.children.size()); /*1.4*/
     for (const auto &v2 : obj.children) { /*3.1*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2); /*0.4*/
     }
-    if (flags.has_redirect_node == 1) { /*8.2*/
+    if (V_flags.has_redirect_node == 1) { /*8.2*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.redirectNode); /*0.4*/
     }
-    if (flags.command_node_type == 0) { /*8.2*/
+    if (V_flags.command_node_type == 0) { /*8.2*/
     }
-    else if (flags.command_node_type == 1) { /*8.2*/
+    else if (V_flags.command_node_type == 1) { /*8.2*/
         const pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData1 &v2 = *obj.extraNodeData_1; /*8.5*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.name.length());
         WRITE_OR_BAIL(writeString, v2.name); /*name: pstring*/ /*4.2*/
     }
-    else if (flags.command_node_type == 2) { /*8.2*/
+    else if (V_flags.command_node_type == 2) { /*8.2*/
         const pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData2 &v2 = *obj.extraNodeData_2; /*8.5*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.name.length());
         WRITE_OR_BAIL(writeString, v2.name); /*name: pstring*/ /*4.2*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.parser.length());
         WRITE_OR_BAIL(writeString, v2.parser); /*parser: pstring*/ /*4.2*/
-        const std::string &parser = v2.parser; /*4.7*/
-        if (parser == "brigadier:bool") { /*8.0*/
+        const std::string &V_parser = v2.parser; /*4.7*/
+        if (V_parser == "brigadier:bool") { /*8.0*/
         }
-        else if (parser == "brigadier:float") { /*8.0*/
+        else if (V_parser == "brigadier:float") { /*8.0*/
             const pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData2::PropertiesBrigadierFloat &v4 = *v2.properties_brigadier_float; /*8.5*/
             uint8_t flags_val = 0;
             flags_val |= (uint8_t)v4.flags.unused << 0;
             flags_val |= (uint8_t)v4.flags.max_present << 6;
             flags_val |= (uint8_t)v4.flags.min_present << 7;
             WRITE_OR_BAIL(writeUByte, flags_val); /*flags: bitfield*/ /*4.2*/
-            const pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData2::PropertiesBrigadierFloat::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData2::PropertiesBrigadierFloat::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeFloatBE, (float)v4.min); /*0.4*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeFloatBE, (float)v4.max); /*0.4*/
             }
         }
-        else if (parser == "brigadier:double") { /*8.0*/
+        else if (V_parser == "brigadier:double") { /*8.0*/
             const pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData2::PropertiesBrigadierDouble &v4 = *v2.properties_brigadier_double; /*8.5*/
             uint8_t flags_val = 0;
             flags_val |= (uint8_t)v4.flags.unused << 0;
             flags_val |= (uint8_t)v4.flags.max_present << 6;
             flags_val |= (uint8_t)v4.flags.min_present << 7;
             WRITE_OR_BAIL(writeUByte, flags_val); /*flags: bitfield*/ /*4.2*/
-            const pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData2::PropertiesBrigadierDouble::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData2::PropertiesBrigadierDouble::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeDoubleBE, (double)v4.min); /*0.4*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeDoubleBE, (double)v4.max); /*0.4*/
             }
         }
-        else if (parser == "brigadier:integer") { /*8.0*/
+        else if (V_parser == "brigadier:integer") { /*8.0*/
             const pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData2::PropertiesBrigadierInteger &v4 = *v2.properties_brigadier_integer; /*8.5*/
             uint8_t flags_val = 0;
             flags_val |= (uint8_t)v4.flags.unused << 0;
             flags_val |= (uint8_t)v4.flags.max_present << 6;
             flags_val |= (uint8_t)v4.flags.min_present << 7;
             WRITE_OR_BAIL(writeUByte, flags_val); /*flags: bitfield*/ /*4.2*/
-            const pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData2::PropertiesBrigadierInteger::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData2::PropertiesBrigadierInteger::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeIntBE, (int32_t)v4.min); /*0.4*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeIntBE, (int32_t)v4.max); /*0.4*/
             }
         }
-        else if (parser == "brigadier:long") { /*8.0*/
+        else if (V_parser == "brigadier:long") { /*8.0*/
             const pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData2::PropertiesBrigadierLong &v4 = *v2.properties_brigadier_long; /*8.5*/
             uint8_t flags_val = 0;
             flags_val |= (uint8_t)v4.flags.unused << 0;
             flags_val |= (uint8_t)v4.flags.max_present << 6;
             flags_val |= (uint8_t)v4.flags.min_present << 7;
             WRITE_OR_BAIL(writeUByte, flags_val); /*flags: bitfield*/ /*4.2*/
-            const pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData2::PropertiesBrigadierLong::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData2::PropertiesBrigadierLong::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeLongBE, (int64_t)v4.min); /*0.4*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeLongBE, (int64_t)v4.max); /*0.4*/
             }
         }
-        else if (parser == "brigadier:string") { /*8.0*/
+        else if (V_parser == "brigadier:string") { /*8.0*/
         }
-        else if (parser == "minecraft:entity") { /*8.0*/
+        else if (V_parser == "minecraft:entity") { /*8.0*/
           uint8_t properties_minecraft_entity_val = 0;
           properties_minecraft_entity_val |= (uint8_t)v2.properties_minecraft_entity.unused << 0;
           properties_minecraft_entity_val |= (uint8_t)v2.properties_minecraft_entity.onlyAllowPlayers << 6;
           properties_minecraft_entity_val |= (uint8_t)v2.properties_minecraft_entity.onlyAllowEntities << 7;
           WRITE_OR_BAIL(writeUByte, properties_minecraft_entity_val); /*properties_minecraft_entity: bitfield*/ /*4.2*/
         }
-        else if (parser == "minecraft:game_profile") { /*8.0*/
+        else if (V_parser == "minecraft:game_profile") { /*8.0*/
         }
-        else if (parser == "minecraft:block_pos") { /*8.0*/
+        else if (V_parser == "minecraft:block_pos") { /*8.0*/
         }
-        else if (parser == "minecraft:column_pos") { /*8.0*/
+        else if (V_parser == "minecraft:column_pos") { /*8.0*/
         }
-        else if (parser == "minecraft:vec3") { /*8.0*/
+        else if (V_parser == "minecraft:vec3") { /*8.0*/
         }
-        else if (parser == "minecraft:vec2") { /*8.0*/
+        else if (V_parser == "minecraft:vec2") { /*8.0*/
         }
-        else if (parser == "minecraft:block_state") { /*8.0*/
+        else if (V_parser == "minecraft:block_state") { /*8.0*/
         }
-        else if (parser == "minecraft:block_predicate") { /*8.0*/
+        else if (V_parser == "minecraft:block_predicate") { /*8.0*/
         }
-        else if (parser == "minecraft:item_stack") { /*8.0*/
+        else if (V_parser == "minecraft:item_stack") { /*8.0*/
         }
-        else if (parser == "minecraft:item_predicate") { /*8.0*/
+        else if (V_parser == "minecraft:item_predicate") { /*8.0*/
         }
-        else if (parser == "minecraft:color") { /*8.0*/
+        else if (V_parser == "minecraft:color") { /*8.0*/
         }
-        else if (parser == "minecraft:component") { /*8.0*/
+        else if (V_parser == "minecraft:component") { /*8.0*/
         }
-        else if (parser == "minecraft:message") { /*8.0*/
+        else if (V_parser == "minecraft:message") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt") { /*8.0*/
+        else if (V_parser == "minecraft:nbt") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt_path") { /*8.0*/
+        else if (V_parser == "minecraft:nbt_path") { /*8.0*/
         }
-        else if (parser == "minecraft:objective") { /*8.0*/
+        else if (V_parser == "minecraft:objective") { /*8.0*/
         }
-        else if (parser == "minecraft:objective_criteria") { /*8.0*/
+        else if (V_parser == "minecraft:objective_criteria") { /*8.0*/
         }
-        else if (parser == "minecraft:operation") { /*8.0*/
+        else if (V_parser == "minecraft:operation") { /*8.0*/
         }
-        else if (parser == "minecraft:particle") { /*8.0*/
+        else if (V_parser == "minecraft:particle") { /*8.0*/
         }
-        else if (parser == "minecraft:angle") { /*8.0*/
+        else if (V_parser == "minecraft:angle") { /*8.0*/
         }
-        else if (parser == "minecraft:rotation") { /*8.0*/
+        else if (V_parser == "minecraft:rotation") { /*8.0*/
         }
-        else if (parser == "minecraft:scoreboard_slot") { /*8.0*/
+        else if (V_parser == "minecraft:scoreboard_slot") { /*8.0*/
         }
-        else if (parser == "minecraft:score_holder") { /*8.0*/
+        else if (V_parser == "minecraft:score_holder") { /*8.0*/
           uint8_t properties_minecraft_score_holder_val = 0;
           properties_minecraft_score_holder_val |= (uint8_t)v2.properties_minecraft_score_holder.unused << 0;
           properties_minecraft_score_holder_val |= (uint8_t)v2.properties_minecraft_score_holder.allowMultiple << 7;
           WRITE_OR_BAIL(writeUByte, properties_minecraft_score_holder_val); /*properties_minecraft_score_holder: bitfield*/ /*4.2*/
         }
-        else if (parser == "minecraft:swizzle") { /*8.0*/
+        else if (V_parser == "minecraft:swizzle") { /*8.0*/
         }
-        else if (parser == "minecraft:team") { /*8.0*/
+        else if (V_parser == "minecraft:team") { /*8.0*/
         }
-        else if (parser == "minecraft:item_slot") { /*8.0*/
+        else if (V_parser == "minecraft:item_slot") { /*8.0*/
         }
-        else if (parser == "minecraft:resource_location") { /*8.0*/
+        else if (V_parser == "minecraft:resource_location") { /*8.0*/
         }
-        else if (parser == "minecraft:mob_effect") { /*8.0*/
+        else if (V_parser == "minecraft:mob_effect") { /*8.0*/
         }
-        else if (parser == "minecraft:function") { /*8.0*/
+        else if (V_parser == "minecraft:function") { /*8.0*/
         }
-        else if (parser == "minecraft:entity_anchor") { /*8.0*/
+        else if (V_parser == "minecraft:entity_anchor") { /*8.0*/
         }
-        else if (parser == "minecraft:range") { /*8.0*/
+        else if (V_parser == "minecraft:range") { /*8.0*/
             const pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData2::PropertiesMinecraftRange &v4 = *v2.properties_minecraft_range; /*8.5*/
             WRITE_OR_BAIL(writeBool, (bool)v4.allowDecimals); /*0.4*/
         }
-        else if (parser == "minecraft:int_range") { /*8.0*/
+        else if (V_parser == "minecraft:int_range") { /*8.0*/
         }
-        else if (parser == "minecraft:float_range") { /*8.0*/
+        else if (V_parser == "minecraft:float_range") { /*8.0*/
         }
-        else if (parser == "minecraft:item_enchantment") { /*8.0*/
+        else if (V_parser == "minecraft:item_enchantment") { /*8.0*/
         }
-        else if (parser == "minecraft:entity_summon") { /*8.0*/
+        else if (V_parser == "minecraft:entity_summon") { /*8.0*/
         }
-        else if (parser == "minecraft:dimension") { /*8.0*/
+        else if (V_parser == "minecraft:dimension") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt_compound_tag") { /*8.0*/
+        else if (V_parser == "minecraft:nbt_compound_tag") { /*8.0*/
         }
-        else if (parser == "minecraft:time") { /*8.0*/
+        else if (V_parser == "minecraft:time") { /*8.0*/
         }
-        else if (parser == "minecraft:resource_or_tag") { /*8.0*/
+        else if (V_parser == "minecraft:resource_or_tag") { /*8.0*/
             const pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData2::PropertiesMinecraftResourceOrTagOrMinecraftResource &v4 = *v2.properties_minecraft_resource_or_tag_or_minecraft_resource; /*8.5*/
             WRITE_OR_BAIL(writeUnsignedVarInt, (int)v4.registry.length());
             WRITE_OR_BAIL(writeString, v4.registry); /*registry: pstring*/ /*4.2*/
         }
-        else if (parser == "minecraft:resource") { /*8.0*/
+        else if (V_parser == "minecraft:resource") { /*8.0*/
             const pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData2::PropertiesMinecraftResourceOrTagOrMinecraftResource &v4 = *v2.properties_minecraft_resource_or_tag_or_minecraft_resource; /*8.5*/
             WRITE_OR_BAIL(writeUnsignedVarInt, (int)v4.registry.length());
             WRITE_OR_BAIL(writeString, v4.registry); /*registry: pstring*/ /*4.2*/
         }
-        else if (parser == "minecraft:uuid") { /*8.0*/
+        else if (V_parser == "minecraft:uuid") { /*8.0*/
         }
-        if (flags.has_custom_suggestions == 1) { /*8.2*/
+        if (V_flags.has_custom_suggestions == 1) { /*8.2*/
           WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.suggestionType.length());
           WRITE_OR_BAIL(writeString, v2.suggestionType); /*suggestionType: pstring*/ /*4.2*/
         }
@@ -823,7 +823,7 @@ bool tags(pdef::Stream &stream, const pdef::pc1_18_handshaking_toClient::tags &o
   }
   bool packet(pdef::Stream &stream, const pdef::pc1_18_handshaking_toClient::packet &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::pc1_18_handshaking_toClient::size::packet(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const pdef::pc1_18_handshaking_toClient::packet::Name &name = obj.name; /*0.3*/
+    const pdef::pc1_18_handshaking_toClient::packet::Name &V_name = obj.name; /*0.3*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)(int&)obj.name); /*7.1*/
     return true;
   }
@@ -839,10 +839,10 @@ bool command_node(pdef::Stream &stream, pdef::pc1_18_handshaking_toClient::comma
 bool packet(pdef::Stream &stream, pdef::pc1_18_handshaking_toClient::packet &obj);
   bool slot(pdef::Stream &stream, pdef::pc1_18_handshaking_toClient::slot &obj) {
     READ_OR_BAIL(readBool, (bool&)obj.present); /*0.5*/
-    bool &present = obj.present; /*0.6*/
-    if (present == false) { /*8.1*/
+    bool &V_present = obj.present; /*0.6*/
+    if (V_present == false) { /*8.1*/
     }
-    else if (present == true) { /*8.1*/
+    else if (V_present == true) { /*8.1*/
         READ_OR_BAIL(readUnsignedVarInt, obj.itemId); /*0.5*/
         READ_OR_BAIL(readByte, obj.itemCount); /*0.5*/
         READ_OR_BAIL(readByte, obj.nbtData); /*0.5*/
@@ -851,23 +851,23 @@ bool packet(pdef::Stream &stream, pdef::pc1_18_handshaking_toClient::packet &obj
   }
   bool particle(pdef::Stream &stream, pdef::pc1_18_handshaking_toClient::particle &obj) {
     READ_OR_BAIL(readUnsignedVarInt, obj.particleId); /*0.5*/
-    int &particleId = obj.particleId; /*0.6*/
-    if (particleId == 2) { /*8.2*/
+    int &V_particleId = obj.particleId; /*0.6*/
+    if (V_particleId == 2) { /*8.2*/
          obj.data_2_or_3_or_24 = {}; pdef::pc1_18_handshaking_toClient::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.4*/
         READ_OR_BAIL(readUnsignedVarInt, v2.blockState); /*0.5*/
     }
-    else if (particleId == 3) { /*8.2*/
+    else if (V_particleId == 3) { /*8.2*/
          obj.data_2_or_3_or_24 = {}; pdef::pc1_18_handshaking_toClient::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.4*/
         READ_OR_BAIL(readUnsignedVarInt, v2.blockState); /*0.5*/
     }
-    else if (particleId == 14) { /*8.2*/
+    else if (V_particleId == 14) { /*8.2*/
          obj.data_14 = {}; pdef::pc1_18_handshaking_toClient::particle::Data14 &v2 = *obj.data_14; /*8.4*/
         READ_OR_BAIL(readFloatBE, v2.red); /*0.5*/
         READ_OR_BAIL(readFloatBE, v2.green); /*0.5*/
         READ_OR_BAIL(readFloatBE, v2.blue); /*0.5*/
         READ_OR_BAIL(readFloatBE, v2.scale); /*0.5*/
     }
-    else if (particleId == 15) { /*8.2*/
+    else if (V_particleId == 15) { /*8.2*/
          obj.data_15 = {}; pdef::pc1_18_handshaking_toClient::particle::Data15 &v2 = *obj.data_15; /*8.4*/
         READ_OR_BAIL(readFloatBE, v2.fromRed); /*0.5*/
         READ_OR_BAIL(readFloatBE, v2.fromGreen); /*0.5*/
@@ -877,15 +877,15 @@ bool packet(pdef::Stream &stream, pdef::pc1_18_handshaking_toClient::packet &obj
         READ_OR_BAIL(readFloatBE, v2.toGreen); /*0.5*/
         READ_OR_BAIL(readFloatBE, v2.toBlue); /*0.5*/
     }
-    else if (particleId == 24) { /*8.2*/
+    else if (V_particleId == 24) { /*8.2*/
          obj.data_2_or_3_or_24 = {}; pdef::pc1_18_handshaking_toClient::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.4*/
         READ_OR_BAIL(readUnsignedVarInt, v2.blockState); /*0.5*/
     }
-    else if (particleId == 35) { /*8.2*/
+    else if (V_particleId == 35) { /*8.2*/
          obj.data_35 = {}; pdef::pc1_18_handshaking_toClient::particle::Data35 &v2 = *obj.data_35; /*8.4*/
         READ_OR_BAIL(readByte, v2.item); /*0.5*/
     }
-    else if (particleId == 36) { /*8.2*/
+    else if (V_particleId == 36) { /*8.2*/
          obj.data_36 = {}; pdef::pc1_18_handshaking_toClient::particle::Data36 &v2 = *obj.data_36; /*8.4*/
         uint64_t origin_val;
         READ_OR_BAIL(readULongBE, origin_val);
@@ -894,15 +894,15 @@ bool packet(pdef::Stream &stream, pdef::pc1_18_handshaking_toClient::packet &obj
         v2.origin.y = origin_val >> 52 & 12; /*origin: bitfield*/ /*4.3*/
         int positionType_strlen; READ_OR_BAIL(readUnsignedVarInt, positionType_strlen);
         if (!stream.readString(v2.positionType, positionType_strlen)) return false; /*positionType: pstring*/ /*4.3*/
-        std::string &positionType = v2.positionType; /*4.8*/
-        if (positionType == "minecraft:block") { /*8.0*/
+        std::string &V_positionType = v2.positionType; /*4.8*/
+        if (V_positionType == "minecraft:block") { /*8.0*/
           uint64_t destination_position_val;
           READ_OR_BAIL(readULongBE, destination_position_val);
           v2.destination_position.x = destination_position_val >> 0 & 26;
           v2.destination_position.z = destination_position_val >> 26 & 26;
           v2.destination_position.y = destination_position_val >> 52 & 12; /*destination_position: bitfield*/ /*4.3*/
         }
-        else if (positionType == "minecraft:entity") { /*8.0*/
+        else if (V_positionType == "minecraft:entity") { /*8.0*/
           READ_OR_BAIL(readUnsignedVarInt, v2.destination_varint); /*0.5*/
         }
         READ_OR_BAIL(readUnsignedVarInt, v2.ticks); /*0.5*/
@@ -914,7 +914,7 @@ bool packet(pdef::Stream &stream, pdef::pc1_18_handshaking_toClient::packet &obj
     if (!stream.readString(obj.group, group_strlen)) return false; /*group: pstring*/ /*4.3*/
     int ingredient_len; READ_OR_BAIL(readUnsignedVarInt, ingredient_len); /*1.5*/
     obj.ingredient.resize(ingredient_len); /*1.6*/
-    for (int i = 0; i < ingredient_len; i++) {
+    for (int i = 0; i < ingredient_len; i++) { /*3.3*/
       auto &v2 = obj.ingredient[i]; /*3.4*/
       READ_OR_BAIL(readByte, v2); /*0.5*/
     }
@@ -928,7 +928,7 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_handshaking_toClient::tags &obj) {
     if (!stream.readString(obj.tagName, tagName_strlen)) return false; /*tagName: pstring*/ /*4.3*/
     int entries_len; READ_OR_BAIL(readUnsignedVarInt, entries_len); /*1.5*/
     obj.entries.resize(entries_len); /*1.6*/
-    for (int i = 0; i < entries_len; i++) {
+    for (int i = 0; i < entries_len; i++) { /*3.3*/
       auto &v2 = obj.entries[i]; /*3.4*/
       READ_OR_BAIL(readUnsignedVarInt, v2); /*0.5*/
     }
@@ -952,194 +952,194 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_handshaking_toClient::tags &obj) {
     obj.flags.has_redirect_node = flags_val >> 4 & 1;
     obj.flags.has_command = flags_val >> 5 & 1;
     obj.flags.command_node_type = flags_val >> 6 & 2; /*flags: bitfield*/ /*4.3*/
-    pdef::pc1_18_handshaking_toClient::command_node::flags_t &flags = obj.flags; /*4.8*/
+    pdef::pc1_18_handshaking_toClient::command_node::flags_t &V_flags = obj.flags; /*4.8*/
     int children_len; READ_OR_BAIL(readUnsignedVarInt, children_len); /*1.5*/
     obj.children.resize(children_len); /*1.6*/
-    for (int i = 0; i < children_len; i++) {
+    for (int i = 0; i < children_len; i++) { /*3.3*/
       auto &v2 = obj.children[i]; /*3.4*/
       READ_OR_BAIL(readUnsignedVarInt, v2); /*0.5*/
     }
-    if (flags.has_redirect_node == 1) { /*8.2*/
+    if (V_flags.has_redirect_node == 1) { /*8.2*/
       READ_OR_BAIL(readUnsignedVarInt, obj.redirectNode); /*0.5*/
     }
-    if (flags.command_node_type == 0) { /*8.2*/
+    if (V_flags.command_node_type == 0) { /*8.2*/
     }
-    else if (flags.command_node_type == 1) { /*8.2*/
+    else if (V_flags.command_node_type == 1) { /*8.2*/
          obj.extraNodeData_1 = {}; pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData1 &v2 = *obj.extraNodeData_1; /*8.4*/
         int name_strlen; READ_OR_BAIL(readUnsignedVarInt, name_strlen);
         if (!stream.readString(v2.name, name_strlen)) return false; /*name: pstring*/ /*4.3*/
     }
-    else if (flags.command_node_type == 2) { /*8.2*/
+    else if (V_flags.command_node_type == 2) { /*8.2*/
          obj.extraNodeData_2 = {}; pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData2 &v2 = *obj.extraNodeData_2; /*8.4*/
         int name_strlen; READ_OR_BAIL(readUnsignedVarInt, name_strlen);
         if (!stream.readString(v2.name, name_strlen)) return false; /*name: pstring*/ /*4.3*/
         int parser_strlen; READ_OR_BAIL(readUnsignedVarInt, parser_strlen);
         if (!stream.readString(v2.parser, parser_strlen)) return false; /*parser: pstring*/ /*4.3*/
-        std::string &parser = v2.parser; /*4.8*/
-        if (parser == "brigadier:bool") { /*8.0*/
+        std::string &V_parser = v2.parser; /*4.8*/
+        if (V_parser == "brigadier:bool") { /*8.0*/
         }
-        else if (parser == "brigadier:float") { /*8.0*/
+        else if (V_parser == "brigadier:float") { /*8.0*/
              v2.properties_brigadier_float = {}; pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData2::PropertiesBrigadierFloat &v4 = *v2.properties_brigadier_float; /*8.4*/
             uint8_t flags_val;
             READ_OR_BAIL(readUByte, flags_val);
             v4.flags.unused = flags_val >> 0 & 6;
             v4.flags.max_present = flags_val >> 6 & 1;
             v4.flags.min_present = flags_val >> 7 & 1; /*flags: bitfield*/ /*4.3*/
-            pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData2::PropertiesBrigadierFloat::flags_t &flags = v4.flags; /*4.8*/
-            if (flags.min_present == 1) { /*8.2*/
+            pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData2::PropertiesBrigadierFloat::flags_t &V_flags = v4.flags; /*4.8*/
+            if (V_flags.min_present == 1) { /*8.2*/
               READ_OR_BAIL(readFloatBE, v4.min); /*0.5*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               READ_OR_BAIL(readFloatBE, v4.max); /*0.5*/
             }
         }
-        else if (parser == "brigadier:double") { /*8.0*/
+        else if (V_parser == "brigadier:double") { /*8.0*/
              v2.properties_brigadier_double = {}; pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData2::PropertiesBrigadierDouble &v4 = *v2.properties_brigadier_double; /*8.4*/
             uint8_t flags_val;
             READ_OR_BAIL(readUByte, flags_val);
             v4.flags.unused = flags_val >> 0 & 6;
             v4.flags.max_present = flags_val >> 6 & 1;
             v4.flags.min_present = flags_val >> 7 & 1; /*flags: bitfield*/ /*4.3*/
-            pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData2::PropertiesBrigadierDouble::flags_t &flags = v4.flags; /*4.8*/
-            if (flags.min_present == 1) { /*8.2*/
+            pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData2::PropertiesBrigadierDouble::flags_t &V_flags = v4.flags; /*4.8*/
+            if (V_flags.min_present == 1) { /*8.2*/
               READ_OR_BAIL(readDoubleBE, v4.min); /*0.5*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               READ_OR_BAIL(readDoubleBE, v4.max); /*0.5*/
             }
         }
-        else if (parser == "brigadier:integer") { /*8.0*/
+        else if (V_parser == "brigadier:integer") { /*8.0*/
              v2.properties_brigadier_integer = {}; pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData2::PropertiesBrigadierInteger &v4 = *v2.properties_brigadier_integer; /*8.4*/
             uint8_t flags_val;
             READ_OR_BAIL(readUByte, flags_val);
             v4.flags.unused = flags_val >> 0 & 6;
             v4.flags.max_present = flags_val >> 6 & 1;
             v4.flags.min_present = flags_val >> 7 & 1; /*flags: bitfield*/ /*4.3*/
-            pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData2::PropertiesBrigadierInteger::flags_t &flags = v4.flags; /*4.8*/
-            if (flags.min_present == 1) { /*8.2*/
+            pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData2::PropertiesBrigadierInteger::flags_t &V_flags = v4.flags; /*4.8*/
+            if (V_flags.min_present == 1) { /*8.2*/
               READ_OR_BAIL(readIntBE, v4.min); /*0.5*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               READ_OR_BAIL(readIntBE, v4.max); /*0.5*/
             }
         }
-        else if (parser == "brigadier:long") { /*8.0*/
+        else if (V_parser == "brigadier:long") { /*8.0*/
              v2.properties_brigadier_long = {}; pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData2::PropertiesBrigadierLong &v4 = *v2.properties_brigadier_long; /*8.4*/
             uint8_t flags_val;
             READ_OR_BAIL(readUByte, flags_val);
             v4.flags.unused = flags_val >> 0 & 6;
             v4.flags.max_present = flags_val >> 6 & 1;
             v4.flags.min_present = flags_val >> 7 & 1; /*flags: bitfield*/ /*4.3*/
-            pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData2::PropertiesBrigadierLong::flags_t &flags = v4.flags; /*4.8*/
-            if (flags.min_present == 1) { /*8.2*/
+            pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData2::PropertiesBrigadierLong::flags_t &V_flags = v4.flags; /*4.8*/
+            if (V_flags.min_present == 1) { /*8.2*/
               READ_OR_BAIL(readLongBE, v4.min); /*0.5*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               READ_OR_BAIL(readLongBE, v4.max); /*0.5*/
             }
         }
-        else if (parser == "brigadier:string") { /*8.0*/
+        else if (V_parser == "brigadier:string") { /*8.0*/
         }
-        else if (parser == "minecraft:entity") { /*8.0*/
+        else if (V_parser == "minecraft:entity") { /*8.0*/
           uint8_t properties_minecraft_entity_val;
           READ_OR_BAIL(readUByte, properties_minecraft_entity_val);
           v2.properties_minecraft_entity.unused = properties_minecraft_entity_val >> 0 & 6;
           v2.properties_minecraft_entity.onlyAllowPlayers = properties_minecraft_entity_val >> 6 & 1;
           v2.properties_minecraft_entity.onlyAllowEntities = properties_minecraft_entity_val >> 7 & 1; /*properties_minecraft_entity: bitfield*/ /*4.3*/
         }
-        else if (parser == "minecraft:game_profile") { /*8.0*/
+        else if (V_parser == "minecraft:game_profile") { /*8.0*/
         }
-        else if (parser == "minecraft:block_pos") { /*8.0*/
+        else if (V_parser == "minecraft:block_pos") { /*8.0*/
         }
-        else if (parser == "minecraft:column_pos") { /*8.0*/
+        else if (V_parser == "minecraft:column_pos") { /*8.0*/
         }
-        else if (parser == "minecraft:vec3") { /*8.0*/
+        else if (V_parser == "minecraft:vec3") { /*8.0*/
         }
-        else if (parser == "minecraft:vec2") { /*8.0*/
+        else if (V_parser == "minecraft:vec2") { /*8.0*/
         }
-        else if (parser == "minecraft:block_state") { /*8.0*/
+        else if (V_parser == "minecraft:block_state") { /*8.0*/
         }
-        else if (parser == "minecraft:block_predicate") { /*8.0*/
+        else if (V_parser == "minecraft:block_predicate") { /*8.0*/
         }
-        else if (parser == "minecraft:item_stack") { /*8.0*/
+        else if (V_parser == "minecraft:item_stack") { /*8.0*/
         }
-        else if (parser == "minecraft:item_predicate") { /*8.0*/
+        else if (V_parser == "minecraft:item_predicate") { /*8.0*/
         }
-        else if (parser == "minecraft:color") { /*8.0*/
+        else if (V_parser == "minecraft:color") { /*8.0*/
         }
-        else if (parser == "minecraft:component") { /*8.0*/
+        else if (V_parser == "minecraft:component") { /*8.0*/
         }
-        else if (parser == "minecraft:message") { /*8.0*/
+        else if (V_parser == "minecraft:message") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt") { /*8.0*/
+        else if (V_parser == "minecraft:nbt") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt_path") { /*8.0*/
+        else if (V_parser == "minecraft:nbt_path") { /*8.0*/
         }
-        else if (parser == "minecraft:objective") { /*8.0*/
+        else if (V_parser == "minecraft:objective") { /*8.0*/
         }
-        else if (parser == "minecraft:objective_criteria") { /*8.0*/
+        else if (V_parser == "minecraft:objective_criteria") { /*8.0*/
         }
-        else if (parser == "minecraft:operation") { /*8.0*/
+        else if (V_parser == "minecraft:operation") { /*8.0*/
         }
-        else if (parser == "minecraft:particle") { /*8.0*/
+        else if (V_parser == "minecraft:particle") { /*8.0*/
         }
-        else if (parser == "minecraft:angle") { /*8.0*/
+        else if (V_parser == "minecraft:angle") { /*8.0*/
         }
-        else if (parser == "minecraft:rotation") { /*8.0*/
+        else if (V_parser == "minecraft:rotation") { /*8.0*/
         }
-        else if (parser == "minecraft:scoreboard_slot") { /*8.0*/
+        else if (V_parser == "minecraft:scoreboard_slot") { /*8.0*/
         }
-        else if (parser == "minecraft:score_holder") { /*8.0*/
+        else if (V_parser == "minecraft:score_holder") { /*8.0*/
           uint8_t properties_minecraft_score_holder_val;
           READ_OR_BAIL(readUByte, properties_minecraft_score_holder_val);
           v2.properties_minecraft_score_holder.unused = properties_minecraft_score_holder_val >> 0 & 7;
           v2.properties_minecraft_score_holder.allowMultiple = properties_minecraft_score_holder_val >> 7 & 1; /*properties_minecraft_score_holder: bitfield*/ /*4.3*/
         }
-        else if (parser == "minecraft:swizzle") { /*8.0*/
+        else if (V_parser == "minecraft:swizzle") { /*8.0*/
         }
-        else if (parser == "minecraft:team") { /*8.0*/
+        else if (V_parser == "minecraft:team") { /*8.0*/
         }
-        else if (parser == "minecraft:item_slot") { /*8.0*/
+        else if (V_parser == "minecraft:item_slot") { /*8.0*/
         }
-        else if (parser == "minecraft:resource_location") { /*8.0*/
+        else if (V_parser == "minecraft:resource_location") { /*8.0*/
         }
-        else if (parser == "minecraft:mob_effect") { /*8.0*/
+        else if (V_parser == "minecraft:mob_effect") { /*8.0*/
         }
-        else if (parser == "minecraft:function") { /*8.0*/
+        else if (V_parser == "minecraft:function") { /*8.0*/
         }
-        else if (parser == "minecraft:entity_anchor") { /*8.0*/
+        else if (V_parser == "minecraft:entity_anchor") { /*8.0*/
         }
-        else if (parser == "minecraft:range") { /*8.0*/
+        else if (V_parser == "minecraft:range") { /*8.0*/
              v2.properties_minecraft_range = {}; pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData2::PropertiesMinecraftRange &v4 = *v2.properties_minecraft_range; /*8.4*/
             READ_OR_BAIL(readBool, (bool&)v4.allowDecimals); /*0.5*/
         }
-        else if (parser == "minecraft:int_range") { /*8.0*/
+        else if (V_parser == "minecraft:int_range") { /*8.0*/
         }
-        else if (parser == "minecraft:float_range") { /*8.0*/
+        else if (V_parser == "minecraft:float_range") { /*8.0*/
         }
-        else if (parser == "minecraft:item_enchantment") { /*8.0*/
+        else if (V_parser == "minecraft:item_enchantment") { /*8.0*/
         }
-        else if (parser == "minecraft:entity_summon") { /*8.0*/
+        else if (V_parser == "minecraft:entity_summon") { /*8.0*/
         }
-        else if (parser == "minecraft:dimension") { /*8.0*/
+        else if (V_parser == "minecraft:dimension") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt_compound_tag") { /*8.0*/
+        else if (V_parser == "minecraft:nbt_compound_tag") { /*8.0*/
         }
-        else if (parser == "minecraft:time") { /*8.0*/
+        else if (V_parser == "minecraft:time") { /*8.0*/
         }
-        else if (parser == "minecraft:resource_or_tag") { /*8.0*/
+        else if (V_parser == "minecraft:resource_or_tag") { /*8.0*/
              v2.properties_minecraft_resource_or_tag_or_minecraft_resource = {}; pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData2::PropertiesMinecraftResourceOrTagOrMinecraftResource &v4 = *v2.properties_minecraft_resource_or_tag_or_minecraft_resource; /*8.4*/
             int registry_strlen; READ_OR_BAIL(readUnsignedVarInt, registry_strlen);
             if (!stream.readString(v4.registry, registry_strlen)) return false; /*registry: pstring*/ /*4.3*/
         }
-        else if (parser == "minecraft:resource") { /*8.0*/
+        else if (V_parser == "minecraft:resource") { /*8.0*/
              v2.properties_minecraft_resource_or_tag_or_minecraft_resource = {}; pdef::pc1_18_handshaking_toClient::command_node::ExtraNodeData2::PropertiesMinecraftResourceOrTagOrMinecraftResource &v4 = *v2.properties_minecraft_resource_or_tag_or_minecraft_resource; /*8.4*/
             int registry_strlen; READ_OR_BAIL(readUnsignedVarInt, registry_strlen);
             if (!stream.readString(v4.registry, registry_strlen)) return false; /*registry: pstring*/ /*4.3*/
         }
-        else if (parser == "minecraft:uuid") { /*8.0*/
+        else if (V_parser == "minecraft:uuid") { /*8.0*/
         }
-        if (flags.has_custom_suggestions == 1) { /*8.2*/
+        if (V_flags.has_custom_suggestions == 1) { /*8.2*/
           int suggestionType_strlen; READ_OR_BAIL(readUnsignedVarInt, suggestionType_strlen);
           if (!stream.readString(v2.suggestionType, suggestionType_strlen)) return false; /*suggestionType: pstring*/ /*4.3*/
         }
@@ -1148,7 +1148,7 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_handshaking_toClient::tags &obj) {
   }
   bool packet(pdef::Stream &stream, pdef::pc1_18_handshaking_toClient::packet &obj) {
     READ_OR_BAIL(readUnsignedVarInt, (int&)obj.name); /*7.2*/
-    const pdef::pc1_18_handshaking_toClient::packet::Name &name = obj.name; /*0.7*/
+    const pdef::pc1_18_handshaking_toClient::packet::Name &V_name = obj.name; /*0.7*/
     return true;
   }
 }

--- a/examples/mcpc-protocol/build/pc1_18_handshaking_toServer.h
+++ b/examples/mcpc-protocol/build/pc1_18_handshaking_toServer.h
@@ -248,10 +248,10 @@ size_t packet_legacy_server_list_ping(pdef::Stream &stream, const pdef::pc1_18_h
 size_t packet(pdef::Stream &stream, const pdef::pc1_18_handshaking_toServer::packet &obj);
   size_t slot(pdef::Stream &stream, const pdef::pc1_18_handshaking_toServer::slot &obj) {
     size_t len = 0;
-    const bool &present = obj.present; /*0.1*/
-    if (present == false) { /*8.1*/
+    const bool &V_present = obj.present; /*0.1*/
+    if (V_present == false) { /*8.1*/
     }
-    else if (present == true) { /*8.1*/
+    else if (V_present == true) { /*8.1*/
         len += stream.sizeOfVarInt(obj.itemId); /*0.2*/
         len += 1; /*0.2*/
         len += 1; /*0.2*/
@@ -260,23 +260,23 @@ size_t packet(pdef::Stream &stream, const pdef::pc1_18_handshaking_toServer::pac
   }
   size_t particle(pdef::Stream &stream, const pdef::pc1_18_handshaking_toServer::particle &obj) {
     size_t len = 0;
-    const int &particleId = obj.particleId; /*0.1*/
-    if (particleId == 2) { /*8.2*/
+    const int &V_particleId = obj.particleId; /*0.1*/
+    if (V_particleId == 2) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_2_or_3_or_24); const pdef::pc1_18_handshaking_toServer::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.6*/
         len += stream.sizeOfVarInt(v2.blockState); /*0.2*/
     }
-    else if (particleId == 3) { /*8.2*/
+    else if (V_particleId == 3) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_2_or_3_or_24); const pdef::pc1_18_handshaking_toServer::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.6*/
         len += stream.sizeOfVarInt(v2.blockState); /*0.2*/
     }
-    else if (particleId == 14) { /*8.2*/
+    else if (V_particleId == 14) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_14); const pdef::pc1_18_handshaking_toServer::particle::Data14 &v2 = *obj.data_14; /*8.6*/
         len += 4; /*0.2*/
         len += 4; /*0.2*/
         len += 4; /*0.2*/
         len += 4; /*0.2*/
     }
-    else if (particleId == 15) { /*8.2*/
+    else if (V_particleId == 15) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_15); const pdef::pc1_18_handshaking_toServer::particle::Data15 &v2 = *obj.data_15; /*8.6*/
         len += 4; /*0.2*/
         len += 4; /*0.2*/
@@ -286,24 +286,24 @@ size_t packet(pdef::Stream &stream, const pdef::pc1_18_handshaking_toServer::pac
         len += 4; /*0.2*/
         len += 4; /*0.2*/
     }
-    else if (particleId == 24) { /*8.2*/
+    else if (V_particleId == 24) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_2_or_3_or_24); const pdef::pc1_18_handshaking_toServer::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.6*/
         len += stream.sizeOfVarInt(v2.blockState); /*0.2*/
     }
-    else if (particleId == 35) { /*8.2*/
+    else if (V_particleId == 35) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_35); const pdef::pc1_18_handshaking_toServer::particle::Data35 &v2 = *obj.data_35; /*8.6*/
         len += 1; /*0.2*/
     }
-    else if (particleId == 36) { /*8.2*/
+    else if (V_particleId == 36) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_36); const pdef::pc1_18_handshaking_toServer::particle::Data36 &v2 = *obj.data_36; /*8.6*/
         len += 1; /*origin: bitfield*/ /*4.1*/
         len += stream.sizeOfVarInt(v2.positionType.length());
         len += v2.positionType.length(); /*positionType^: pstring*/ /*4.1*/
-        const std::string &positionType = v2.positionType; /*4.7*/
-        if (positionType == "minecraft:block") { /*8.0*/
+        const std::string &V_positionType = v2.positionType; /*4.7*/
+        if (V_positionType == "minecraft:block") { /*8.0*/
           len += 1; /*destination: bitfield*/ /*4.1*/
         }
-        else if (positionType == "minecraft:entity") { /*8.0*/
+        else if (V_positionType == "minecraft:entity") { /*8.0*/
           len += stream.sizeOfVarInt(v2.destination_varint); /*0.2*/
         }
         len += stream.sizeOfVarInt(v2.ticks); /*0.2*/
@@ -315,7 +315,7 @@ size_t packet(pdef::Stream &stream, const pdef::pc1_18_handshaking_toServer::pac
     len += stream.sizeOfVarInt(obj.group.length());
     len += obj.group.length(); /*group: pstring*/ /*4.1*/
     len += stream.sizeOfVarInt(obj.ingredient.size()); /*1.3*/
-    for (const auto &v2 : obj.ingredient) {
+    for (const auto &v2 : obj.ingredient) { /*3.2*/
       len += 1; /*0.2*/
     }
     len += 1; /*0.2*/
@@ -328,7 +328,7 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_handshaking_toServer::tags 
     len += stream.sizeOfVarInt(obj.tagName.length());
     len += obj.tagName.length(); /*tagName: pstring*/ /*4.1*/
     len += stream.sizeOfVarInt(obj.entries.size()); /*1.3*/
-    for (const auto &v2 : obj.entries) {
+    for (const auto &v2 : obj.entries) { /*3.2*/
       len += stream.sizeOfVarInt(v2); /*0.2*/
     }
   PDEF_SIZE_DBG; return len;
@@ -344,169 +344,169 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_handshaking_toServer::tags 
   size_t command_node(pdef::Stream &stream, const pdef::pc1_18_handshaking_toServer::command_node &obj) {
     size_t len = 0;
     len += 1; /*flags^: bitfield*/ /*4.1*/
-    const pdef::pc1_18_handshaking_toServer::command_node::flags_t &flags = obj.flags; /*4.7*/
+    const pdef::pc1_18_handshaking_toServer::command_node::flags_t &V_flags = obj.flags; /*4.7*/
     len += stream.sizeOfVarInt(obj.children.size()); /*1.3*/
-    for (const auto &v2 : obj.children) {
+    for (const auto &v2 : obj.children) { /*3.2*/
       len += stream.sizeOfVarInt(v2); /*0.2*/
     }
-    if (flags.has_redirect_node == 1) { /*8.2*/
+    if (V_flags.has_redirect_node == 1) { /*8.2*/
       len += stream.sizeOfVarInt(obj.redirectNode); /*0.2*/
     }
-    if (flags.command_node_type == 0) { /*8.2*/
+    if (V_flags.command_node_type == 0) { /*8.2*/
     }
-    else if (flags.command_node_type == 1) { /*8.2*/
+    else if (V_flags.command_node_type == 1) { /*8.2*/
         EXPECT_OR_BAIL(obj.extraNodeData_1); const pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData1 &v2 = *obj.extraNodeData_1; /*8.6*/
         len += stream.sizeOfVarInt(v2.name.length());
         len += v2.name.length(); /*name: pstring*/ /*4.1*/
     }
-    else if (flags.command_node_type == 2) { /*8.2*/
+    else if (V_flags.command_node_type == 2) { /*8.2*/
         EXPECT_OR_BAIL(obj.extraNodeData_2); const pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData2 &v2 = *obj.extraNodeData_2; /*8.6*/
         len += stream.sizeOfVarInt(v2.name.length());
         len += v2.name.length(); /*name: pstring*/ /*4.1*/
         len += stream.sizeOfVarInt(v2.parser.length());
         len += v2.parser.length(); /*parser^: pstring*/ /*4.1*/
-        const std::string &parser = v2.parser; /*4.7*/
-        if (parser == "brigadier:bool") { /*8.0*/
+        const std::string &V_parser = v2.parser; /*4.7*/
+        if (V_parser == "brigadier:bool") { /*8.0*/
         }
-        else if (parser == "brigadier:float") { /*8.0*/
+        else if (V_parser == "brigadier:float") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_brigadier_float); const pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData2::PropertiesBrigadierFloat &v4 = *v2.properties_brigadier_float; /*8.6*/
             len += 1; /*flags^: bitfield*/ /*4.1*/
-            const pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData2::PropertiesBrigadierFloat::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData2::PropertiesBrigadierFloat::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               len += 4; /*0.2*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               len += 4; /*0.2*/
             }
         }
-        else if (parser == "brigadier:double") { /*8.0*/
+        else if (V_parser == "brigadier:double") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_brigadier_double); const pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData2::PropertiesBrigadierDouble &v4 = *v2.properties_brigadier_double; /*8.6*/
             len += 1; /*flags^: bitfield*/ /*4.1*/
-            const pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData2::PropertiesBrigadierDouble::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData2::PropertiesBrigadierDouble::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               len += 8; /*0.2*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               len += 8; /*0.2*/
             }
         }
-        else if (parser == "brigadier:integer") { /*8.0*/
+        else if (V_parser == "brigadier:integer") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_brigadier_integer); const pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData2::PropertiesBrigadierInteger &v4 = *v2.properties_brigadier_integer; /*8.6*/
             len += 1; /*flags^: bitfield*/ /*4.1*/
-            const pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData2::PropertiesBrigadierInteger::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData2::PropertiesBrigadierInteger::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               len += 4; /*0.2*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               len += 4; /*0.2*/
             }
         }
-        else if (parser == "brigadier:long") { /*8.0*/
+        else if (V_parser == "brigadier:long") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_brigadier_long); const pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData2::PropertiesBrigadierLong &v4 = *v2.properties_brigadier_long; /*8.6*/
             len += 1; /*flags^: bitfield*/ /*4.1*/
-            const pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData2::PropertiesBrigadierLong::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData2::PropertiesBrigadierLong::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               len += 8; /*0.2*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               len += 8; /*0.2*/
             }
         }
-        else if (parser == "brigadier:string") { /*8.0*/
+        else if (V_parser == "brigadier:string") { /*8.0*/
         }
-        else if (parser == "minecraft:entity") { /*8.0*/
+        else if (V_parser == "minecraft:entity") { /*8.0*/
           len += 1; /*properties: bitfield*/ /*4.1*/
         }
-        else if (parser == "minecraft:game_profile") { /*8.0*/
+        else if (V_parser == "minecraft:game_profile") { /*8.0*/
         }
-        else if (parser == "minecraft:block_pos") { /*8.0*/
+        else if (V_parser == "minecraft:block_pos") { /*8.0*/
         }
-        else if (parser == "minecraft:column_pos") { /*8.0*/
+        else if (V_parser == "minecraft:column_pos") { /*8.0*/
         }
-        else if (parser == "minecraft:vec3") { /*8.0*/
+        else if (V_parser == "minecraft:vec3") { /*8.0*/
         }
-        else if (parser == "minecraft:vec2") { /*8.0*/
+        else if (V_parser == "minecraft:vec2") { /*8.0*/
         }
-        else if (parser == "minecraft:block_state") { /*8.0*/
+        else if (V_parser == "minecraft:block_state") { /*8.0*/
         }
-        else if (parser == "minecraft:block_predicate") { /*8.0*/
+        else if (V_parser == "minecraft:block_predicate") { /*8.0*/
         }
-        else if (parser == "minecraft:item_stack") { /*8.0*/
+        else if (V_parser == "minecraft:item_stack") { /*8.0*/
         }
-        else if (parser == "minecraft:item_predicate") { /*8.0*/
+        else if (V_parser == "minecraft:item_predicate") { /*8.0*/
         }
-        else if (parser == "minecraft:color") { /*8.0*/
+        else if (V_parser == "minecraft:color") { /*8.0*/
         }
-        else if (parser == "minecraft:component") { /*8.0*/
+        else if (V_parser == "minecraft:component") { /*8.0*/
         }
-        else if (parser == "minecraft:message") { /*8.0*/
+        else if (V_parser == "minecraft:message") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt") { /*8.0*/
+        else if (V_parser == "minecraft:nbt") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt_path") { /*8.0*/
+        else if (V_parser == "minecraft:nbt_path") { /*8.0*/
         }
-        else if (parser == "minecraft:objective") { /*8.0*/
+        else if (V_parser == "minecraft:objective") { /*8.0*/
         }
-        else if (parser == "minecraft:objective_criteria") { /*8.0*/
+        else if (V_parser == "minecraft:objective_criteria") { /*8.0*/
         }
-        else if (parser == "minecraft:operation") { /*8.0*/
+        else if (V_parser == "minecraft:operation") { /*8.0*/
         }
-        else if (parser == "minecraft:particle") { /*8.0*/
+        else if (V_parser == "minecraft:particle") { /*8.0*/
         }
-        else if (parser == "minecraft:angle") { /*8.0*/
+        else if (V_parser == "minecraft:angle") { /*8.0*/
         }
-        else if (parser == "minecraft:rotation") { /*8.0*/
+        else if (V_parser == "minecraft:rotation") { /*8.0*/
         }
-        else if (parser == "minecraft:scoreboard_slot") { /*8.0*/
+        else if (V_parser == "minecraft:scoreboard_slot") { /*8.0*/
         }
-        else if (parser == "minecraft:score_holder") { /*8.0*/
+        else if (V_parser == "minecraft:score_holder") { /*8.0*/
           len += 1; /*properties: bitfield*/ /*4.1*/
         }
-        else if (parser == "minecraft:swizzle") { /*8.0*/
+        else if (V_parser == "minecraft:swizzle") { /*8.0*/
         }
-        else if (parser == "minecraft:team") { /*8.0*/
+        else if (V_parser == "minecraft:team") { /*8.0*/
         }
-        else if (parser == "minecraft:item_slot") { /*8.0*/
+        else if (V_parser == "minecraft:item_slot") { /*8.0*/
         }
-        else if (parser == "minecraft:resource_location") { /*8.0*/
+        else if (V_parser == "minecraft:resource_location") { /*8.0*/
         }
-        else if (parser == "minecraft:mob_effect") { /*8.0*/
+        else if (V_parser == "minecraft:mob_effect") { /*8.0*/
         }
-        else if (parser == "minecraft:function") { /*8.0*/
+        else if (V_parser == "minecraft:function") { /*8.0*/
         }
-        else if (parser == "minecraft:entity_anchor") { /*8.0*/
+        else if (V_parser == "minecraft:entity_anchor") { /*8.0*/
         }
-        else if (parser == "minecraft:range") { /*8.0*/
+        else if (V_parser == "minecraft:range") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_minecraft_range); const pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData2::PropertiesMinecraftRange &v4 = *v2.properties_minecraft_range; /*8.6*/
             len += 1; /*0.2*/
         }
-        else if (parser == "minecraft:int_range") { /*8.0*/
+        else if (V_parser == "minecraft:int_range") { /*8.0*/
         }
-        else if (parser == "minecraft:float_range") { /*8.0*/
+        else if (V_parser == "minecraft:float_range") { /*8.0*/
         }
-        else if (parser == "minecraft:item_enchantment") { /*8.0*/
+        else if (V_parser == "minecraft:item_enchantment") { /*8.0*/
         }
-        else if (parser == "minecraft:entity_summon") { /*8.0*/
+        else if (V_parser == "minecraft:entity_summon") { /*8.0*/
         }
-        else if (parser == "minecraft:dimension") { /*8.0*/
+        else if (V_parser == "minecraft:dimension") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt_compound_tag") { /*8.0*/
+        else if (V_parser == "minecraft:nbt_compound_tag") { /*8.0*/
         }
-        else if (parser == "minecraft:time") { /*8.0*/
+        else if (V_parser == "minecraft:time") { /*8.0*/
         }
-        else if (parser == "minecraft:resource_or_tag") { /*8.0*/
+        else if (V_parser == "minecraft:resource_or_tag") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_minecraft_resource_or_tag_or_minecraft_resource); const pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData2::PropertiesMinecraftResourceOrTagOrMinecraftResource &v4 = *v2.properties_minecraft_resource_or_tag_or_minecraft_resource; /*8.6*/
             len += stream.sizeOfVarInt(v4.registry.length());
             len += v4.registry.length(); /*registry: pstring*/ /*4.1*/
         }
-        else if (parser == "minecraft:resource") { /*8.0*/
+        else if (V_parser == "minecraft:resource") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_minecraft_resource_or_tag_or_minecraft_resource); const pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData2::PropertiesMinecraftResourceOrTagOrMinecraftResource &v4 = *v2.properties_minecraft_resource_or_tag_or_minecraft_resource; /*8.6*/
             len += stream.sizeOfVarInt(v4.registry.length());
             len += v4.registry.length(); /*registry: pstring*/ /*4.1*/
         }
-        else if (parser == "minecraft:uuid") { /*8.0*/
+        else if (V_parser == "minecraft:uuid") { /*8.0*/
         }
-        if (flags.has_custom_suggestions == 1) { /*8.2*/
+        if (V_flags.has_custom_suggestions == 1) { /*8.2*/
           len += stream.sizeOfVarInt(v2.suggestionType.length());
           len += v2.suggestionType.length(); /*suggestionType: pstring*/ /*4.1*/
         }
@@ -529,9 +529,9 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_handshaking_toServer::tags 
   }
   size_t packet(pdef::Stream &stream, const pdef::pc1_18_handshaking_toServer::packet &obj) {
     size_t len = 0;
-    const pdef::pc1_18_handshaking_toServer::packet::Name &name = obj.name; /*0.3*/
+    const pdef::pc1_18_handshaking_toServer::packet::Name &V_name = obj.name; /*0.3*/
     len += stream.sizeOfVarInt((int&)obj.name); /*name^: varint*/ /*7.0*/
-    switch (name) { /*8.0*/
+    switch (V_name) { /*8.0*/
       case pdef::pc1_18_handshaking_toServer::packet::Name::SetProtocol: { /*8.5*/
         EXPECT_OR_BAIL(obj.params_packet_set_protocol); size_t len_0 = pdef::pc1_18_handshaking_toServer::size::packet_set_protocol(stream, *obj.params_packet_set_protocol); EXPECT_OR_BAIL(len_0); len += len_0; /*params_packet_set_protocol*/ /*4.4*/
         break;
@@ -558,11 +558,11 @@ bool packet_legacy_server_list_ping(pdef::Stream &stream, const pdef::pc1_18_han
 bool packet(pdef::Stream &stream, const pdef::pc1_18_handshaking_toServer::packet &obj, bool allocate);
   bool slot(pdef::Stream &stream, const pdef::pc1_18_handshaking_toServer::slot &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::pc1_18_handshaking_toServer::size::slot(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const bool &present = obj.present; /*0.1*/
+    const bool &V_present = obj.present; /*0.1*/
     WRITE_OR_BAIL(writeBool, (bool)obj.present); /*0.4*/
-    if (present == false) { /*8.1*/
+    if (V_present == false) { /*8.1*/
     }
-    else if (present == true) { /*8.1*/
+    else if (V_present == true) { /*8.1*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.itemId); /*0.4*/
         WRITE_OR_BAIL(writeByte, (int8_t)obj.itemCount); /*0.4*/
         WRITE_OR_BAIL(writeByte, (int8_t)obj.nbtData); /*0.4*/
@@ -571,24 +571,24 @@ bool packet(pdef::Stream &stream, const pdef::pc1_18_handshaking_toServer::packe
   }
   bool particle(pdef::Stream &stream, const pdef::pc1_18_handshaking_toServer::particle &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::pc1_18_handshaking_toServer::size::particle(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const int &particleId = obj.particleId; /*0.1*/
+    const int &V_particleId = obj.particleId; /*0.1*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.particleId); /*0.4*/
-    if (particleId == 2) { /*8.2*/
+    if (V_particleId == 2) { /*8.2*/
         const pdef::pc1_18_handshaking_toServer::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.5*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.blockState); /*0.4*/
     }
-    else if (particleId == 3) { /*8.2*/
+    else if (V_particleId == 3) { /*8.2*/
         const pdef::pc1_18_handshaking_toServer::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.5*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.blockState); /*0.4*/
     }
-    else if (particleId == 14) { /*8.2*/
+    else if (V_particleId == 14) { /*8.2*/
         const pdef::pc1_18_handshaking_toServer::particle::Data14 &v2 = *obj.data_14; /*8.5*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.red); /*0.4*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.green); /*0.4*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.blue); /*0.4*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.scale); /*0.4*/
     }
-    else if (particleId == 15) { /*8.2*/
+    else if (V_particleId == 15) { /*8.2*/
         const pdef::pc1_18_handshaking_toServer::particle::Data15 &v2 = *obj.data_15; /*8.5*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.fromRed); /*0.4*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.fromGreen); /*0.4*/
@@ -598,15 +598,15 @@ bool packet(pdef::Stream &stream, const pdef::pc1_18_handshaking_toServer::packe
         WRITE_OR_BAIL(writeFloatBE, (float)v2.toGreen); /*0.4*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.toBlue); /*0.4*/
     }
-    else if (particleId == 24) { /*8.2*/
+    else if (V_particleId == 24) { /*8.2*/
         const pdef::pc1_18_handshaking_toServer::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.5*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.blockState); /*0.4*/
     }
-    else if (particleId == 35) { /*8.2*/
+    else if (V_particleId == 35) { /*8.2*/
         const pdef::pc1_18_handshaking_toServer::particle::Data35 &v2 = *obj.data_35; /*8.5*/
         WRITE_OR_BAIL(writeByte, (int8_t)v2.item); /*0.4*/
     }
-    else if (particleId == 36) { /*8.2*/
+    else if (V_particleId == 36) { /*8.2*/
         const pdef::pc1_18_handshaking_toServer::particle::Data36 &v2 = *obj.data_36; /*8.5*/
         uint64_t origin_val = 0;
         origin_val |= (uint64_t)v2.origin.x << 0;
@@ -615,15 +615,15 @@ bool packet(pdef::Stream &stream, const pdef::pc1_18_handshaking_toServer::packe
         WRITE_OR_BAIL(writeULongBE, origin_val); /*origin: bitfield*/ /*4.2*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.positionType.length());
         WRITE_OR_BAIL(writeString, v2.positionType); /*positionType: pstring*/ /*4.2*/
-        const std::string &positionType = v2.positionType; /*4.7*/
-        if (positionType == "minecraft:block") { /*8.0*/
+        const std::string &V_positionType = v2.positionType; /*4.7*/
+        if (V_positionType == "minecraft:block") { /*8.0*/
           uint64_t destination_position_val = 0;
           destination_position_val |= (uint64_t)v2.destination_position.x << 0;
           destination_position_val |= (uint64_t)v2.destination_position.z << 26;
           destination_position_val |= (uint64_t)v2.destination_position.y << 52;
           WRITE_OR_BAIL(writeULongBE, destination_position_val); /*destination_position: bitfield*/ /*4.2*/
         }
-        else if (positionType == "minecraft:entity") { /*8.0*/
+        else if (V_positionType == "minecraft:entity") { /*8.0*/
           WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.destination_varint); /*0.4*/
         }
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.ticks); /*0.4*/
@@ -673,192 +673,192 @@ bool tags(pdef::Stream &stream, const pdef::pc1_18_handshaking_toServer::tags &o
     flags_val |= (uint8_t)obj.flags.has_command << 5;
     flags_val |= (uint8_t)obj.flags.command_node_type << 6;
     WRITE_OR_BAIL(writeUByte, flags_val); /*flags: bitfield*/ /*4.2*/
-    const pdef::pc1_18_handshaking_toServer::command_node::flags_t &flags = obj.flags; /*4.7*/
+    const pdef::pc1_18_handshaking_toServer::command_node::flags_t &V_flags = obj.flags; /*4.7*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.children.size()); /*1.4*/
     for (const auto &v2 : obj.children) { /*3.1*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2); /*0.4*/
     }
-    if (flags.has_redirect_node == 1) { /*8.2*/
+    if (V_flags.has_redirect_node == 1) { /*8.2*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.redirectNode); /*0.4*/
     }
-    if (flags.command_node_type == 0) { /*8.2*/
+    if (V_flags.command_node_type == 0) { /*8.2*/
     }
-    else if (flags.command_node_type == 1) { /*8.2*/
+    else if (V_flags.command_node_type == 1) { /*8.2*/
         const pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData1 &v2 = *obj.extraNodeData_1; /*8.5*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.name.length());
         WRITE_OR_BAIL(writeString, v2.name); /*name: pstring*/ /*4.2*/
     }
-    else if (flags.command_node_type == 2) { /*8.2*/
+    else if (V_flags.command_node_type == 2) { /*8.2*/
         const pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData2 &v2 = *obj.extraNodeData_2; /*8.5*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.name.length());
         WRITE_OR_BAIL(writeString, v2.name); /*name: pstring*/ /*4.2*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.parser.length());
         WRITE_OR_BAIL(writeString, v2.parser); /*parser: pstring*/ /*4.2*/
-        const std::string &parser = v2.parser; /*4.7*/
-        if (parser == "brigadier:bool") { /*8.0*/
+        const std::string &V_parser = v2.parser; /*4.7*/
+        if (V_parser == "brigadier:bool") { /*8.0*/
         }
-        else if (parser == "brigadier:float") { /*8.0*/
+        else if (V_parser == "brigadier:float") { /*8.0*/
             const pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData2::PropertiesBrigadierFloat &v4 = *v2.properties_brigadier_float; /*8.5*/
             uint8_t flags_val = 0;
             flags_val |= (uint8_t)v4.flags.unused << 0;
             flags_val |= (uint8_t)v4.flags.max_present << 6;
             flags_val |= (uint8_t)v4.flags.min_present << 7;
             WRITE_OR_BAIL(writeUByte, flags_val); /*flags: bitfield*/ /*4.2*/
-            const pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData2::PropertiesBrigadierFloat::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData2::PropertiesBrigadierFloat::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeFloatBE, (float)v4.min); /*0.4*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeFloatBE, (float)v4.max); /*0.4*/
             }
         }
-        else if (parser == "brigadier:double") { /*8.0*/
+        else if (V_parser == "brigadier:double") { /*8.0*/
             const pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData2::PropertiesBrigadierDouble &v4 = *v2.properties_brigadier_double; /*8.5*/
             uint8_t flags_val = 0;
             flags_val |= (uint8_t)v4.flags.unused << 0;
             flags_val |= (uint8_t)v4.flags.max_present << 6;
             flags_val |= (uint8_t)v4.flags.min_present << 7;
             WRITE_OR_BAIL(writeUByte, flags_val); /*flags: bitfield*/ /*4.2*/
-            const pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData2::PropertiesBrigadierDouble::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData2::PropertiesBrigadierDouble::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeDoubleBE, (double)v4.min); /*0.4*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeDoubleBE, (double)v4.max); /*0.4*/
             }
         }
-        else if (parser == "brigadier:integer") { /*8.0*/
+        else if (V_parser == "brigadier:integer") { /*8.0*/
             const pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData2::PropertiesBrigadierInteger &v4 = *v2.properties_brigadier_integer; /*8.5*/
             uint8_t flags_val = 0;
             flags_val |= (uint8_t)v4.flags.unused << 0;
             flags_val |= (uint8_t)v4.flags.max_present << 6;
             flags_val |= (uint8_t)v4.flags.min_present << 7;
             WRITE_OR_BAIL(writeUByte, flags_val); /*flags: bitfield*/ /*4.2*/
-            const pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData2::PropertiesBrigadierInteger::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData2::PropertiesBrigadierInteger::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeIntBE, (int32_t)v4.min); /*0.4*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeIntBE, (int32_t)v4.max); /*0.4*/
             }
         }
-        else if (parser == "brigadier:long") { /*8.0*/
+        else if (V_parser == "brigadier:long") { /*8.0*/
             const pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData2::PropertiesBrigadierLong &v4 = *v2.properties_brigadier_long; /*8.5*/
             uint8_t flags_val = 0;
             flags_val |= (uint8_t)v4.flags.unused << 0;
             flags_val |= (uint8_t)v4.flags.max_present << 6;
             flags_val |= (uint8_t)v4.flags.min_present << 7;
             WRITE_OR_BAIL(writeUByte, flags_val); /*flags: bitfield*/ /*4.2*/
-            const pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData2::PropertiesBrigadierLong::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData2::PropertiesBrigadierLong::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeLongBE, (int64_t)v4.min); /*0.4*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeLongBE, (int64_t)v4.max); /*0.4*/
             }
         }
-        else if (parser == "brigadier:string") { /*8.0*/
+        else if (V_parser == "brigadier:string") { /*8.0*/
         }
-        else if (parser == "minecraft:entity") { /*8.0*/
+        else if (V_parser == "minecraft:entity") { /*8.0*/
           uint8_t properties_minecraft_entity_val = 0;
           properties_minecraft_entity_val |= (uint8_t)v2.properties_minecraft_entity.unused << 0;
           properties_minecraft_entity_val |= (uint8_t)v2.properties_minecraft_entity.onlyAllowPlayers << 6;
           properties_minecraft_entity_val |= (uint8_t)v2.properties_minecraft_entity.onlyAllowEntities << 7;
           WRITE_OR_BAIL(writeUByte, properties_minecraft_entity_val); /*properties_minecraft_entity: bitfield*/ /*4.2*/
         }
-        else if (parser == "minecraft:game_profile") { /*8.0*/
+        else if (V_parser == "minecraft:game_profile") { /*8.0*/
         }
-        else if (parser == "minecraft:block_pos") { /*8.0*/
+        else if (V_parser == "minecraft:block_pos") { /*8.0*/
         }
-        else if (parser == "minecraft:column_pos") { /*8.0*/
+        else if (V_parser == "minecraft:column_pos") { /*8.0*/
         }
-        else if (parser == "minecraft:vec3") { /*8.0*/
+        else if (V_parser == "minecraft:vec3") { /*8.0*/
         }
-        else if (parser == "minecraft:vec2") { /*8.0*/
+        else if (V_parser == "minecraft:vec2") { /*8.0*/
         }
-        else if (parser == "minecraft:block_state") { /*8.0*/
+        else if (V_parser == "minecraft:block_state") { /*8.0*/
         }
-        else if (parser == "minecraft:block_predicate") { /*8.0*/
+        else if (V_parser == "minecraft:block_predicate") { /*8.0*/
         }
-        else if (parser == "minecraft:item_stack") { /*8.0*/
+        else if (V_parser == "minecraft:item_stack") { /*8.0*/
         }
-        else if (parser == "minecraft:item_predicate") { /*8.0*/
+        else if (V_parser == "minecraft:item_predicate") { /*8.0*/
         }
-        else if (parser == "minecraft:color") { /*8.0*/
+        else if (V_parser == "minecraft:color") { /*8.0*/
         }
-        else if (parser == "minecraft:component") { /*8.0*/
+        else if (V_parser == "minecraft:component") { /*8.0*/
         }
-        else if (parser == "minecraft:message") { /*8.0*/
+        else if (V_parser == "minecraft:message") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt") { /*8.0*/
+        else if (V_parser == "minecraft:nbt") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt_path") { /*8.0*/
+        else if (V_parser == "minecraft:nbt_path") { /*8.0*/
         }
-        else if (parser == "minecraft:objective") { /*8.0*/
+        else if (V_parser == "minecraft:objective") { /*8.0*/
         }
-        else if (parser == "minecraft:objective_criteria") { /*8.0*/
+        else if (V_parser == "minecraft:objective_criteria") { /*8.0*/
         }
-        else if (parser == "minecraft:operation") { /*8.0*/
+        else if (V_parser == "minecraft:operation") { /*8.0*/
         }
-        else if (parser == "minecraft:particle") { /*8.0*/
+        else if (V_parser == "minecraft:particle") { /*8.0*/
         }
-        else if (parser == "minecraft:angle") { /*8.0*/
+        else if (V_parser == "minecraft:angle") { /*8.0*/
         }
-        else if (parser == "minecraft:rotation") { /*8.0*/
+        else if (V_parser == "minecraft:rotation") { /*8.0*/
         }
-        else if (parser == "minecraft:scoreboard_slot") { /*8.0*/
+        else if (V_parser == "minecraft:scoreboard_slot") { /*8.0*/
         }
-        else if (parser == "minecraft:score_holder") { /*8.0*/
+        else if (V_parser == "minecraft:score_holder") { /*8.0*/
           uint8_t properties_minecraft_score_holder_val = 0;
           properties_minecraft_score_holder_val |= (uint8_t)v2.properties_minecraft_score_holder.unused << 0;
           properties_minecraft_score_holder_val |= (uint8_t)v2.properties_minecraft_score_holder.allowMultiple << 7;
           WRITE_OR_BAIL(writeUByte, properties_minecraft_score_holder_val); /*properties_minecraft_score_holder: bitfield*/ /*4.2*/
         }
-        else if (parser == "minecraft:swizzle") { /*8.0*/
+        else if (V_parser == "minecraft:swizzle") { /*8.0*/
         }
-        else if (parser == "minecraft:team") { /*8.0*/
+        else if (V_parser == "minecraft:team") { /*8.0*/
         }
-        else if (parser == "minecraft:item_slot") { /*8.0*/
+        else if (V_parser == "minecraft:item_slot") { /*8.0*/
         }
-        else if (parser == "minecraft:resource_location") { /*8.0*/
+        else if (V_parser == "minecraft:resource_location") { /*8.0*/
         }
-        else if (parser == "minecraft:mob_effect") { /*8.0*/
+        else if (V_parser == "minecraft:mob_effect") { /*8.0*/
         }
-        else if (parser == "minecraft:function") { /*8.0*/
+        else if (V_parser == "minecraft:function") { /*8.0*/
         }
-        else if (parser == "minecraft:entity_anchor") { /*8.0*/
+        else if (V_parser == "minecraft:entity_anchor") { /*8.0*/
         }
-        else if (parser == "minecraft:range") { /*8.0*/
+        else if (V_parser == "minecraft:range") { /*8.0*/
             const pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData2::PropertiesMinecraftRange &v4 = *v2.properties_minecraft_range; /*8.5*/
             WRITE_OR_BAIL(writeBool, (bool)v4.allowDecimals); /*0.4*/
         }
-        else if (parser == "minecraft:int_range") { /*8.0*/
+        else if (V_parser == "minecraft:int_range") { /*8.0*/
         }
-        else if (parser == "minecraft:float_range") { /*8.0*/
+        else if (V_parser == "minecraft:float_range") { /*8.0*/
         }
-        else if (parser == "minecraft:item_enchantment") { /*8.0*/
+        else if (V_parser == "minecraft:item_enchantment") { /*8.0*/
         }
-        else if (parser == "minecraft:entity_summon") { /*8.0*/
+        else if (V_parser == "minecraft:entity_summon") { /*8.0*/
         }
-        else if (parser == "minecraft:dimension") { /*8.0*/
+        else if (V_parser == "minecraft:dimension") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt_compound_tag") { /*8.0*/
+        else if (V_parser == "minecraft:nbt_compound_tag") { /*8.0*/
         }
-        else if (parser == "minecraft:time") { /*8.0*/
+        else if (V_parser == "minecraft:time") { /*8.0*/
         }
-        else if (parser == "minecraft:resource_or_tag") { /*8.0*/
+        else if (V_parser == "minecraft:resource_or_tag") { /*8.0*/
             const pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData2::PropertiesMinecraftResourceOrTagOrMinecraftResource &v4 = *v2.properties_minecraft_resource_or_tag_or_minecraft_resource; /*8.5*/
             WRITE_OR_BAIL(writeUnsignedVarInt, (int)v4.registry.length());
             WRITE_OR_BAIL(writeString, v4.registry); /*registry: pstring*/ /*4.2*/
         }
-        else if (parser == "minecraft:resource") { /*8.0*/
+        else if (V_parser == "minecraft:resource") { /*8.0*/
             const pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData2::PropertiesMinecraftResourceOrTagOrMinecraftResource &v4 = *v2.properties_minecraft_resource_or_tag_or_minecraft_resource; /*8.5*/
             WRITE_OR_BAIL(writeUnsignedVarInt, (int)v4.registry.length());
             WRITE_OR_BAIL(writeString, v4.registry); /*registry: pstring*/ /*4.2*/
         }
-        else if (parser == "minecraft:uuid") { /*8.0*/
+        else if (V_parser == "minecraft:uuid") { /*8.0*/
         }
-        if (flags.has_custom_suggestions == 1) { /*8.2*/
+        if (V_flags.has_custom_suggestions == 1) { /*8.2*/
           WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.suggestionType.length());
           WRITE_OR_BAIL(writeString, v2.suggestionType); /*suggestionType: pstring*/ /*4.2*/
         }
@@ -881,9 +881,9 @@ bool tags(pdef::Stream &stream, const pdef::pc1_18_handshaking_toServer::tags &o
   }
   bool packet(pdef::Stream &stream, const pdef::pc1_18_handshaking_toServer::packet &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::pc1_18_handshaking_toServer::size::packet(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const pdef::pc1_18_handshaking_toServer::packet::Name &name = obj.name; /*0.3*/
+    const pdef::pc1_18_handshaking_toServer::packet::Name &V_name = obj.name; /*0.3*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)(int&)obj.name); /*7.1*/
-    switch (name) { /*8.0*/
+    switch (V_name) { /*8.0*/
       case pdef::pc1_18_handshaking_toServer::packet::Name::SetProtocol: { /*8.5*/
         pdef::pc1_18_handshaking_toServer::encode::packet_set_protocol(stream, *obj.params_packet_set_protocol); /*packet_set_protocol*/ /*4.5*/
         break;
@@ -910,10 +910,10 @@ bool packet_legacy_server_list_ping(pdef::Stream &stream, pdef::pc1_18_handshaki
 bool packet(pdef::Stream &stream, pdef::pc1_18_handshaking_toServer::packet &obj);
   bool slot(pdef::Stream &stream, pdef::pc1_18_handshaking_toServer::slot &obj) {
     READ_OR_BAIL(readBool, (bool&)obj.present); /*0.5*/
-    bool &present = obj.present; /*0.6*/
-    if (present == false) { /*8.1*/
+    bool &V_present = obj.present; /*0.6*/
+    if (V_present == false) { /*8.1*/
     }
-    else if (present == true) { /*8.1*/
+    else if (V_present == true) { /*8.1*/
         READ_OR_BAIL(readUnsignedVarInt, obj.itemId); /*0.5*/
         READ_OR_BAIL(readByte, obj.itemCount); /*0.5*/
         READ_OR_BAIL(readByte, obj.nbtData); /*0.5*/
@@ -922,23 +922,23 @@ bool packet(pdef::Stream &stream, pdef::pc1_18_handshaking_toServer::packet &obj
   }
   bool particle(pdef::Stream &stream, pdef::pc1_18_handshaking_toServer::particle &obj) {
     READ_OR_BAIL(readUnsignedVarInt, obj.particleId); /*0.5*/
-    int &particleId = obj.particleId; /*0.6*/
-    if (particleId == 2) { /*8.2*/
+    int &V_particleId = obj.particleId; /*0.6*/
+    if (V_particleId == 2) { /*8.2*/
          obj.data_2_or_3_or_24 = {}; pdef::pc1_18_handshaking_toServer::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.4*/
         READ_OR_BAIL(readUnsignedVarInt, v2.blockState); /*0.5*/
     }
-    else if (particleId == 3) { /*8.2*/
+    else if (V_particleId == 3) { /*8.2*/
          obj.data_2_or_3_or_24 = {}; pdef::pc1_18_handshaking_toServer::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.4*/
         READ_OR_BAIL(readUnsignedVarInt, v2.blockState); /*0.5*/
     }
-    else if (particleId == 14) { /*8.2*/
+    else if (V_particleId == 14) { /*8.2*/
          obj.data_14 = {}; pdef::pc1_18_handshaking_toServer::particle::Data14 &v2 = *obj.data_14; /*8.4*/
         READ_OR_BAIL(readFloatBE, v2.red); /*0.5*/
         READ_OR_BAIL(readFloatBE, v2.green); /*0.5*/
         READ_OR_BAIL(readFloatBE, v2.blue); /*0.5*/
         READ_OR_BAIL(readFloatBE, v2.scale); /*0.5*/
     }
-    else if (particleId == 15) { /*8.2*/
+    else if (V_particleId == 15) { /*8.2*/
          obj.data_15 = {}; pdef::pc1_18_handshaking_toServer::particle::Data15 &v2 = *obj.data_15; /*8.4*/
         READ_OR_BAIL(readFloatBE, v2.fromRed); /*0.5*/
         READ_OR_BAIL(readFloatBE, v2.fromGreen); /*0.5*/
@@ -948,15 +948,15 @@ bool packet(pdef::Stream &stream, pdef::pc1_18_handshaking_toServer::packet &obj
         READ_OR_BAIL(readFloatBE, v2.toGreen); /*0.5*/
         READ_OR_BAIL(readFloatBE, v2.toBlue); /*0.5*/
     }
-    else if (particleId == 24) { /*8.2*/
+    else if (V_particleId == 24) { /*8.2*/
          obj.data_2_or_3_or_24 = {}; pdef::pc1_18_handshaking_toServer::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.4*/
         READ_OR_BAIL(readUnsignedVarInt, v2.blockState); /*0.5*/
     }
-    else if (particleId == 35) { /*8.2*/
+    else if (V_particleId == 35) { /*8.2*/
          obj.data_35 = {}; pdef::pc1_18_handshaking_toServer::particle::Data35 &v2 = *obj.data_35; /*8.4*/
         READ_OR_BAIL(readByte, v2.item); /*0.5*/
     }
-    else if (particleId == 36) { /*8.2*/
+    else if (V_particleId == 36) { /*8.2*/
          obj.data_36 = {}; pdef::pc1_18_handshaking_toServer::particle::Data36 &v2 = *obj.data_36; /*8.4*/
         uint64_t origin_val;
         READ_OR_BAIL(readULongBE, origin_val);
@@ -965,15 +965,15 @@ bool packet(pdef::Stream &stream, pdef::pc1_18_handshaking_toServer::packet &obj
         v2.origin.y = origin_val >> 52 & 12; /*origin: bitfield*/ /*4.3*/
         int positionType_strlen; READ_OR_BAIL(readUnsignedVarInt, positionType_strlen);
         if (!stream.readString(v2.positionType, positionType_strlen)) return false; /*positionType: pstring*/ /*4.3*/
-        std::string &positionType = v2.positionType; /*4.8*/
-        if (positionType == "minecraft:block") { /*8.0*/
+        std::string &V_positionType = v2.positionType; /*4.8*/
+        if (V_positionType == "minecraft:block") { /*8.0*/
           uint64_t destination_position_val;
           READ_OR_BAIL(readULongBE, destination_position_val);
           v2.destination_position.x = destination_position_val >> 0 & 26;
           v2.destination_position.z = destination_position_val >> 26 & 26;
           v2.destination_position.y = destination_position_val >> 52 & 12; /*destination_position: bitfield*/ /*4.3*/
         }
-        else if (positionType == "minecraft:entity") { /*8.0*/
+        else if (V_positionType == "minecraft:entity") { /*8.0*/
           READ_OR_BAIL(readUnsignedVarInt, v2.destination_varint); /*0.5*/
         }
         READ_OR_BAIL(readUnsignedVarInt, v2.ticks); /*0.5*/
@@ -985,7 +985,7 @@ bool packet(pdef::Stream &stream, pdef::pc1_18_handshaking_toServer::packet &obj
     if (!stream.readString(obj.group, group_strlen)) return false; /*group: pstring*/ /*4.3*/
     int ingredient_len; READ_OR_BAIL(readUnsignedVarInt, ingredient_len); /*1.5*/
     obj.ingredient.resize(ingredient_len); /*1.6*/
-    for (int i = 0; i < ingredient_len; i++) {
+    for (int i = 0; i < ingredient_len; i++) { /*3.3*/
       auto &v2 = obj.ingredient[i]; /*3.4*/
       READ_OR_BAIL(readByte, v2); /*0.5*/
     }
@@ -999,7 +999,7 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_handshaking_toServer::tags &obj) {
     if (!stream.readString(obj.tagName, tagName_strlen)) return false; /*tagName: pstring*/ /*4.3*/
     int entries_len; READ_OR_BAIL(readUnsignedVarInt, entries_len); /*1.5*/
     obj.entries.resize(entries_len); /*1.6*/
-    for (int i = 0; i < entries_len; i++) {
+    for (int i = 0; i < entries_len; i++) { /*3.3*/
       auto &v2 = obj.entries[i]; /*3.4*/
       READ_OR_BAIL(readUnsignedVarInt, v2); /*0.5*/
     }
@@ -1023,194 +1023,194 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_handshaking_toServer::tags &obj) {
     obj.flags.has_redirect_node = flags_val >> 4 & 1;
     obj.flags.has_command = flags_val >> 5 & 1;
     obj.flags.command_node_type = flags_val >> 6 & 2; /*flags: bitfield*/ /*4.3*/
-    pdef::pc1_18_handshaking_toServer::command_node::flags_t &flags = obj.flags; /*4.8*/
+    pdef::pc1_18_handshaking_toServer::command_node::flags_t &V_flags = obj.flags; /*4.8*/
     int children_len; READ_OR_BAIL(readUnsignedVarInt, children_len); /*1.5*/
     obj.children.resize(children_len); /*1.6*/
-    for (int i = 0; i < children_len; i++) {
+    for (int i = 0; i < children_len; i++) { /*3.3*/
       auto &v2 = obj.children[i]; /*3.4*/
       READ_OR_BAIL(readUnsignedVarInt, v2); /*0.5*/
     }
-    if (flags.has_redirect_node == 1) { /*8.2*/
+    if (V_flags.has_redirect_node == 1) { /*8.2*/
       READ_OR_BAIL(readUnsignedVarInt, obj.redirectNode); /*0.5*/
     }
-    if (flags.command_node_type == 0) { /*8.2*/
+    if (V_flags.command_node_type == 0) { /*8.2*/
     }
-    else if (flags.command_node_type == 1) { /*8.2*/
+    else if (V_flags.command_node_type == 1) { /*8.2*/
          obj.extraNodeData_1 = {}; pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData1 &v2 = *obj.extraNodeData_1; /*8.4*/
         int name_strlen; READ_OR_BAIL(readUnsignedVarInt, name_strlen);
         if (!stream.readString(v2.name, name_strlen)) return false; /*name: pstring*/ /*4.3*/
     }
-    else if (flags.command_node_type == 2) { /*8.2*/
+    else if (V_flags.command_node_type == 2) { /*8.2*/
          obj.extraNodeData_2 = {}; pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData2 &v2 = *obj.extraNodeData_2; /*8.4*/
         int name_strlen; READ_OR_BAIL(readUnsignedVarInt, name_strlen);
         if (!stream.readString(v2.name, name_strlen)) return false; /*name: pstring*/ /*4.3*/
         int parser_strlen; READ_OR_BAIL(readUnsignedVarInt, parser_strlen);
         if (!stream.readString(v2.parser, parser_strlen)) return false; /*parser: pstring*/ /*4.3*/
-        std::string &parser = v2.parser; /*4.8*/
-        if (parser == "brigadier:bool") { /*8.0*/
+        std::string &V_parser = v2.parser; /*4.8*/
+        if (V_parser == "brigadier:bool") { /*8.0*/
         }
-        else if (parser == "brigadier:float") { /*8.0*/
+        else if (V_parser == "brigadier:float") { /*8.0*/
              v2.properties_brigadier_float = {}; pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData2::PropertiesBrigadierFloat &v4 = *v2.properties_brigadier_float; /*8.4*/
             uint8_t flags_val;
             READ_OR_BAIL(readUByte, flags_val);
             v4.flags.unused = flags_val >> 0 & 6;
             v4.flags.max_present = flags_val >> 6 & 1;
             v4.flags.min_present = flags_val >> 7 & 1; /*flags: bitfield*/ /*4.3*/
-            pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData2::PropertiesBrigadierFloat::flags_t &flags = v4.flags; /*4.8*/
-            if (flags.min_present == 1) { /*8.2*/
+            pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData2::PropertiesBrigadierFloat::flags_t &V_flags = v4.flags; /*4.8*/
+            if (V_flags.min_present == 1) { /*8.2*/
               READ_OR_BAIL(readFloatBE, v4.min); /*0.5*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               READ_OR_BAIL(readFloatBE, v4.max); /*0.5*/
             }
         }
-        else if (parser == "brigadier:double") { /*8.0*/
+        else if (V_parser == "brigadier:double") { /*8.0*/
              v2.properties_brigadier_double = {}; pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData2::PropertiesBrigadierDouble &v4 = *v2.properties_brigadier_double; /*8.4*/
             uint8_t flags_val;
             READ_OR_BAIL(readUByte, flags_val);
             v4.flags.unused = flags_val >> 0 & 6;
             v4.flags.max_present = flags_val >> 6 & 1;
             v4.flags.min_present = flags_val >> 7 & 1; /*flags: bitfield*/ /*4.3*/
-            pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData2::PropertiesBrigadierDouble::flags_t &flags = v4.flags; /*4.8*/
-            if (flags.min_present == 1) { /*8.2*/
+            pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData2::PropertiesBrigadierDouble::flags_t &V_flags = v4.flags; /*4.8*/
+            if (V_flags.min_present == 1) { /*8.2*/
               READ_OR_BAIL(readDoubleBE, v4.min); /*0.5*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               READ_OR_BAIL(readDoubleBE, v4.max); /*0.5*/
             }
         }
-        else if (parser == "brigadier:integer") { /*8.0*/
+        else if (V_parser == "brigadier:integer") { /*8.0*/
              v2.properties_brigadier_integer = {}; pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData2::PropertiesBrigadierInteger &v4 = *v2.properties_brigadier_integer; /*8.4*/
             uint8_t flags_val;
             READ_OR_BAIL(readUByte, flags_val);
             v4.flags.unused = flags_val >> 0 & 6;
             v4.flags.max_present = flags_val >> 6 & 1;
             v4.flags.min_present = flags_val >> 7 & 1; /*flags: bitfield*/ /*4.3*/
-            pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData2::PropertiesBrigadierInteger::flags_t &flags = v4.flags; /*4.8*/
-            if (flags.min_present == 1) { /*8.2*/
+            pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData2::PropertiesBrigadierInteger::flags_t &V_flags = v4.flags; /*4.8*/
+            if (V_flags.min_present == 1) { /*8.2*/
               READ_OR_BAIL(readIntBE, v4.min); /*0.5*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               READ_OR_BAIL(readIntBE, v4.max); /*0.5*/
             }
         }
-        else if (parser == "brigadier:long") { /*8.0*/
+        else if (V_parser == "brigadier:long") { /*8.0*/
              v2.properties_brigadier_long = {}; pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData2::PropertiesBrigadierLong &v4 = *v2.properties_brigadier_long; /*8.4*/
             uint8_t flags_val;
             READ_OR_BAIL(readUByte, flags_val);
             v4.flags.unused = flags_val >> 0 & 6;
             v4.flags.max_present = flags_val >> 6 & 1;
             v4.flags.min_present = flags_val >> 7 & 1; /*flags: bitfield*/ /*4.3*/
-            pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData2::PropertiesBrigadierLong::flags_t &flags = v4.flags; /*4.8*/
-            if (flags.min_present == 1) { /*8.2*/
+            pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData2::PropertiesBrigadierLong::flags_t &V_flags = v4.flags; /*4.8*/
+            if (V_flags.min_present == 1) { /*8.2*/
               READ_OR_BAIL(readLongBE, v4.min); /*0.5*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               READ_OR_BAIL(readLongBE, v4.max); /*0.5*/
             }
         }
-        else if (parser == "brigadier:string") { /*8.0*/
+        else if (V_parser == "brigadier:string") { /*8.0*/
         }
-        else if (parser == "minecraft:entity") { /*8.0*/
+        else if (V_parser == "minecraft:entity") { /*8.0*/
           uint8_t properties_minecraft_entity_val;
           READ_OR_BAIL(readUByte, properties_minecraft_entity_val);
           v2.properties_minecraft_entity.unused = properties_minecraft_entity_val >> 0 & 6;
           v2.properties_minecraft_entity.onlyAllowPlayers = properties_minecraft_entity_val >> 6 & 1;
           v2.properties_minecraft_entity.onlyAllowEntities = properties_minecraft_entity_val >> 7 & 1; /*properties_minecraft_entity: bitfield*/ /*4.3*/
         }
-        else if (parser == "minecraft:game_profile") { /*8.0*/
+        else if (V_parser == "minecraft:game_profile") { /*8.0*/
         }
-        else if (parser == "minecraft:block_pos") { /*8.0*/
+        else if (V_parser == "minecraft:block_pos") { /*8.0*/
         }
-        else if (parser == "minecraft:column_pos") { /*8.0*/
+        else if (V_parser == "minecraft:column_pos") { /*8.0*/
         }
-        else if (parser == "minecraft:vec3") { /*8.0*/
+        else if (V_parser == "minecraft:vec3") { /*8.0*/
         }
-        else if (parser == "minecraft:vec2") { /*8.0*/
+        else if (V_parser == "minecraft:vec2") { /*8.0*/
         }
-        else if (parser == "minecraft:block_state") { /*8.0*/
+        else if (V_parser == "minecraft:block_state") { /*8.0*/
         }
-        else if (parser == "minecraft:block_predicate") { /*8.0*/
+        else if (V_parser == "minecraft:block_predicate") { /*8.0*/
         }
-        else if (parser == "minecraft:item_stack") { /*8.0*/
+        else if (V_parser == "minecraft:item_stack") { /*8.0*/
         }
-        else if (parser == "minecraft:item_predicate") { /*8.0*/
+        else if (V_parser == "minecraft:item_predicate") { /*8.0*/
         }
-        else if (parser == "minecraft:color") { /*8.0*/
+        else if (V_parser == "minecraft:color") { /*8.0*/
         }
-        else if (parser == "minecraft:component") { /*8.0*/
+        else if (V_parser == "minecraft:component") { /*8.0*/
         }
-        else if (parser == "minecraft:message") { /*8.0*/
+        else if (V_parser == "minecraft:message") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt") { /*8.0*/
+        else if (V_parser == "minecraft:nbt") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt_path") { /*8.0*/
+        else if (V_parser == "minecraft:nbt_path") { /*8.0*/
         }
-        else if (parser == "minecraft:objective") { /*8.0*/
+        else if (V_parser == "minecraft:objective") { /*8.0*/
         }
-        else if (parser == "minecraft:objective_criteria") { /*8.0*/
+        else if (V_parser == "minecraft:objective_criteria") { /*8.0*/
         }
-        else if (parser == "minecraft:operation") { /*8.0*/
+        else if (V_parser == "minecraft:operation") { /*8.0*/
         }
-        else if (parser == "minecraft:particle") { /*8.0*/
+        else if (V_parser == "minecraft:particle") { /*8.0*/
         }
-        else if (parser == "minecraft:angle") { /*8.0*/
+        else if (V_parser == "minecraft:angle") { /*8.0*/
         }
-        else if (parser == "minecraft:rotation") { /*8.0*/
+        else if (V_parser == "minecraft:rotation") { /*8.0*/
         }
-        else if (parser == "minecraft:scoreboard_slot") { /*8.0*/
+        else if (V_parser == "minecraft:scoreboard_slot") { /*8.0*/
         }
-        else if (parser == "minecraft:score_holder") { /*8.0*/
+        else if (V_parser == "minecraft:score_holder") { /*8.0*/
           uint8_t properties_minecraft_score_holder_val;
           READ_OR_BAIL(readUByte, properties_minecraft_score_holder_val);
           v2.properties_minecraft_score_holder.unused = properties_minecraft_score_holder_val >> 0 & 7;
           v2.properties_minecraft_score_holder.allowMultiple = properties_minecraft_score_holder_val >> 7 & 1; /*properties_minecraft_score_holder: bitfield*/ /*4.3*/
         }
-        else if (parser == "minecraft:swizzle") { /*8.0*/
+        else if (V_parser == "minecraft:swizzle") { /*8.0*/
         }
-        else if (parser == "minecraft:team") { /*8.0*/
+        else if (V_parser == "minecraft:team") { /*8.0*/
         }
-        else if (parser == "minecraft:item_slot") { /*8.0*/
+        else if (V_parser == "minecraft:item_slot") { /*8.0*/
         }
-        else if (parser == "minecraft:resource_location") { /*8.0*/
+        else if (V_parser == "minecraft:resource_location") { /*8.0*/
         }
-        else if (parser == "minecraft:mob_effect") { /*8.0*/
+        else if (V_parser == "minecraft:mob_effect") { /*8.0*/
         }
-        else if (parser == "minecraft:function") { /*8.0*/
+        else if (V_parser == "minecraft:function") { /*8.0*/
         }
-        else if (parser == "minecraft:entity_anchor") { /*8.0*/
+        else if (V_parser == "minecraft:entity_anchor") { /*8.0*/
         }
-        else if (parser == "minecraft:range") { /*8.0*/
+        else if (V_parser == "minecraft:range") { /*8.0*/
              v2.properties_minecraft_range = {}; pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData2::PropertiesMinecraftRange &v4 = *v2.properties_minecraft_range; /*8.4*/
             READ_OR_BAIL(readBool, (bool&)v4.allowDecimals); /*0.5*/
         }
-        else if (parser == "minecraft:int_range") { /*8.0*/
+        else if (V_parser == "minecraft:int_range") { /*8.0*/
         }
-        else if (parser == "minecraft:float_range") { /*8.0*/
+        else if (V_parser == "minecraft:float_range") { /*8.0*/
         }
-        else if (parser == "minecraft:item_enchantment") { /*8.0*/
+        else if (V_parser == "minecraft:item_enchantment") { /*8.0*/
         }
-        else if (parser == "minecraft:entity_summon") { /*8.0*/
+        else if (V_parser == "minecraft:entity_summon") { /*8.0*/
         }
-        else if (parser == "minecraft:dimension") { /*8.0*/
+        else if (V_parser == "minecraft:dimension") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt_compound_tag") { /*8.0*/
+        else if (V_parser == "minecraft:nbt_compound_tag") { /*8.0*/
         }
-        else if (parser == "minecraft:time") { /*8.0*/
+        else if (V_parser == "minecraft:time") { /*8.0*/
         }
-        else if (parser == "minecraft:resource_or_tag") { /*8.0*/
+        else if (V_parser == "minecraft:resource_or_tag") { /*8.0*/
              v2.properties_minecraft_resource_or_tag_or_minecraft_resource = {}; pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData2::PropertiesMinecraftResourceOrTagOrMinecraftResource &v4 = *v2.properties_minecraft_resource_or_tag_or_minecraft_resource; /*8.4*/
             int registry_strlen; READ_OR_BAIL(readUnsignedVarInt, registry_strlen);
             if (!stream.readString(v4.registry, registry_strlen)) return false; /*registry: pstring*/ /*4.3*/
         }
-        else if (parser == "minecraft:resource") { /*8.0*/
+        else if (V_parser == "minecraft:resource") { /*8.0*/
              v2.properties_minecraft_resource_or_tag_or_minecraft_resource = {}; pdef::pc1_18_handshaking_toServer::command_node::ExtraNodeData2::PropertiesMinecraftResourceOrTagOrMinecraftResource &v4 = *v2.properties_minecraft_resource_or_tag_or_minecraft_resource; /*8.4*/
             int registry_strlen; READ_OR_BAIL(readUnsignedVarInt, registry_strlen);
             if (!stream.readString(v4.registry, registry_strlen)) return false; /*registry: pstring*/ /*4.3*/
         }
-        else if (parser == "minecraft:uuid") { /*8.0*/
+        else if (V_parser == "minecraft:uuid") { /*8.0*/
         }
-        if (flags.has_custom_suggestions == 1) { /*8.2*/
+        if (V_flags.has_custom_suggestions == 1) { /*8.2*/
           int suggestionType_strlen; READ_OR_BAIL(readUnsignedVarInt, suggestionType_strlen);
           if (!stream.readString(v2.suggestionType, suggestionType_strlen)) return false; /*suggestionType: pstring*/ /*4.3*/
         }
@@ -1231,8 +1231,8 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_handshaking_toServer::tags &obj) {
   }
   bool packet(pdef::Stream &stream, pdef::pc1_18_handshaking_toServer::packet &obj) {
     READ_OR_BAIL(readUnsignedVarInt, (int&)obj.name); /*7.2*/
-    const pdef::pc1_18_handshaking_toServer::packet::Name &name = obj.name; /*0.7*/
-    switch (name) { /*8.0*/
+    const pdef::pc1_18_handshaking_toServer::packet::Name &V_name = obj.name; /*0.7*/
+    switch (V_name) { /*8.0*/
       case pdef::pc1_18_handshaking_toServer::packet::Name::SetProtocol: { /*8.5*/
         obj.params_packet_set_protocol = {}; pdef::pc1_18_handshaking_toServer::decode::packet_set_protocol(stream, *obj.params_packet_set_protocol); /*obj*/ /*4.6*/
         break;

--- a/examples/mcpc-protocol/build/pc1_18_login_toClient.h
+++ b/examples/mcpc-protocol/build/pc1_18_login_toClient.h
@@ -271,10 +271,10 @@ size_t packet_login_plugin_request(pdef::Stream &stream, const pdef::pc1_18_logi
 size_t packet(pdef::Stream &stream, const pdef::pc1_18_login_toClient::packet &obj);
   size_t slot(pdef::Stream &stream, const pdef::pc1_18_login_toClient::slot &obj) {
     size_t len = 0;
-    const bool &present = obj.present; /*0.1*/
-    if (present == false) { /*8.1*/
+    const bool &V_present = obj.present; /*0.1*/
+    if (V_present == false) { /*8.1*/
     }
-    else if (present == true) { /*8.1*/
+    else if (V_present == true) { /*8.1*/
         len += stream.sizeOfVarInt(obj.itemId); /*0.2*/
         len += 1; /*0.2*/
         len += 1; /*0.2*/
@@ -283,23 +283,23 @@ size_t packet(pdef::Stream &stream, const pdef::pc1_18_login_toClient::packet &o
   }
   size_t particle(pdef::Stream &stream, const pdef::pc1_18_login_toClient::particle &obj) {
     size_t len = 0;
-    const int &particleId = obj.particleId; /*0.1*/
-    if (particleId == 2) { /*8.2*/
+    const int &V_particleId = obj.particleId; /*0.1*/
+    if (V_particleId == 2) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_2_or_3_or_24); const pdef::pc1_18_login_toClient::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.6*/
         len += stream.sizeOfVarInt(v2.blockState); /*0.2*/
     }
-    else if (particleId == 3) { /*8.2*/
+    else if (V_particleId == 3) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_2_or_3_or_24); const pdef::pc1_18_login_toClient::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.6*/
         len += stream.sizeOfVarInt(v2.blockState); /*0.2*/
     }
-    else if (particleId == 14) { /*8.2*/
+    else if (V_particleId == 14) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_14); const pdef::pc1_18_login_toClient::particle::Data14 &v2 = *obj.data_14; /*8.6*/
         len += 4; /*0.2*/
         len += 4; /*0.2*/
         len += 4; /*0.2*/
         len += 4; /*0.2*/
     }
-    else if (particleId == 15) { /*8.2*/
+    else if (V_particleId == 15) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_15); const pdef::pc1_18_login_toClient::particle::Data15 &v2 = *obj.data_15; /*8.6*/
         len += 4; /*0.2*/
         len += 4; /*0.2*/
@@ -309,24 +309,24 @@ size_t packet(pdef::Stream &stream, const pdef::pc1_18_login_toClient::packet &o
         len += 4; /*0.2*/
         len += 4; /*0.2*/
     }
-    else if (particleId == 24) { /*8.2*/
+    else if (V_particleId == 24) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_2_or_3_or_24); const pdef::pc1_18_login_toClient::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.6*/
         len += stream.sizeOfVarInt(v2.blockState); /*0.2*/
     }
-    else if (particleId == 35) { /*8.2*/
+    else if (V_particleId == 35) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_35); const pdef::pc1_18_login_toClient::particle::Data35 &v2 = *obj.data_35; /*8.6*/
         len += 1; /*0.2*/
     }
-    else if (particleId == 36) { /*8.2*/
+    else if (V_particleId == 36) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_36); const pdef::pc1_18_login_toClient::particle::Data36 &v2 = *obj.data_36; /*8.6*/
         len += 1; /*origin: bitfield*/ /*4.1*/
         len += stream.sizeOfVarInt(v2.positionType.length());
         len += v2.positionType.length(); /*positionType^: pstring*/ /*4.1*/
-        const std::string &positionType = v2.positionType; /*4.7*/
-        if (positionType == "minecraft:block") { /*8.0*/
+        const std::string &V_positionType = v2.positionType; /*4.7*/
+        if (V_positionType == "minecraft:block") { /*8.0*/
           len += 1; /*destination: bitfield*/ /*4.1*/
         }
-        else if (positionType == "minecraft:entity") { /*8.0*/
+        else if (V_positionType == "minecraft:entity") { /*8.0*/
           len += stream.sizeOfVarInt(v2.destination_varint); /*0.2*/
         }
         len += stream.sizeOfVarInt(v2.ticks); /*0.2*/
@@ -338,7 +338,7 @@ size_t packet(pdef::Stream &stream, const pdef::pc1_18_login_toClient::packet &o
     len += stream.sizeOfVarInt(obj.group.length());
     len += obj.group.length(); /*group: pstring*/ /*4.1*/
     len += stream.sizeOfVarInt(obj.ingredient.size()); /*1.3*/
-    for (const auto &v2 : obj.ingredient) {
+    for (const auto &v2 : obj.ingredient) { /*3.2*/
       len += 1; /*0.2*/
     }
     len += 1; /*0.2*/
@@ -351,7 +351,7 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_login_toClient::tags &obj) 
     len += stream.sizeOfVarInt(obj.tagName.length());
     len += obj.tagName.length(); /*tagName: pstring*/ /*4.1*/
     len += stream.sizeOfVarInt(obj.entries.size()); /*1.3*/
-    for (const auto &v2 : obj.entries) {
+    for (const auto &v2 : obj.entries) { /*3.2*/
       len += stream.sizeOfVarInt(v2); /*0.2*/
     }
   PDEF_SIZE_DBG; return len;
@@ -367,169 +367,169 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_login_toClient::tags &obj) 
   size_t command_node(pdef::Stream &stream, const pdef::pc1_18_login_toClient::command_node &obj) {
     size_t len = 0;
     len += 1; /*flags^: bitfield*/ /*4.1*/
-    const pdef::pc1_18_login_toClient::command_node::flags_t &flags = obj.flags; /*4.7*/
+    const pdef::pc1_18_login_toClient::command_node::flags_t &V_flags = obj.flags; /*4.7*/
     len += stream.sizeOfVarInt(obj.children.size()); /*1.3*/
-    for (const auto &v2 : obj.children) {
+    for (const auto &v2 : obj.children) { /*3.2*/
       len += stream.sizeOfVarInt(v2); /*0.2*/
     }
-    if (flags.has_redirect_node == 1) { /*8.2*/
+    if (V_flags.has_redirect_node == 1) { /*8.2*/
       len += stream.sizeOfVarInt(obj.redirectNode); /*0.2*/
     }
-    if (flags.command_node_type == 0) { /*8.2*/
+    if (V_flags.command_node_type == 0) { /*8.2*/
     }
-    else if (flags.command_node_type == 1) { /*8.2*/
+    else if (V_flags.command_node_type == 1) { /*8.2*/
         EXPECT_OR_BAIL(obj.extraNodeData_1); const pdef::pc1_18_login_toClient::command_node::ExtraNodeData1 &v2 = *obj.extraNodeData_1; /*8.6*/
         len += stream.sizeOfVarInt(v2.name.length());
         len += v2.name.length(); /*name: pstring*/ /*4.1*/
     }
-    else if (flags.command_node_type == 2) { /*8.2*/
+    else if (V_flags.command_node_type == 2) { /*8.2*/
         EXPECT_OR_BAIL(obj.extraNodeData_2); const pdef::pc1_18_login_toClient::command_node::ExtraNodeData2 &v2 = *obj.extraNodeData_2; /*8.6*/
         len += stream.sizeOfVarInt(v2.name.length());
         len += v2.name.length(); /*name: pstring*/ /*4.1*/
         len += stream.sizeOfVarInt(v2.parser.length());
         len += v2.parser.length(); /*parser^: pstring*/ /*4.1*/
-        const std::string &parser = v2.parser; /*4.7*/
-        if (parser == "brigadier:bool") { /*8.0*/
+        const std::string &V_parser = v2.parser; /*4.7*/
+        if (V_parser == "brigadier:bool") { /*8.0*/
         }
-        else if (parser == "brigadier:float") { /*8.0*/
+        else if (V_parser == "brigadier:float") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_brigadier_float); const pdef::pc1_18_login_toClient::command_node::ExtraNodeData2::PropertiesBrigadierFloat &v4 = *v2.properties_brigadier_float; /*8.6*/
             len += 1; /*flags^: bitfield*/ /*4.1*/
-            const pdef::pc1_18_login_toClient::command_node::ExtraNodeData2::PropertiesBrigadierFloat::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_login_toClient::command_node::ExtraNodeData2::PropertiesBrigadierFloat::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               len += 4; /*0.2*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               len += 4; /*0.2*/
             }
         }
-        else if (parser == "brigadier:double") { /*8.0*/
+        else if (V_parser == "brigadier:double") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_brigadier_double); const pdef::pc1_18_login_toClient::command_node::ExtraNodeData2::PropertiesBrigadierDouble &v4 = *v2.properties_brigadier_double; /*8.6*/
             len += 1; /*flags^: bitfield*/ /*4.1*/
-            const pdef::pc1_18_login_toClient::command_node::ExtraNodeData2::PropertiesBrigadierDouble::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_login_toClient::command_node::ExtraNodeData2::PropertiesBrigadierDouble::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               len += 8; /*0.2*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               len += 8; /*0.2*/
             }
         }
-        else if (parser == "brigadier:integer") { /*8.0*/
+        else if (V_parser == "brigadier:integer") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_brigadier_integer); const pdef::pc1_18_login_toClient::command_node::ExtraNodeData2::PropertiesBrigadierInteger &v4 = *v2.properties_brigadier_integer; /*8.6*/
             len += 1; /*flags^: bitfield*/ /*4.1*/
-            const pdef::pc1_18_login_toClient::command_node::ExtraNodeData2::PropertiesBrigadierInteger::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_login_toClient::command_node::ExtraNodeData2::PropertiesBrigadierInteger::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               len += 4; /*0.2*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               len += 4; /*0.2*/
             }
         }
-        else if (parser == "brigadier:long") { /*8.0*/
+        else if (V_parser == "brigadier:long") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_brigadier_long); const pdef::pc1_18_login_toClient::command_node::ExtraNodeData2::PropertiesBrigadierLong &v4 = *v2.properties_brigadier_long; /*8.6*/
             len += 1; /*flags^: bitfield*/ /*4.1*/
-            const pdef::pc1_18_login_toClient::command_node::ExtraNodeData2::PropertiesBrigadierLong::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_login_toClient::command_node::ExtraNodeData2::PropertiesBrigadierLong::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               len += 8; /*0.2*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               len += 8; /*0.2*/
             }
         }
-        else if (parser == "brigadier:string") { /*8.0*/
+        else if (V_parser == "brigadier:string") { /*8.0*/
         }
-        else if (parser == "minecraft:entity") { /*8.0*/
+        else if (V_parser == "minecraft:entity") { /*8.0*/
           len += 1; /*properties: bitfield*/ /*4.1*/
         }
-        else if (parser == "minecraft:game_profile") { /*8.0*/
+        else if (V_parser == "minecraft:game_profile") { /*8.0*/
         }
-        else if (parser == "minecraft:block_pos") { /*8.0*/
+        else if (V_parser == "minecraft:block_pos") { /*8.0*/
         }
-        else if (parser == "minecraft:column_pos") { /*8.0*/
+        else if (V_parser == "minecraft:column_pos") { /*8.0*/
         }
-        else if (parser == "minecraft:vec3") { /*8.0*/
+        else if (V_parser == "minecraft:vec3") { /*8.0*/
         }
-        else if (parser == "minecraft:vec2") { /*8.0*/
+        else if (V_parser == "minecraft:vec2") { /*8.0*/
         }
-        else if (parser == "minecraft:block_state") { /*8.0*/
+        else if (V_parser == "minecraft:block_state") { /*8.0*/
         }
-        else if (parser == "minecraft:block_predicate") { /*8.0*/
+        else if (V_parser == "minecraft:block_predicate") { /*8.0*/
         }
-        else if (parser == "minecraft:item_stack") { /*8.0*/
+        else if (V_parser == "minecraft:item_stack") { /*8.0*/
         }
-        else if (parser == "minecraft:item_predicate") { /*8.0*/
+        else if (V_parser == "minecraft:item_predicate") { /*8.0*/
         }
-        else if (parser == "minecraft:color") { /*8.0*/
+        else if (V_parser == "minecraft:color") { /*8.0*/
         }
-        else if (parser == "minecraft:component") { /*8.0*/
+        else if (V_parser == "minecraft:component") { /*8.0*/
         }
-        else if (parser == "minecraft:message") { /*8.0*/
+        else if (V_parser == "minecraft:message") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt") { /*8.0*/
+        else if (V_parser == "minecraft:nbt") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt_path") { /*8.0*/
+        else if (V_parser == "minecraft:nbt_path") { /*8.0*/
         }
-        else if (parser == "minecraft:objective") { /*8.0*/
+        else if (V_parser == "minecraft:objective") { /*8.0*/
         }
-        else if (parser == "minecraft:objective_criteria") { /*8.0*/
+        else if (V_parser == "minecraft:objective_criteria") { /*8.0*/
         }
-        else if (parser == "minecraft:operation") { /*8.0*/
+        else if (V_parser == "minecraft:operation") { /*8.0*/
         }
-        else if (parser == "minecraft:particle") { /*8.0*/
+        else if (V_parser == "minecraft:particle") { /*8.0*/
         }
-        else if (parser == "minecraft:angle") { /*8.0*/
+        else if (V_parser == "minecraft:angle") { /*8.0*/
         }
-        else if (parser == "minecraft:rotation") { /*8.0*/
+        else if (V_parser == "minecraft:rotation") { /*8.0*/
         }
-        else if (parser == "minecraft:scoreboard_slot") { /*8.0*/
+        else if (V_parser == "minecraft:scoreboard_slot") { /*8.0*/
         }
-        else if (parser == "minecraft:score_holder") { /*8.0*/
+        else if (V_parser == "minecraft:score_holder") { /*8.0*/
           len += 1; /*properties: bitfield*/ /*4.1*/
         }
-        else if (parser == "minecraft:swizzle") { /*8.0*/
+        else if (V_parser == "minecraft:swizzle") { /*8.0*/
         }
-        else if (parser == "minecraft:team") { /*8.0*/
+        else if (V_parser == "minecraft:team") { /*8.0*/
         }
-        else if (parser == "minecraft:item_slot") { /*8.0*/
+        else if (V_parser == "minecraft:item_slot") { /*8.0*/
         }
-        else if (parser == "minecraft:resource_location") { /*8.0*/
+        else if (V_parser == "minecraft:resource_location") { /*8.0*/
         }
-        else if (parser == "minecraft:mob_effect") { /*8.0*/
+        else if (V_parser == "minecraft:mob_effect") { /*8.0*/
         }
-        else if (parser == "minecraft:function") { /*8.0*/
+        else if (V_parser == "minecraft:function") { /*8.0*/
         }
-        else if (parser == "minecraft:entity_anchor") { /*8.0*/
+        else if (V_parser == "minecraft:entity_anchor") { /*8.0*/
         }
-        else if (parser == "minecraft:range") { /*8.0*/
+        else if (V_parser == "minecraft:range") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_minecraft_range); const pdef::pc1_18_login_toClient::command_node::ExtraNodeData2::PropertiesMinecraftRange &v4 = *v2.properties_minecraft_range; /*8.6*/
             len += 1; /*0.2*/
         }
-        else if (parser == "minecraft:int_range") { /*8.0*/
+        else if (V_parser == "minecraft:int_range") { /*8.0*/
         }
-        else if (parser == "minecraft:float_range") { /*8.0*/
+        else if (V_parser == "minecraft:float_range") { /*8.0*/
         }
-        else if (parser == "minecraft:item_enchantment") { /*8.0*/
+        else if (V_parser == "minecraft:item_enchantment") { /*8.0*/
         }
-        else if (parser == "minecraft:entity_summon") { /*8.0*/
+        else if (V_parser == "minecraft:entity_summon") { /*8.0*/
         }
-        else if (parser == "minecraft:dimension") { /*8.0*/
+        else if (V_parser == "minecraft:dimension") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt_compound_tag") { /*8.0*/
+        else if (V_parser == "minecraft:nbt_compound_tag") { /*8.0*/
         }
-        else if (parser == "minecraft:time") { /*8.0*/
+        else if (V_parser == "minecraft:time") { /*8.0*/
         }
-        else if (parser == "minecraft:resource_or_tag") { /*8.0*/
+        else if (V_parser == "minecraft:resource_or_tag") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_minecraft_resource_or_tag_or_minecraft_resource); const pdef::pc1_18_login_toClient::command_node::ExtraNodeData2::PropertiesMinecraftResourceOrTagOrMinecraftResource &v4 = *v2.properties_minecraft_resource_or_tag_or_minecraft_resource; /*8.6*/
             len += stream.sizeOfVarInt(v4.registry.length());
             len += v4.registry.length(); /*registry: pstring*/ /*4.1*/
         }
-        else if (parser == "minecraft:resource") { /*8.0*/
+        else if (V_parser == "minecraft:resource") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_minecraft_resource_or_tag_or_minecraft_resource); const pdef::pc1_18_login_toClient::command_node::ExtraNodeData2::PropertiesMinecraftResourceOrTagOrMinecraftResource &v4 = *v2.properties_minecraft_resource_or_tag_or_minecraft_resource; /*8.6*/
             len += stream.sizeOfVarInt(v4.registry.length());
             len += v4.registry.length(); /*registry: pstring*/ /*4.1*/
         }
-        else if (parser == "minecraft:uuid") { /*8.0*/
+        else if (V_parser == "minecraft:uuid") { /*8.0*/
         }
-        if (flags.has_custom_suggestions == 1) { /*8.2*/
+        if (V_flags.has_custom_suggestions == 1) { /*8.2*/
           len += stream.sizeOfVarInt(v2.suggestionType.length());
           len += v2.suggestionType.length(); /*suggestionType: pstring*/ /*4.1*/
         }
@@ -574,9 +574,9 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_login_toClient::tags &obj) 
   }
   size_t packet(pdef::Stream &stream, const pdef::pc1_18_login_toClient::packet &obj) {
     size_t len = 0;
-    const pdef::pc1_18_login_toClient::packet::Name &name = obj.name; /*0.3*/
+    const pdef::pc1_18_login_toClient::packet::Name &V_name = obj.name; /*0.3*/
     len += stream.sizeOfVarInt((int&)obj.name); /*name^: varint*/ /*7.0*/
-    switch (name) { /*8.0*/
+    switch (V_name) { /*8.0*/
       case pdef::pc1_18_login_toClient::packet::Name::Disconnect: { /*8.5*/
         EXPECT_OR_BAIL(obj.params_packet_disconnect); size_t len_0 = pdef::pc1_18_login_toClient::size::packet_disconnect(stream, *obj.params_packet_disconnect); EXPECT_OR_BAIL(len_0); len += len_0; /*params_packet_disconnect*/ /*4.4*/
         break;
@@ -618,11 +618,11 @@ bool packet_login_plugin_request(pdef::Stream &stream, const pdef::pc1_18_login_
 bool packet(pdef::Stream &stream, const pdef::pc1_18_login_toClient::packet &obj, bool allocate);
   bool slot(pdef::Stream &stream, const pdef::pc1_18_login_toClient::slot &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::pc1_18_login_toClient::size::slot(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const bool &present = obj.present; /*0.1*/
+    const bool &V_present = obj.present; /*0.1*/
     WRITE_OR_BAIL(writeBool, (bool)obj.present); /*0.4*/
-    if (present == false) { /*8.1*/
+    if (V_present == false) { /*8.1*/
     }
-    else if (present == true) { /*8.1*/
+    else if (V_present == true) { /*8.1*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.itemId); /*0.4*/
         WRITE_OR_BAIL(writeByte, (int8_t)obj.itemCount); /*0.4*/
         WRITE_OR_BAIL(writeByte, (int8_t)obj.nbtData); /*0.4*/
@@ -631,24 +631,24 @@ bool packet(pdef::Stream &stream, const pdef::pc1_18_login_toClient::packet &obj
   }
   bool particle(pdef::Stream &stream, const pdef::pc1_18_login_toClient::particle &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::pc1_18_login_toClient::size::particle(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const int &particleId = obj.particleId; /*0.1*/
+    const int &V_particleId = obj.particleId; /*0.1*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.particleId); /*0.4*/
-    if (particleId == 2) { /*8.2*/
+    if (V_particleId == 2) { /*8.2*/
         const pdef::pc1_18_login_toClient::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.5*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.blockState); /*0.4*/
     }
-    else if (particleId == 3) { /*8.2*/
+    else if (V_particleId == 3) { /*8.2*/
         const pdef::pc1_18_login_toClient::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.5*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.blockState); /*0.4*/
     }
-    else if (particleId == 14) { /*8.2*/
+    else if (V_particleId == 14) { /*8.2*/
         const pdef::pc1_18_login_toClient::particle::Data14 &v2 = *obj.data_14; /*8.5*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.red); /*0.4*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.green); /*0.4*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.blue); /*0.4*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.scale); /*0.4*/
     }
-    else if (particleId == 15) { /*8.2*/
+    else if (V_particleId == 15) { /*8.2*/
         const pdef::pc1_18_login_toClient::particle::Data15 &v2 = *obj.data_15; /*8.5*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.fromRed); /*0.4*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.fromGreen); /*0.4*/
@@ -658,15 +658,15 @@ bool packet(pdef::Stream &stream, const pdef::pc1_18_login_toClient::packet &obj
         WRITE_OR_BAIL(writeFloatBE, (float)v2.toGreen); /*0.4*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.toBlue); /*0.4*/
     }
-    else if (particleId == 24) { /*8.2*/
+    else if (V_particleId == 24) { /*8.2*/
         const pdef::pc1_18_login_toClient::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.5*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.blockState); /*0.4*/
     }
-    else if (particleId == 35) { /*8.2*/
+    else if (V_particleId == 35) { /*8.2*/
         const pdef::pc1_18_login_toClient::particle::Data35 &v2 = *obj.data_35; /*8.5*/
         WRITE_OR_BAIL(writeByte, (int8_t)v2.item); /*0.4*/
     }
-    else if (particleId == 36) { /*8.2*/
+    else if (V_particleId == 36) { /*8.2*/
         const pdef::pc1_18_login_toClient::particle::Data36 &v2 = *obj.data_36; /*8.5*/
         uint64_t origin_val = 0;
         origin_val |= (uint64_t)v2.origin.x << 0;
@@ -675,15 +675,15 @@ bool packet(pdef::Stream &stream, const pdef::pc1_18_login_toClient::packet &obj
         WRITE_OR_BAIL(writeULongBE, origin_val); /*origin: bitfield*/ /*4.2*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.positionType.length());
         WRITE_OR_BAIL(writeString, v2.positionType); /*positionType: pstring*/ /*4.2*/
-        const std::string &positionType = v2.positionType; /*4.7*/
-        if (positionType == "minecraft:block") { /*8.0*/
+        const std::string &V_positionType = v2.positionType; /*4.7*/
+        if (V_positionType == "minecraft:block") { /*8.0*/
           uint64_t destination_position_val = 0;
           destination_position_val |= (uint64_t)v2.destination_position.x << 0;
           destination_position_val |= (uint64_t)v2.destination_position.z << 26;
           destination_position_val |= (uint64_t)v2.destination_position.y << 52;
           WRITE_OR_BAIL(writeULongBE, destination_position_val); /*destination_position: bitfield*/ /*4.2*/
         }
-        else if (positionType == "minecraft:entity") { /*8.0*/
+        else if (V_positionType == "minecraft:entity") { /*8.0*/
           WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.destination_varint); /*0.4*/
         }
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.ticks); /*0.4*/
@@ -733,192 +733,192 @@ bool tags(pdef::Stream &stream, const pdef::pc1_18_login_toClient::tags &obj, bo
     flags_val |= (uint8_t)obj.flags.has_command << 5;
     flags_val |= (uint8_t)obj.flags.command_node_type << 6;
     WRITE_OR_BAIL(writeUByte, flags_val); /*flags: bitfield*/ /*4.2*/
-    const pdef::pc1_18_login_toClient::command_node::flags_t &flags = obj.flags; /*4.7*/
+    const pdef::pc1_18_login_toClient::command_node::flags_t &V_flags = obj.flags; /*4.7*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.children.size()); /*1.4*/
     for (const auto &v2 : obj.children) { /*3.1*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2); /*0.4*/
     }
-    if (flags.has_redirect_node == 1) { /*8.2*/
+    if (V_flags.has_redirect_node == 1) { /*8.2*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.redirectNode); /*0.4*/
     }
-    if (flags.command_node_type == 0) { /*8.2*/
+    if (V_flags.command_node_type == 0) { /*8.2*/
     }
-    else if (flags.command_node_type == 1) { /*8.2*/
+    else if (V_flags.command_node_type == 1) { /*8.2*/
         const pdef::pc1_18_login_toClient::command_node::ExtraNodeData1 &v2 = *obj.extraNodeData_1; /*8.5*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.name.length());
         WRITE_OR_BAIL(writeString, v2.name); /*name: pstring*/ /*4.2*/
     }
-    else if (flags.command_node_type == 2) { /*8.2*/
+    else if (V_flags.command_node_type == 2) { /*8.2*/
         const pdef::pc1_18_login_toClient::command_node::ExtraNodeData2 &v2 = *obj.extraNodeData_2; /*8.5*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.name.length());
         WRITE_OR_BAIL(writeString, v2.name); /*name: pstring*/ /*4.2*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.parser.length());
         WRITE_OR_BAIL(writeString, v2.parser); /*parser: pstring*/ /*4.2*/
-        const std::string &parser = v2.parser; /*4.7*/
-        if (parser == "brigadier:bool") { /*8.0*/
+        const std::string &V_parser = v2.parser; /*4.7*/
+        if (V_parser == "brigadier:bool") { /*8.0*/
         }
-        else if (parser == "brigadier:float") { /*8.0*/
+        else if (V_parser == "brigadier:float") { /*8.0*/
             const pdef::pc1_18_login_toClient::command_node::ExtraNodeData2::PropertiesBrigadierFloat &v4 = *v2.properties_brigadier_float; /*8.5*/
             uint8_t flags_val = 0;
             flags_val |= (uint8_t)v4.flags.unused << 0;
             flags_val |= (uint8_t)v4.flags.max_present << 6;
             flags_val |= (uint8_t)v4.flags.min_present << 7;
             WRITE_OR_BAIL(writeUByte, flags_val); /*flags: bitfield*/ /*4.2*/
-            const pdef::pc1_18_login_toClient::command_node::ExtraNodeData2::PropertiesBrigadierFloat::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_login_toClient::command_node::ExtraNodeData2::PropertiesBrigadierFloat::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeFloatBE, (float)v4.min); /*0.4*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeFloatBE, (float)v4.max); /*0.4*/
             }
         }
-        else if (parser == "brigadier:double") { /*8.0*/
+        else if (V_parser == "brigadier:double") { /*8.0*/
             const pdef::pc1_18_login_toClient::command_node::ExtraNodeData2::PropertiesBrigadierDouble &v4 = *v2.properties_brigadier_double; /*8.5*/
             uint8_t flags_val = 0;
             flags_val |= (uint8_t)v4.flags.unused << 0;
             flags_val |= (uint8_t)v4.flags.max_present << 6;
             flags_val |= (uint8_t)v4.flags.min_present << 7;
             WRITE_OR_BAIL(writeUByte, flags_val); /*flags: bitfield*/ /*4.2*/
-            const pdef::pc1_18_login_toClient::command_node::ExtraNodeData2::PropertiesBrigadierDouble::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_login_toClient::command_node::ExtraNodeData2::PropertiesBrigadierDouble::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeDoubleBE, (double)v4.min); /*0.4*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeDoubleBE, (double)v4.max); /*0.4*/
             }
         }
-        else if (parser == "brigadier:integer") { /*8.0*/
+        else if (V_parser == "brigadier:integer") { /*8.0*/
             const pdef::pc1_18_login_toClient::command_node::ExtraNodeData2::PropertiesBrigadierInteger &v4 = *v2.properties_brigadier_integer; /*8.5*/
             uint8_t flags_val = 0;
             flags_val |= (uint8_t)v4.flags.unused << 0;
             flags_val |= (uint8_t)v4.flags.max_present << 6;
             flags_val |= (uint8_t)v4.flags.min_present << 7;
             WRITE_OR_BAIL(writeUByte, flags_val); /*flags: bitfield*/ /*4.2*/
-            const pdef::pc1_18_login_toClient::command_node::ExtraNodeData2::PropertiesBrigadierInteger::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_login_toClient::command_node::ExtraNodeData2::PropertiesBrigadierInteger::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeIntBE, (int32_t)v4.min); /*0.4*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeIntBE, (int32_t)v4.max); /*0.4*/
             }
         }
-        else if (parser == "brigadier:long") { /*8.0*/
+        else if (V_parser == "brigadier:long") { /*8.0*/
             const pdef::pc1_18_login_toClient::command_node::ExtraNodeData2::PropertiesBrigadierLong &v4 = *v2.properties_brigadier_long; /*8.5*/
             uint8_t flags_val = 0;
             flags_val |= (uint8_t)v4.flags.unused << 0;
             flags_val |= (uint8_t)v4.flags.max_present << 6;
             flags_val |= (uint8_t)v4.flags.min_present << 7;
             WRITE_OR_BAIL(writeUByte, flags_val); /*flags: bitfield*/ /*4.2*/
-            const pdef::pc1_18_login_toClient::command_node::ExtraNodeData2::PropertiesBrigadierLong::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_login_toClient::command_node::ExtraNodeData2::PropertiesBrigadierLong::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeLongBE, (int64_t)v4.min); /*0.4*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeLongBE, (int64_t)v4.max); /*0.4*/
             }
         }
-        else if (parser == "brigadier:string") { /*8.0*/
+        else if (V_parser == "brigadier:string") { /*8.0*/
         }
-        else if (parser == "minecraft:entity") { /*8.0*/
+        else if (V_parser == "minecraft:entity") { /*8.0*/
           uint8_t properties_minecraft_entity_val = 0;
           properties_minecraft_entity_val |= (uint8_t)v2.properties_minecraft_entity.unused << 0;
           properties_minecraft_entity_val |= (uint8_t)v2.properties_minecraft_entity.onlyAllowPlayers << 6;
           properties_minecraft_entity_val |= (uint8_t)v2.properties_minecraft_entity.onlyAllowEntities << 7;
           WRITE_OR_BAIL(writeUByte, properties_minecraft_entity_val); /*properties_minecraft_entity: bitfield*/ /*4.2*/
         }
-        else if (parser == "minecraft:game_profile") { /*8.0*/
+        else if (V_parser == "minecraft:game_profile") { /*8.0*/
         }
-        else if (parser == "minecraft:block_pos") { /*8.0*/
+        else if (V_parser == "minecraft:block_pos") { /*8.0*/
         }
-        else if (parser == "minecraft:column_pos") { /*8.0*/
+        else if (V_parser == "minecraft:column_pos") { /*8.0*/
         }
-        else if (parser == "minecraft:vec3") { /*8.0*/
+        else if (V_parser == "minecraft:vec3") { /*8.0*/
         }
-        else if (parser == "minecraft:vec2") { /*8.0*/
+        else if (V_parser == "minecraft:vec2") { /*8.0*/
         }
-        else if (parser == "minecraft:block_state") { /*8.0*/
+        else if (V_parser == "minecraft:block_state") { /*8.0*/
         }
-        else if (parser == "minecraft:block_predicate") { /*8.0*/
+        else if (V_parser == "minecraft:block_predicate") { /*8.0*/
         }
-        else if (parser == "minecraft:item_stack") { /*8.0*/
+        else if (V_parser == "minecraft:item_stack") { /*8.0*/
         }
-        else if (parser == "minecraft:item_predicate") { /*8.0*/
+        else if (V_parser == "minecraft:item_predicate") { /*8.0*/
         }
-        else if (parser == "minecraft:color") { /*8.0*/
+        else if (V_parser == "minecraft:color") { /*8.0*/
         }
-        else if (parser == "minecraft:component") { /*8.0*/
+        else if (V_parser == "minecraft:component") { /*8.0*/
         }
-        else if (parser == "minecraft:message") { /*8.0*/
+        else if (V_parser == "minecraft:message") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt") { /*8.0*/
+        else if (V_parser == "minecraft:nbt") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt_path") { /*8.0*/
+        else if (V_parser == "minecraft:nbt_path") { /*8.0*/
         }
-        else if (parser == "minecraft:objective") { /*8.0*/
+        else if (V_parser == "minecraft:objective") { /*8.0*/
         }
-        else if (parser == "minecraft:objective_criteria") { /*8.0*/
+        else if (V_parser == "minecraft:objective_criteria") { /*8.0*/
         }
-        else if (parser == "minecraft:operation") { /*8.0*/
+        else if (V_parser == "minecraft:operation") { /*8.0*/
         }
-        else if (parser == "minecraft:particle") { /*8.0*/
+        else if (V_parser == "minecraft:particle") { /*8.0*/
         }
-        else if (parser == "minecraft:angle") { /*8.0*/
+        else if (V_parser == "minecraft:angle") { /*8.0*/
         }
-        else if (parser == "minecraft:rotation") { /*8.0*/
+        else if (V_parser == "minecraft:rotation") { /*8.0*/
         }
-        else if (parser == "minecraft:scoreboard_slot") { /*8.0*/
+        else if (V_parser == "minecraft:scoreboard_slot") { /*8.0*/
         }
-        else if (parser == "minecraft:score_holder") { /*8.0*/
+        else if (V_parser == "minecraft:score_holder") { /*8.0*/
           uint8_t properties_minecraft_score_holder_val = 0;
           properties_minecraft_score_holder_val |= (uint8_t)v2.properties_minecraft_score_holder.unused << 0;
           properties_minecraft_score_holder_val |= (uint8_t)v2.properties_minecraft_score_holder.allowMultiple << 7;
           WRITE_OR_BAIL(writeUByte, properties_minecraft_score_holder_val); /*properties_minecraft_score_holder: bitfield*/ /*4.2*/
         }
-        else if (parser == "minecraft:swizzle") { /*8.0*/
+        else if (V_parser == "minecraft:swizzle") { /*8.0*/
         }
-        else if (parser == "minecraft:team") { /*8.0*/
+        else if (V_parser == "minecraft:team") { /*8.0*/
         }
-        else if (parser == "minecraft:item_slot") { /*8.0*/
+        else if (V_parser == "minecraft:item_slot") { /*8.0*/
         }
-        else if (parser == "minecraft:resource_location") { /*8.0*/
+        else if (V_parser == "minecraft:resource_location") { /*8.0*/
         }
-        else if (parser == "minecraft:mob_effect") { /*8.0*/
+        else if (V_parser == "minecraft:mob_effect") { /*8.0*/
         }
-        else if (parser == "minecraft:function") { /*8.0*/
+        else if (V_parser == "minecraft:function") { /*8.0*/
         }
-        else if (parser == "minecraft:entity_anchor") { /*8.0*/
+        else if (V_parser == "minecraft:entity_anchor") { /*8.0*/
         }
-        else if (parser == "minecraft:range") { /*8.0*/
+        else if (V_parser == "minecraft:range") { /*8.0*/
             const pdef::pc1_18_login_toClient::command_node::ExtraNodeData2::PropertiesMinecraftRange &v4 = *v2.properties_minecraft_range; /*8.5*/
             WRITE_OR_BAIL(writeBool, (bool)v4.allowDecimals); /*0.4*/
         }
-        else if (parser == "minecraft:int_range") { /*8.0*/
+        else if (V_parser == "minecraft:int_range") { /*8.0*/
         }
-        else if (parser == "minecraft:float_range") { /*8.0*/
+        else if (V_parser == "minecraft:float_range") { /*8.0*/
         }
-        else if (parser == "minecraft:item_enchantment") { /*8.0*/
+        else if (V_parser == "minecraft:item_enchantment") { /*8.0*/
         }
-        else if (parser == "minecraft:entity_summon") { /*8.0*/
+        else if (V_parser == "minecraft:entity_summon") { /*8.0*/
         }
-        else if (parser == "minecraft:dimension") { /*8.0*/
+        else if (V_parser == "minecraft:dimension") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt_compound_tag") { /*8.0*/
+        else if (V_parser == "minecraft:nbt_compound_tag") { /*8.0*/
         }
-        else if (parser == "minecraft:time") { /*8.0*/
+        else if (V_parser == "minecraft:time") { /*8.0*/
         }
-        else if (parser == "minecraft:resource_or_tag") { /*8.0*/
+        else if (V_parser == "minecraft:resource_or_tag") { /*8.0*/
             const pdef::pc1_18_login_toClient::command_node::ExtraNodeData2::PropertiesMinecraftResourceOrTagOrMinecraftResource &v4 = *v2.properties_minecraft_resource_or_tag_or_minecraft_resource; /*8.5*/
             WRITE_OR_BAIL(writeUnsignedVarInt, (int)v4.registry.length());
             WRITE_OR_BAIL(writeString, v4.registry); /*registry: pstring*/ /*4.2*/
         }
-        else if (parser == "minecraft:resource") { /*8.0*/
+        else if (V_parser == "minecraft:resource") { /*8.0*/
             const pdef::pc1_18_login_toClient::command_node::ExtraNodeData2::PropertiesMinecraftResourceOrTagOrMinecraftResource &v4 = *v2.properties_minecraft_resource_or_tag_or_minecraft_resource; /*8.5*/
             WRITE_OR_BAIL(writeUnsignedVarInt, (int)v4.registry.length());
             WRITE_OR_BAIL(writeString, v4.registry); /*registry: pstring*/ /*4.2*/
         }
-        else if (parser == "minecraft:uuid") { /*8.0*/
+        else if (V_parser == "minecraft:uuid") { /*8.0*/
         }
-        if (flags.has_custom_suggestions == 1) { /*8.2*/
+        if (V_flags.has_custom_suggestions == 1) { /*8.2*/
           WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.suggestionType.length());
           WRITE_OR_BAIL(writeString, v2.suggestionType); /*suggestionType: pstring*/ /*4.2*/
         }
@@ -963,9 +963,9 @@ bool tags(pdef::Stream &stream, const pdef::pc1_18_login_toClient::tags &obj, bo
   }
   bool packet(pdef::Stream &stream, const pdef::pc1_18_login_toClient::packet &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::pc1_18_login_toClient::size::packet(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const pdef::pc1_18_login_toClient::packet::Name &name = obj.name; /*0.3*/
+    const pdef::pc1_18_login_toClient::packet::Name &V_name = obj.name; /*0.3*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)(int&)obj.name); /*7.1*/
-    switch (name) { /*8.0*/
+    switch (V_name) { /*8.0*/
       case pdef::pc1_18_login_toClient::packet::Name::Disconnect: { /*8.5*/
         pdef::pc1_18_login_toClient::encode::packet_disconnect(stream, *obj.params_packet_disconnect); /*packet_disconnect*/ /*4.5*/
         break;
@@ -1007,10 +1007,10 @@ bool packet_login_plugin_request(pdef::Stream &stream, pdef::pc1_18_login_toClie
 bool packet(pdef::Stream &stream, pdef::pc1_18_login_toClient::packet &obj);
   bool slot(pdef::Stream &stream, pdef::pc1_18_login_toClient::slot &obj) {
     READ_OR_BAIL(readBool, (bool&)obj.present); /*0.5*/
-    bool &present = obj.present; /*0.6*/
-    if (present == false) { /*8.1*/
+    bool &V_present = obj.present; /*0.6*/
+    if (V_present == false) { /*8.1*/
     }
-    else if (present == true) { /*8.1*/
+    else if (V_present == true) { /*8.1*/
         READ_OR_BAIL(readUnsignedVarInt, obj.itemId); /*0.5*/
         READ_OR_BAIL(readByte, obj.itemCount); /*0.5*/
         READ_OR_BAIL(readByte, obj.nbtData); /*0.5*/
@@ -1019,23 +1019,23 @@ bool packet(pdef::Stream &stream, pdef::pc1_18_login_toClient::packet &obj);
   }
   bool particle(pdef::Stream &stream, pdef::pc1_18_login_toClient::particle &obj) {
     READ_OR_BAIL(readUnsignedVarInt, obj.particleId); /*0.5*/
-    int &particleId = obj.particleId; /*0.6*/
-    if (particleId == 2) { /*8.2*/
+    int &V_particleId = obj.particleId; /*0.6*/
+    if (V_particleId == 2) { /*8.2*/
          obj.data_2_or_3_or_24 = {}; pdef::pc1_18_login_toClient::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.4*/
         READ_OR_BAIL(readUnsignedVarInt, v2.blockState); /*0.5*/
     }
-    else if (particleId == 3) { /*8.2*/
+    else if (V_particleId == 3) { /*8.2*/
          obj.data_2_or_3_or_24 = {}; pdef::pc1_18_login_toClient::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.4*/
         READ_OR_BAIL(readUnsignedVarInt, v2.blockState); /*0.5*/
     }
-    else if (particleId == 14) { /*8.2*/
+    else if (V_particleId == 14) { /*8.2*/
          obj.data_14 = {}; pdef::pc1_18_login_toClient::particle::Data14 &v2 = *obj.data_14; /*8.4*/
         READ_OR_BAIL(readFloatBE, v2.red); /*0.5*/
         READ_OR_BAIL(readFloatBE, v2.green); /*0.5*/
         READ_OR_BAIL(readFloatBE, v2.blue); /*0.5*/
         READ_OR_BAIL(readFloatBE, v2.scale); /*0.5*/
     }
-    else if (particleId == 15) { /*8.2*/
+    else if (V_particleId == 15) { /*8.2*/
          obj.data_15 = {}; pdef::pc1_18_login_toClient::particle::Data15 &v2 = *obj.data_15; /*8.4*/
         READ_OR_BAIL(readFloatBE, v2.fromRed); /*0.5*/
         READ_OR_BAIL(readFloatBE, v2.fromGreen); /*0.5*/
@@ -1045,15 +1045,15 @@ bool packet(pdef::Stream &stream, pdef::pc1_18_login_toClient::packet &obj);
         READ_OR_BAIL(readFloatBE, v2.toGreen); /*0.5*/
         READ_OR_BAIL(readFloatBE, v2.toBlue); /*0.5*/
     }
-    else if (particleId == 24) { /*8.2*/
+    else if (V_particleId == 24) { /*8.2*/
          obj.data_2_or_3_or_24 = {}; pdef::pc1_18_login_toClient::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.4*/
         READ_OR_BAIL(readUnsignedVarInt, v2.blockState); /*0.5*/
     }
-    else if (particleId == 35) { /*8.2*/
+    else if (V_particleId == 35) { /*8.2*/
          obj.data_35 = {}; pdef::pc1_18_login_toClient::particle::Data35 &v2 = *obj.data_35; /*8.4*/
         READ_OR_BAIL(readByte, v2.item); /*0.5*/
     }
-    else if (particleId == 36) { /*8.2*/
+    else if (V_particleId == 36) { /*8.2*/
          obj.data_36 = {}; pdef::pc1_18_login_toClient::particle::Data36 &v2 = *obj.data_36; /*8.4*/
         uint64_t origin_val;
         READ_OR_BAIL(readULongBE, origin_val);
@@ -1062,15 +1062,15 @@ bool packet(pdef::Stream &stream, pdef::pc1_18_login_toClient::packet &obj);
         v2.origin.y = origin_val >> 52 & 12; /*origin: bitfield*/ /*4.3*/
         int positionType_strlen; READ_OR_BAIL(readUnsignedVarInt, positionType_strlen);
         if (!stream.readString(v2.positionType, positionType_strlen)) return false; /*positionType: pstring*/ /*4.3*/
-        std::string &positionType = v2.positionType; /*4.8*/
-        if (positionType == "minecraft:block") { /*8.0*/
+        std::string &V_positionType = v2.positionType; /*4.8*/
+        if (V_positionType == "minecraft:block") { /*8.0*/
           uint64_t destination_position_val;
           READ_OR_BAIL(readULongBE, destination_position_val);
           v2.destination_position.x = destination_position_val >> 0 & 26;
           v2.destination_position.z = destination_position_val >> 26 & 26;
           v2.destination_position.y = destination_position_val >> 52 & 12; /*destination_position: bitfield*/ /*4.3*/
         }
-        else if (positionType == "minecraft:entity") { /*8.0*/
+        else if (V_positionType == "minecraft:entity") { /*8.0*/
           READ_OR_BAIL(readUnsignedVarInt, v2.destination_varint); /*0.5*/
         }
         READ_OR_BAIL(readUnsignedVarInt, v2.ticks); /*0.5*/
@@ -1082,7 +1082,7 @@ bool packet(pdef::Stream &stream, pdef::pc1_18_login_toClient::packet &obj);
     if (!stream.readString(obj.group, group_strlen)) return false; /*group: pstring*/ /*4.3*/
     int ingredient_len; READ_OR_BAIL(readUnsignedVarInt, ingredient_len); /*1.5*/
     obj.ingredient.resize(ingredient_len); /*1.6*/
-    for (int i = 0; i < ingredient_len; i++) {
+    for (int i = 0; i < ingredient_len; i++) { /*3.3*/
       auto &v2 = obj.ingredient[i]; /*3.4*/
       READ_OR_BAIL(readByte, v2); /*0.5*/
     }
@@ -1096,7 +1096,7 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_login_toClient::tags &obj) {
     if (!stream.readString(obj.tagName, tagName_strlen)) return false; /*tagName: pstring*/ /*4.3*/
     int entries_len; READ_OR_BAIL(readUnsignedVarInt, entries_len); /*1.5*/
     obj.entries.resize(entries_len); /*1.6*/
-    for (int i = 0; i < entries_len; i++) {
+    for (int i = 0; i < entries_len; i++) { /*3.3*/
       auto &v2 = obj.entries[i]; /*3.4*/
       READ_OR_BAIL(readUnsignedVarInt, v2); /*0.5*/
     }
@@ -1120,194 +1120,194 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_login_toClient::tags &obj) {
     obj.flags.has_redirect_node = flags_val >> 4 & 1;
     obj.flags.has_command = flags_val >> 5 & 1;
     obj.flags.command_node_type = flags_val >> 6 & 2; /*flags: bitfield*/ /*4.3*/
-    pdef::pc1_18_login_toClient::command_node::flags_t &flags = obj.flags; /*4.8*/
+    pdef::pc1_18_login_toClient::command_node::flags_t &V_flags = obj.flags; /*4.8*/
     int children_len; READ_OR_BAIL(readUnsignedVarInt, children_len); /*1.5*/
     obj.children.resize(children_len); /*1.6*/
-    for (int i = 0; i < children_len; i++) {
+    for (int i = 0; i < children_len; i++) { /*3.3*/
       auto &v2 = obj.children[i]; /*3.4*/
       READ_OR_BAIL(readUnsignedVarInt, v2); /*0.5*/
     }
-    if (flags.has_redirect_node == 1) { /*8.2*/
+    if (V_flags.has_redirect_node == 1) { /*8.2*/
       READ_OR_BAIL(readUnsignedVarInt, obj.redirectNode); /*0.5*/
     }
-    if (flags.command_node_type == 0) { /*8.2*/
+    if (V_flags.command_node_type == 0) { /*8.2*/
     }
-    else if (flags.command_node_type == 1) { /*8.2*/
+    else if (V_flags.command_node_type == 1) { /*8.2*/
          obj.extraNodeData_1 = {}; pdef::pc1_18_login_toClient::command_node::ExtraNodeData1 &v2 = *obj.extraNodeData_1; /*8.4*/
         int name_strlen; READ_OR_BAIL(readUnsignedVarInt, name_strlen);
         if (!stream.readString(v2.name, name_strlen)) return false; /*name: pstring*/ /*4.3*/
     }
-    else if (flags.command_node_type == 2) { /*8.2*/
+    else if (V_flags.command_node_type == 2) { /*8.2*/
          obj.extraNodeData_2 = {}; pdef::pc1_18_login_toClient::command_node::ExtraNodeData2 &v2 = *obj.extraNodeData_2; /*8.4*/
         int name_strlen; READ_OR_BAIL(readUnsignedVarInt, name_strlen);
         if (!stream.readString(v2.name, name_strlen)) return false; /*name: pstring*/ /*4.3*/
         int parser_strlen; READ_OR_BAIL(readUnsignedVarInt, parser_strlen);
         if (!stream.readString(v2.parser, parser_strlen)) return false; /*parser: pstring*/ /*4.3*/
-        std::string &parser = v2.parser; /*4.8*/
-        if (parser == "brigadier:bool") { /*8.0*/
+        std::string &V_parser = v2.parser; /*4.8*/
+        if (V_parser == "brigadier:bool") { /*8.0*/
         }
-        else if (parser == "brigadier:float") { /*8.0*/
+        else if (V_parser == "brigadier:float") { /*8.0*/
              v2.properties_brigadier_float = {}; pdef::pc1_18_login_toClient::command_node::ExtraNodeData2::PropertiesBrigadierFloat &v4 = *v2.properties_brigadier_float; /*8.4*/
             uint8_t flags_val;
             READ_OR_BAIL(readUByte, flags_val);
             v4.flags.unused = flags_val >> 0 & 6;
             v4.flags.max_present = flags_val >> 6 & 1;
             v4.flags.min_present = flags_val >> 7 & 1; /*flags: bitfield*/ /*4.3*/
-            pdef::pc1_18_login_toClient::command_node::ExtraNodeData2::PropertiesBrigadierFloat::flags_t &flags = v4.flags; /*4.8*/
-            if (flags.min_present == 1) { /*8.2*/
+            pdef::pc1_18_login_toClient::command_node::ExtraNodeData2::PropertiesBrigadierFloat::flags_t &V_flags = v4.flags; /*4.8*/
+            if (V_flags.min_present == 1) { /*8.2*/
               READ_OR_BAIL(readFloatBE, v4.min); /*0.5*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               READ_OR_BAIL(readFloatBE, v4.max); /*0.5*/
             }
         }
-        else if (parser == "brigadier:double") { /*8.0*/
+        else if (V_parser == "brigadier:double") { /*8.0*/
              v2.properties_brigadier_double = {}; pdef::pc1_18_login_toClient::command_node::ExtraNodeData2::PropertiesBrigadierDouble &v4 = *v2.properties_brigadier_double; /*8.4*/
             uint8_t flags_val;
             READ_OR_BAIL(readUByte, flags_val);
             v4.flags.unused = flags_val >> 0 & 6;
             v4.flags.max_present = flags_val >> 6 & 1;
             v4.flags.min_present = flags_val >> 7 & 1; /*flags: bitfield*/ /*4.3*/
-            pdef::pc1_18_login_toClient::command_node::ExtraNodeData2::PropertiesBrigadierDouble::flags_t &flags = v4.flags; /*4.8*/
-            if (flags.min_present == 1) { /*8.2*/
+            pdef::pc1_18_login_toClient::command_node::ExtraNodeData2::PropertiesBrigadierDouble::flags_t &V_flags = v4.flags; /*4.8*/
+            if (V_flags.min_present == 1) { /*8.2*/
               READ_OR_BAIL(readDoubleBE, v4.min); /*0.5*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               READ_OR_BAIL(readDoubleBE, v4.max); /*0.5*/
             }
         }
-        else if (parser == "brigadier:integer") { /*8.0*/
+        else if (V_parser == "brigadier:integer") { /*8.0*/
              v2.properties_brigadier_integer = {}; pdef::pc1_18_login_toClient::command_node::ExtraNodeData2::PropertiesBrigadierInteger &v4 = *v2.properties_brigadier_integer; /*8.4*/
             uint8_t flags_val;
             READ_OR_BAIL(readUByte, flags_val);
             v4.flags.unused = flags_val >> 0 & 6;
             v4.flags.max_present = flags_val >> 6 & 1;
             v4.flags.min_present = flags_val >> 7 & 1; /*flags: bitfield*/ /*4.3*/
-            pdef::pc1_18_login_toClient::command_node::ExtraNodeData2::PropertiesBrigadierInteger::flags_t &flags = v4.flags; /*4.8*/
-            if (flags.min_present == 1) { /*8.2*/
+            pdef::pc1_18_login_toClient::command_node::ExtraNodeData2::PropertiesBrigadierInteger::flags_t &V_flags = v4.flags; /*4.8*/
+            if (V_flags.min_present == 1) { /*8.2*/
               READ_OR_BAIL(readIntBE, v4.min); /*0.5*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               READ_OR_BAIL(readIntBE, v4.max); /*0.5*/
             }
         }
-        else if (parser == "brigadier:long") { /*8.0*/
+        else if (V_parser == "brigadier:long") { /*8.0*/
              v2.properties_brigadier_long = {}; pdef::pc1_18_login_toClient::command_node::ExtraNodeData2::PropertiesBrigadierLong &v4 = *v2.properties_brigadier_long; /*8.4*/
             uint8_t flags_val;
             READ_OR_BAIL(readUByte, flags_val);
             v4.flags.unused = flags_val >> 0 & 6;
             v4.flags.max_present = flags_val >> 6 & 1;
             v4.flags.min_present = flags_val >> 7 & 1; /*flags: bitfield*/ /*4.3*/
-            pdef::pc1_18_login_toClient::command_node::ExtraNodeData2::PropertiesBrigadierLong::flags_t &flags = v4.flags; /*4.8*/
-            if (flags.min_present == 1) { /*8.2*/
+            pdef::pc1_18_login_toClient::command_node::ExtraNodeData2::PropertiesBrigadierLong::flags_t &V_flags = v4.flags; /*4.8*/
+            if (V_flags.min_present == 1) { /*8.2*/
               READ_OR_BAIL(readLongBE, v4.min); /*0.5*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               READ_OR_BAIL(readLongBE, v4.max); /*0.5*/
             }
         }
-        else if (parser == "brigadier:string") { /*8.0*/
+        else if (V_parser == "brigadier:string") { /*8.0*/
         }
-        else if (parser == "minecraft:entity") { /*8.0*/
+        else if (V_parser == "minecraft:entity") { /*8.0*/
           uint8_t properties_minecraft_entity_val;
           READ_OR_BAIL(readUByte, properties_minecraft_entity_val);
           v2.properties_minecraft_entity.unused = properties_minecraft_entity_val >> 0 & 6;
           v2.properties_minecraft_entity.onlyAllowPlayers = properties_minecraft_entity_val >> 6 & 1;
           v2.properties_minecraft_entity.onlyAllowEntities = properties_minecraft_entity_val >> 7 & 1; /*properties_minecraft_entity: bitfield*/ /*4.3*/
         }
-        else if (parser == "minecraft:game_profile") { /*8.0*/
+        else if (V_parser == "minecraft:game_profile") { /*8.0*/
         }
-        else if (parser == "minecraft:block_pos") { /*8.0*/
+        else if (V_parser == "minecraft:block_pos") { /*8.0*/
         }
-        else if (parser == "minecraft:column_pos") { /*8.0*/
+        else if (V_parser == "minecraft:column_pos") { /*8.0*/
         }
-        else if (parser == "minecraft:vec3") { /*8.0*/
+        else if (V_parser == "minecraft:vec3") { /*8.0*/
         }
-        else if (parser == "minecraft:vec2") { /*8.0*/
+        else if (V_parser == "minecraft:vec2") { /*8.0*/
         }
-        else if (parser == "minecraft:block_state") { /*8.0*/
+        else if (V_parser == "minecraft:block_state") { /*8.0*/
         }
-        else if (parser == "minecraft:block_predicate") { /*8.0*/
+        else if (V_parser == "minecraft:block_predicate") { /*8.0*/
         }
-        else if (parser == "minecraft:item_stack") { /*8.0*/
+        else if (V_parser == "minecraft:item_stack") { /*8.0*/
         }
-        else if (parser == "minecraft:item_predicate") { /*8.0*/
+        else if (V_parser == "minecraft:item_predicate") { /*8.0*/
         }
-        else if (parser == "minecraft:color") { /*8.0*/
+        else if (V_parser == "minecraft:color") { /*8.0*/
         }
-        else if (parser == "minecraft:component") { /*8.0*/
+        else if (V_parser == "minecraft:component") { /*8.0*/
         }
-        else if (parser == "minecraft:message") { /*8.0*/
+        else if (V_parser == "minecraft:message") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt") { /*8.0*/
+        else if (V_parser == "minecraft:nbt") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt_path") { /*8.0*/
+        else if (V_parser == "minecraft:nbt_path") { /*8.0*/
         }
-        else if (parser == "minecraft:objective") { /*8.0*/
+        else if (V_parser == "minecraft:objective") { /*8.0*/
         }
-        else if (parser == "minecraft:objective_criteria") { /*8.0*/
+        else if (V_parser == "minecraft:objective_criteria") { /*8.0*/
         }
-        else if (parser == "minecraft:operation") { /*8.0*/
+        else if (V_parser == "minecraft:operation") { /*8.0*/
         }
-        else if (parser == "minecraft:particle") { /*8.0*/
+        else if (V_parser == "minecraft:particle") { /*8.0*/
         }
-        else if (parser == "minecraft:angle") { /*8.0*/
+        else if (V_parser == "minecraft:angle") { /*8.0*/
         }
-        else if (parser == "minecraft:rotation") { /*8.0*/
+        else if (V_parser == "minecraft:rotation") { /*8.0*/
         }
-        else if (parser == "minecraft:scoreboard_slot") { /*8.0*/
+        else if (V_parser == "minecraft:scoreboard_slot") { /*8.0*/
         }
-        else if (parser == "minecraft:score_holder") { /*8.0*/
+        else if (V_parser == "minecraft:score_holder") { /*8.0*/
           uint8_t properties_minecraft_score_holder_val;
           READ_OR_BAIL(readUByte, properties_minecraft_score_holder_val);
           v2.properties_minecraft_score_holder.unused = properties_minecraft_score_holder_val >> 0 & 7;
           v2.properties_minecraft_score_holder.allowMultiple = properties_minecraft_score_holder_val >> 7 & 1; /*properties_minecraft_score_holder: bitfield*/ /*4.3*/
         }
-        else if (parser == "minecraft:swizzle") { /*8.0*/
+        else if (V_parser == "minecraft:swizzle") { /*8.0*/
         }
-        else if (parser == "minecraft:team") { /*8.0*/
+        else if (V_parser == "minecraft:team") { /*8.0*/
         }
-        else if (parser == "minecraft:item_slot") { /*8.0*/
+        else if (V_parser == "minecraft:item_slot") { /*8.0*/
         }
-        else if (parser == "minecraft:resource_location") { /*8.0*/
+        else if (V_parser == "minecraft:resource_location") { /*8.0*/
         }
-        else if (parser == "minecraft:mob_effect") { /*8.0*/
+        else if (V_parser == "minecraft:mob_effect") { /*8.0*/
         }
-        else if (parser == "minecraft:function") { /*8.0*/
+        else if (V_parser == "minecraft:function") { /*8.0*/
         }
-        else if (parser == "minecraft:entity_anchor") { /*8.0*/
+        else if (V_parser == "minecraft:entity_anchor") { /*8.0*/
         }
-        else if (parser == "minecraft:range") { /*8.0*/
+        else if (V_parser == "minecraft:range") { /*8.0*/
              v2.properties_minecraft_range = {}; pdef::pc1_18_login_toClient::command_node::ExtraNodeData2::PropertiesMinecraftRange &v4 = *v2.properties_minecraft_range; /*8.4*/
             READ_OR_BAIL(readBool, (bool&)v4.allowDecimals); /*0.5*/
         }
-        else if (parser == "minecraft:int_range") { /*8.0*/
+        else if (V_parser == "minecraft:int_range") { /*8.0*/
         }
-        else if (parser == "minecraft:float_range") { /*8.0*/
+        else if (V_parser == "minecraft:float_range") { /*8.0*/
         }
-        else if (parser == "minecraft:item_enchantment") { /*8.0*/
+        else if (V_parser == "minecraft:item_enchantment") { /*8.0*/
         }
-        else if (parser == "minecraft:entity_summon") { /*8.0*/
+        else if (V_parser == "minecraft:entity_summon") { /*8.0*/
         }
-        else if (parser == "minecraft:dimension") { /*8.0*/
+        else if (V_parser == "minecraft:dimension") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt_compound_tag") { /*8.0*/
+        else if (V_parser == "minecraft:nbt_compound_tag") { /*8.0*/
         }
-        else if (parser == "minecraft:time") { /*8.0*/
+        else if (V_parser == "minecraft:time") { /*8.0*/
         }
-        else if (parser == "minecraft:resource_or_tag") { /*8.0*/
+        else if (V_parser == "minecraft:resource_or_tag") { /*8.0*/
              v2.properties_minecraft_resource_or_tag_or_minecraft_resource = {}; pdef::pc1_18_login_toClient::command_node::ExtraNodeData2::PropertiesMinecraftResourceOrTagOrMinecraftResource &v4 = *v2.properties_minecraft_resource_or_tag_or_minecraft_resource; /*8.4*/
             int registry_strlen; READ_OR_BAIL(readUnsignedVarInt, registry_strlen);
             if (!stream.readString(v4.registry, registry_strlen)) return false; /*registry: pstring*/ /*4.3*/
         }
-        else if (parser == "minecraft:resource") { /*8.0*/
+        else if (V_parser == "minecraft:resource") { /*8.0*/
              v2.properties_minecraft_resource_or_tag_or_minecraft_resource = {}; pdef::pc1_18_login_toClient::command_node::ExtraNodeData2::PropertiesMinecraftResourceOrTagOrMinecraftResource &v4 = *v2.properties_minecraft_resource_or_tag_or_minecraft_resource; /*8.4*/
             int registry_strlen; READ_OR_BAIL(readUnsignedVarInt, registry_strlen);
             if (!stream.readString(v4.registry, registry_strlen)) return false; /*registry: pstring*/ /*4.3*/
         }
-        else if (parser == "minecraft:uuid") { /*8.0*/
+        else if (V_parser == "minecraft:uuid") { /*8.0*/
         }
-        if (flags.has_custom_suggestions == 1) { /*8.2*/
+        if (V_flags.has_custom_suggestions == 1) { /*8.2*/
           int suggestionType_strlen; READ_OR_BAIL(readUnsignedVarInt, suggestionType_strlen);
           if (!stream.readString(v2.suggestionType, suggestionType_strlen)) return false; /*suggestionType: pstring*/ /*4.3*/
         }
@@ -1345,8 +1345,8 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_login_toClient::tags &obj) {
   }
   bool packet(pdef::Stream &stream, pdef::pc1_18_login_toClient::packet &obj) {
     READ_OR_BAIL(readUnsignedVarInt, (int&)obj.name); /*7.2*/
-    const pdef::pc1_18_login_toClient::packet::Name &name = obj.name; /*0.7*/
-    switch (name) { /*8.0*/
+    const pdef::pc1_18_login_toClient::packet::Name &V_name = obj.name; /*0.7*/
+    switch (V_name) { /*8.0*/
       case pdef::pc1_18_login_toClient::packet::Name::Disconnect: { /*8.5*/
         obj.params_packet_disconnect = {}; pdef::pc1_18_login_toClient::decode::packet_disconnect(stream, *obj.params_packet_disconnect); /*obj*/ /*4.6*/
         break;

--- a/examples/mcpc-protocol/build/pc1_18_login_toServer.h
+++ b/examples/mcpc-protocol/build/pc1_18_login_toServer.h
@@ -259,10 +259,10 @@ size_t packet_login_plugin_response(pdef::Stream &stream, const pdef::pc1_18_log
 size_t packet(pdef::Stream &stream, const pdef::pc1_18_login_toServer::packet &obj);
   size_t slot(pdef::Stream &stream, const pdef::pc1_18_login_toServer::slot &obj) {
     size_t len = 0;
-    const bool &present = obj.present; /*0.1*/
-    if (present == false) { /*8.1*/
+    const bool &V_present = obj.present; /*0.1*/
+    if (V_present == false) { /*8.1*/
     }
-    else if (present == true) { /*8.1*/
+    else if (V_present == true) { /*8.1*/
         len += stream.sizeOfVarInt(obj.itemId); /*0.2*/
         len += 1; /*0.2*/
         len += 1; /*0.2*/
@@ -271,23 +271,23 @@ size_t packet(pdef::Stream &stream, const pdef::pc1_18_login_toServer::packet &o
   }
   size_t particle(pdef::Stream &stream, const pdef::pc1_18_login_toServer::particle &obj) {
     size_t len = 0;
-    const int &particleId = obj.particleId; /*0.1*/
-    if (particleId == 2) { /*8.2*/
+    const int &V_particleId = obj.particleId; /*0.1*/
+    if (V_particleId == 2) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_2_or_3_or_24); const pdef::pc1_18_login_toServer::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.6*/
         len += stream.sizeOfVarInt(v2.blockState); /*0.2*/
     }
-    else if (particleId == 3) { /*8.2*/
+    else if (V_particleId == 3) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_2_or_3_or_24); const pdef::pc1_18_login_toServer::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.6*/
         len += stream.sizeOfVarInt(v2.blockState); /*0.2*/
     }
-    else if (particleId == 14) { /*8.2*/
+    else if (V_particleId == 14) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_14); const pdef::pc1_18_login_toServer::particle::Data14 &v2 = *obj.data_14; /*8.6*/
         len += 4; /*0.2*/
         len += 4; /*0.2*/
         len += 4; /*0.2*/
         len += 4; /*0.2*/
     }
-    else if (particleId == 15) { /*8.2*/
+    else if (V_particleId == 15) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_15); const pdef::pc1_18_login_toServer::particle::Data15 &v2 = *obj.data_15; /*8.6*/
         len += 4; /*0.2*/
         len += 4; /*0.2*/
@@ -297,24 +297,24 @@ size_t packet(pdef::Stream &stream, const pdef::pc1_18_login_toServer::packet &o
         len += 4; /*0.2*/
         len += 4; /*0.2*/
     }
-    else if (particleId == 24) { /*8.2*/
+    else if (V_particleId == 24) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_2_or_3_or_24); const pdef::pc1_18_login_toServer::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.6*/
         len += stream.sizeOfVarInt(v2.blockState); /*0.2*/
     }
-    else if (particleId == 35) { /*8.2*/
+    else if (V_particleId == 35) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_35); const pdef::pc1_18_login_toServer::particle::Data35 &v2 = *obj.data_35; /*8.6*/
         len += 1; /*0.2*/
     }
-    else if (particleId == 36) { /*8.2*/
+    else if (V_particleId == 36) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_36); const pdef::pc1_18_login_toServer::particle::Data36 &v2 = *obj.data_36; /*8.6*/
         len += 1; /*origin: bitfield*/ /*4.1*/
         len += stream.sizeOfVarInt(v2.positionType.length());
         len += v2.positionType.length(); /*positionType^: pstring*/ /*4.1*/
-        const std::string &positionType = v2.positionType; /*4.7*/
-        if (positionType == "minecraft:block") { /*8.0*/
+        const std::string &V_positionType = v2.positionType; /*4.7*/
+        if (V_positionType == "minecraft:block") { /*8.0*/
           len += 1; /*destination: bitfield*/ /*4.1*/
         }
-        else if (positionType == "minecraft:entity") { /*8.0*/
+        else if (V_positionType == "minecraft:entity") { /*8.0*/
           len += stream.sizeOfVarInt(v2.destination_varint); /*0.2*/
         }
         len += stream.sizeOfVarInt(v2.ticks); /*0.2*/
@@ -326,7 +326,7 @@ size_t packet(pdef::Stream &stream, const pdef::pc1_18_login_toServer::packet &o
     len += stream.sizeOfVarInt(obj.group.length());
     len += obj.group.length(); /*group: pstring*/ /*4.1*/
     len += stream.sizeOfVarInt(obj.ingredient.size()); /*1.3*/
-    for (const auto &v2 : obj.ingredient) {
+    for (const auto &v2 : obj.ingredient) { /*3.2*/
       len += 1; /*0.2*/
     }
     len += 1; /*0.2*/
@@ -339,7 +339,7 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_login_toServer::tags &obj) 
     len += stream.sizeOfVarInt(obj.tagName.length());
     len += obj.tagName.length(); /*tagName: pstring*/ /*4.1*/
     len += stream.sizeOfVarInt(obj.entries.size()); /*1.3*/
-    for (const auto &v2 : obj.entries) {
+    for (const auto &v2 : obj.entries) { /*3.2*/
       len += stream.sizeOfVarInt(v2); /*0.2*/
     }
   PDEF_SIZE_DBG; return len;
@@ -355,169 +355,169 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_login_toServer::tags &obj) 
   size_t command_node(pdef::Stream &stream, const pdef::pc1_18_login_toServer::command_node &obj) {
     size_t len = 0;
     len += 1; /*flags^: bitfield*/ /*4.1*/
-    const pdef::pc1_18_login_toServer::command_node::flags_t &flags = obj.flags; /*4.7*/
+    const pdef::pc1_18_login_toServer::command_node::flags_t &V_flags = obj.flags; /*4.7*/
     len += stream.sizeOfVarInt(obj.children.size()); /*1.3*/
-    for (const auto &v2 : obj.children) {
+    for (const auto &v2 : obj.children) { /*3.2*/
       len += stream.sizeOfVarInt(v2); /*0.2*/
     }
-    if (flags.has_redirect_node == 1) { /*8.2*/
+    if (V_flags.has_redirect_node == 1) { /*8.2*/
       len += stream.sizeOfVarInt(obj.redirectNode); /*0.2*/
     }
-    if (flags.command_node_type == 0) { /*8.2*/
+    if (V_flags.command_node_type == 0) { /*8.2*/
     }
-    else if (flags.command_node_type == 1) { /*8.2*/
+    else if (V_flags.command_node_type == 1) { /*8.2*/
         EXPECT_OR_BAIL(obj.extraNodeData_1); const pdef::pc1_18_login_toServer::command_node::ExtraNodeData1 &v2 = *obj.extraNodeData_1; /*8.6*/
         len += stream.sizeOfVarInt(v2.name.length());
         len += v2.name.length(); /*name: pstring*/ /*4.1*/
     }
-    else if (flags.command_node_type == 2) { /*8.2*/
+    else if (V_flags.command_node_type == 2) { /*8.2*/
         EXPECT_OR_BAIL(obj.extraNodeData_2); const pdef::pc1_18_login_toServer::command_node::ExtraNodeData2 &v2 = *obj.extraNodeData_2; /*8.6*/
         len += stream.sizeOfVarInt(v2.name.length());
         len += v2.name.length(); /*name: pstring*/ /*4.1*/
         len += stream.sizeOfVarInt(v2.parser.length());
         len += v2.parser.length(); /*parser^: pstring*/ /*4.1*/
-        const std::string &parser = v2.parser; /*4.7*/
-        if (parser == "brigadier:bool") { /*8.0*/
+        const std::string &V_parser = v2.parser; /*4.7*/
+        if (V_parser == "brigadier:bool") { /*8.0*/
         }
-        else if (parser == "brigadier:float") { /*8.0*/
+        else if (V_parser == "brigadier:float") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_brigadier_float); const pdef::pc1_18_login_toServer::command_node::ExtraNodeData2::PropertiesBrigadierFloat &v4 = *v2.properties_brigadier_float; /*8.6*/
             len += 1; /*flags^: bitfield*/ /*4.1*/
-            const pdef::pc1_18_login_toServer::command_node::ExtraNodeData2::PropertiesBrigadierFloat::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_login_toServer::command_node::ExtraNodeData2::PropertiesBrigadierFloat::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               len += 4; /*0.2*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               len += 4; /*0.2*/
             }
         }
-        else if (parser == "brigadier:double") { /*8.0*/
+        else if (V_parser == "brigadier:double") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_brigadier_double); const pdef::pc1_18_login_toServer::command_node::ExtraNodeData2::PropertiesBrigadierDouble &v4 = *v2.properties_brigadier_double; /*8.6*/
             len += 1; /*flags^: bitfield*/ /*4.1*/
-            const pdef::pc1_18_login_toServer::command_node::ExtraNodeData2::PropertiesBrigadierDouble::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_login_toServer::command_node::ExtraNodeData2::PropertiesBrigadierDouble::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               len += 8; /*0.2*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               len += 8; /*0.2*/
             }
         }
-        else if (parser == "brigadier:integer") { /*8.0*/
+        else if (V_parser == "brigadier:integer") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_brigadier_integer); const pdef::pc1_18_login_toServer::command_node::ExtraNodeData2::PropertiesBrigadierInteger &v4 = *v2.properties_brigadier_integer; /*8.6*/
             len += 1; /*flags^: bitfield*/ /*4.1*/
-            const pdef::pc1_18_login_toServer::command_node::ExtraNodeData2::PropertiesBrigadierInteger::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_login_toServer::command_node::ExtraNodeData2::PropertiesBrigadierInteger::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               len += 4; /*0.2*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               len += 4; /*0.2*/
             }
         }
-        else if (parser == "brigadier:long") { /*8.0*/
+        else if (V_parser == "brigadier:long") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_brigadier_long); const pdef::pc1_18_login_toServer::command_node::ExtraNodeData2::PropertiesBrigadierLong &v4 = *v2.properties_brigadier_long; /*8.6*/
             len += 1; /*flags^: bitfield*/ /*4.1*/
-            const pdef::pc1_18_login_toServer::command_node::ExtraNodeData2::PropertiesBrigadierLong::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_login_toServer::command_node::ExtraNodeData2::PropertiesBrigadierLong::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               len += 8; /*0.2*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               len += 8; /*0.2*/
             }
         }
-        else if (parser == "brigadier:string") { /*8.0*/
+        else if (V_parser == "brigadier:string") { /*8.0*/
         }
-        else if (parser == "minecraft:entity") { /*8.0*/
+        else if (V_parser == "minecraft:entity") { /*8.0*/
           len += 1; /*properties: bitfield*/ /*4.1*/
         }
-        else if (parser == "minecraft:game_profile") { /*8.0*/
+        else if (V_parser == "minecraft:game_profile") { /*8.0*/
         }
-        else if (parser == "minecraft:block_pos") { /*8.0*/
+        else if (V_parser == "minecraft:block_pos") { /*8.0*/
         }
-        else if (parser == "minecraft:column_pos") { /*8.0*/
+        else if (V_parser == "minecraft:column_pos") { /*8.0*/
         }
-        else if (parser == "minecraft:vec3") { /*8.0*/
+        else if (V_parser == "minecraft:vec3") { /*8.0*/
         }
-        else if (parser == "minecraft:vec2") { /*8.0*/
+        else if (V_parser == "minecraft:vec2") { /*8.0*/
         }
-        else if (parser == "minecraft:block_state") { /*8.0*/
+        else if (V_parser == "minecraft:block_state") { /*8.0*/
         }
-        else if (parser == "minecraft:block_predicate") { /*8.0*/
+        else if (V_parser == "minecraft:block_predicate") { /*8.0*/
         }
-        else if (parser == "minecraft:item_stack") { /*8.0*/
+        else if (V_parser == "minecraft:item_stack") { /*8.0*/
         }
-        else if (parser == "minecraft:item_predicate") { /*8.0*/
+        else if (V_parser == "minecraft:item_predicate") { /*8.0*/
         }
-        else if (parser == "minecraft:color") { /*8.0*/
+        else if (V_parser == "minecraft:color") { /*8.0*/
         }
-        else if (parser == "minecraft:component") { /*8.0*/
+        else if (V_parser == "minecraft:component") { /*8.0*/
         }
-        else if (parser == "minecraft:message") { /*8.0*/
+        else if (V_parser == "minecraft:message") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt") { /*8.0*/
+        else if (V_parser == "minecraft:nbt") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt_path") { /*8.0*/
+        else if (V_parser == "minecraft:nbt_path") { /*8.0*/
         }
-        else if (parser == "minecraft:objective") { /*8.0*/
+        else if (V_parser == "minecraft:objective") { /*8.0*/
         }
-        else if (parser == "minecraft:objective_criteria") { /*8.0*/
+        else if (V_parser == "minecraft:objective_criteria") { /*8.0*/
         }
-        else if (parser == "minecraft:operation") { /*8.0*/
+        else if (V_parser == "minecraft:operation") { /*8.0*/
         }
-        else if (parser == "minecraft:particle") { /*8.0*/
+        else if (V_parser == "minecraft:particle") { /*8.0*/
         }
-        else if (parser == "minecraft:angle") { /*8.0*/
+        else if (V_parser == "minecraft:angle") { /*8.0*/
         }
-        else if (parser == "minecraft:rotation") { /*8.0*/
+        else if (V_parser == "minecraft:rotation") { /*8.0*/
         }
-        else if (parser == "minecraft:scoreboard_slot") { /*8.0*/
+        else if (V_parser == "minecraft:scoreboard_slot") { /*8.0*/
         }
-        else if (parser == "minecraft:score_holder") { /*8.0*/
+        else if (V_parser == "minecraft:score_holder") { /*8.0*/
           len += 1; /*properties: bitfield*/ /*4.1*/
         }
-        else if (parser == "minecraft:swizzle") { /*8.0*/
+        else if (V_parser == "minecraft:swizzle") { /*8.0*/
         }
-        else if (parser == "minecraft:team") { /*8.0*/
+        else if (V_parser == "minecraft:team") { /*8.0*/
         }
-        else if (parser == "minecraft:item_slot") { /*8.0*/
+        else if (V_parser == "minecraft:item_slot") { /*8.0*/
         }
-        else if (parser == "minecraft:resource_location") { /*8.0*/
+        else if (V_parser == "minecraft:resource_location") { /*8.0*/
         }
-        else if (parser == "minecraft:mob_effect") { /*8.0*/
+        else if (V_parser == "minecraft:mob_effect") { /*8.0*/
         }
-        else if (parser == "minecraft:function") { /*8.0*/
+        else if (V_parser == "minecraft:function") { /*8.0*/
         }
-        else if (parser == "minecraft:entity_anchor") { /*8.0*/
+        else if (V_parser == "minecraft:entity_anchor") { /*8.0*/
         }
-        else if (parser == "minecraft:range") { /*8.0*/
+        else if (V_parser == "minecraft:range") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_minecraft_range); const pdef::pc1_18_login_toServer::command_node::ExtraNodeData2::PropertiesMinecraftRange &v4 = *v2.properties_minecraft_range; /*8.6*/
             len += 1; /*0.2*/
         }
-        else if (parser == "minecraft:int_range") { /*8.0*/
+        else if (V_parser == "minecraft:int_range") { /*8.0*/
         }
-        else if (parser == "minecraft:float_range") { /*8.0*/
+        else if (V_parser == "minecraft:float_range") { /*8.0*/
         }
-        else if (parser == "minecraft:item_enchantment") { /*8.0*/
+        else if (V_parser == "minecraft:item_enchantment") { /*8.0*/
         }
-        else if (parser == "minecraft:entity_summon") { /*8.0*/
+        else if (V_parser == "minecraft:entity_summon") { /*8.0*/
         }
-        else if (parser == "minecraft:dimension") { /*8.0*/
+        else if (V_parser == "minecraft:dimension") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt_compound_tag") { /*8.0*/
+        else if (V_parser == "minecraft:nbt_compound_tag") { /*8.0*/
         }
-        else if (parser == "minecraft:time") { /*8.0*/
+        else if (V_parser == "minecraft:time") { /*8.0*/
         }
-        else if (parser == "minecraft:resource_or_tag") { /*8.0*/
+        else if (V_parser == "minecraft:resource_or_tag") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_minecraft_resource_or_tag_or_minecraft_resource); const pdef::pc1_18_login_toServer::command_node::ExtraNodeData2::PropertiesMinecraftResourceOrTagOrMinecraftResource &v4 = *v2.properties_minecraft_resource_or_tag_or_minecraft_resource; /*8.6*/
             len += stream.sizeOfVarInt(v4.registry.length());
             len += v4.registry.length(); /*registry: pstring*/ /*4.1*/
         }
-        else if (parser == "minecraft:resource") { /*8.0*/
+        else if (V_parser == "minecraft:resource") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_minecraft_resource_or_tag_or_minecraft_resource); const pdef::pc1_18_login_toServer::command_node::ExtraNodeData2::PropertiesMinecraftResourceOrTagOrMinecraftResource &v4 = *v2.properties_minecraft_resource_or_tag_or_minecraft_resource; /*8.6*/
             len += stream.sizeOfVarInt(v4.registry.length());
             len += v4.registry.length(); /*registry: pstring*/ /*4.1*/
         }
-        else if (parser == "minecraft:uuid") { /*8.0*/
+        else if (V_parser == "minecraft:uuid") { /*8.0*/
         }
-        if (flags.has_custom_suggestions == 1) { /*8.2*/
+        if (V_flags.has_custom_suggestions == 1) { /*8.2*/
           len += stream.sizeOfVarInt(v2.suggestionType.length());
           len += v2.suggestionType.length(); /*suggestionType: pstring*/ /*4.1*/
         }
@@ -546,9 +546,9 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_login_toServer::tags &obj) 
   }
   size_t packet(pdef::Stream &stream, const pdef::pc1_18_login_toServer::packet &obj) {
     size_t len = 0;
-    const pdef::pc1_18_login_toServer::packet::Name &name = obj.name; /*0.3*/
+    const pdef::pc1_18_login_toServer::packet::Name &V_name = obj.name; /*0.3*/
     len += stream.sizeOfVarInt((int&)obj.name); /*name^: varint*/ /*7.0*/
-    switch (name) { /*8.0*/
+    switch (V_name) { /*8.0*/
       case pdef::pc1_18_login_toServer::packet::Name::LoginStart: { /*8.5*/
         EXPECT_OR_BAIL(obj.params_packet_login_start); size_t len_0 = pdef::pc1_18_login_toServer::size::packet_login_start(stream, *obj.params_packet_login_start); EXPECT_OR_BAIL(len_0); len += len_0; /*params_packet_login_start*/ /*4.4*/
         break;
@@ -580,11 +580,11 @@ bool packet_login_plugin_response(pdef::Stream &stream, const pdef::pc1_18_login
 bool packet(pdef::Stream &stream, const pdef::pc1_18_login_toServer::packet &obj, bool allocate);
   bool slot(pdef::Stream &stream, const pdef::pc1_18_login_toServer::slot &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::pc1_18_login_toServer::size::slot(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const bool &present = obj.present; /*0.1*/
+    const bool &V_present = obj.present; /*0.1*/
     WRITE_OR_BAIL(writeBool, (bool)obj.present); /*0.4*/
-    if (present == false) { /*8.1*/
+    if (V_present == false) { /*8.1*/
     }
-    else if (present == true) { /*8.1*/
+    else if (V_present == true) { /*8.1*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.itemId); /*0.4*/
         WRITE_OR_BAIL(writeByte, (int8_t)obj.itemCount); /*0.4*/
         WRITE_OR_BAIL(writeByte, (int8_t)obj.nbtData); /*0.4*/
@@ -593,24 +593,24 @@ bool packet(pdef::Stream &stream, const pdef::pc1_18_login_toServer::packet &obj
   }
   bool particle(pdef::Stream &stream, const pdef::pc1_18_login_toServer::particle &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::pc1_18_login_toServer::size::particle(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const int &particleId = obj.particleId; /*0.1*/
+    const int &V_particleId = obj.particleId; /*0.1*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.particleId); /*0.4*/
-    if (particleId == 2) { /*8.2*/
+    if (V_particleId == 2) { /*8.2*/
         const pdef::pc1_18_login_toServer::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.5*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.blockState); /*0.4*/
     }
-    else if (particleId == 3) { /*8.2*/
+    else if (V_particleId == 3) { /*8.2*/
         const pdef::pc1_18_login_toServer::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.5*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.blockState); /*0.4*/
     }
-    else if (particleId == 14) { /*8.2*/
+    else if (V_particleId == 14) { /*8.2*/
         const pdef::pc1_18_login_toServer::particle::Data14 &v2 = *obj.data_14; /*8.5*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.red); /*0.4*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.green); /*0.4*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.blue); /*0.4*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.scale); /*0.4*/
     }
-    else if (particleId == 15) { /*8.2*/
+    else if (V_particleId == 15) { /*8.2*/
         const pdef::pc1_18_login_toServer::particle::Data15 &v2 = *obj.data_15; /*8.5*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.fromRed); /*0.4*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.fromGreen); /*0.4*/
@@ -620,15 +620,15 @@ bool packet(pdef::Stream &stream, const pdef::pc1_18_login_toServer::packet &obj
         WRITE_OR_BAIL(writeFloatBE, (float)v2.toGreen); /*0.4*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.toBlue); /*0.4*/
     }
-    else if (particleId == 24) { /*8.2*/
+    else if (V_particleId == 24) { /*8.2*/
         const pdef::pc1_18_login_toServer::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.5*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.blockState); /*0.4*/
     }
-    else if (particleId == 35) { /*8.2*/
+    else if (V_particleId == 35) { /*8.2*/
         const pdef::pc1_18_login_toServer::particle::Data35 &v2 = *obj.data_35; /*8.5*/
         WRITE_OR_BAIL(writeByte, (int8_t)v2.item); /*0.4*/
     }
-    else if (particleId == 36) { /*8.2*/
+    else if (V_particleId == 36) { /*8.2*/
         const pdef::pc1_18_login_toServer::particle::Data36 &v2 = *obj.data_36; /*8.5*/
         uint64_t origin_val = 0;
         origin_val |= (uint64_t)v2.origin.x << 0;
@@ -637,15 +637,15 @@ bool packet(pdef::Stream &stream, const pdef::pc1_18_login_toServer::packet &obj
         WRITE_OR_BAIL(writeULongBE, origin_val); /*origin: bitfield*/ /*4.2*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.positionType.length());
         WRITE_OR_BAIL(writeString, v2.positionType); /*positionType: pstring*/ /*4.2*/
-        const std::string &positionType = v2.positionType; /*4.7*/
-        if (positionType == "minecraft:block") { /*8.0*/
+        const std::string &V_positionType = v2.positionType; /*4.7*/
+        if (V_positionType == "minecraft:block") { /*8.0*/
           uint64_t destination_position_val = 0;
           destination_position_val |= (uint64_t)v2.destination_position.x << 0;
           destination_position_val |= (uint64_t)v2.destination_position.z << 26;
           destination_position_val |= (uint64_t)v2.destination_position.y << 52;
           WRITE_OR_BAIL(writeULongBE, destination_position_val); /*destination_position: bitfield*/ /*4.2*/
         }
-        else if (positionType == "minecraft:entity") { /*8.0*/
+        else if (V_positionType == "minecraft:entity") { /*8.0*/
           WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.destination_varint); /*0.4*/
         }
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.ticks); /*0.4*/
@@ -695,192 +695,192 @@ bool tags(pdef::Stream &stream, const pdef::pc1_18_login_toServer::tags &obj, bo
     flags_val |= (uint8_t)obj.flags.has_command << 5;
     flags_val |= (uint8_t)obj.flags.command_node_type << 6;
     WRITE_OR_BAIL(writeUByte, flags_val); /*flags: bitfield*/ /*4.2*/
-    const pdef::pc1_18_login_toServer::command_node::flags_t &flags = obj.flags; /*4.7*/
+    const pdef::pc1_18_login_toServer::command_node::flags_t &V_flags = obj.flags; /*4.7*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.children.size()); /*1.4*/
     for (const auto &v2 : obj.children) { /*3.1*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2); /*0.4*/
     }
-    if (flags.has_redirect_node == 1) { /*8.2*/
+    if (V_flags.has_redirect_node == 1) { /*8.2*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.redirectNode); /*0.4*/
     }
-    if (flags.command_node_type == 0) { /*8.2*/
+    if (V_flags.command_node_type == 0) { /*8.2*/
     }
-    else if (flags.command_node_type == 1) { /*8.2*/
+    else if (V_flags.command_node_type == 1) { /*8.2*/
         const pdef::pc1_18_login_toServer::command_node::ExtraNodeData1 &v2 = *obj.extraNodeData_1; /*8.5*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.name.length());
         WRITE_OR_BAIL(writeString, v2.name); /*name: pstring*/ /*4.2*/
     }
-    else if (flags.command_node_type == 2) { /*8.2*/
+    else if (V_flags.command_node_type == 2) { /*8.2*/
         const pdef::pc1_18_login_toServer::command_node::ExtraNodeData2 &v2 = *obj.extraNodeData_2; /*8.5*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.name.length());
         WRITE_OR_BAIL(writeString, v2.name); /*name: pstring*/ /*4.2*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.parser.length());
         WRITE_OR_BAIL(writeString, v2.parser); /*parser: pstring*/ /*4.2*/
-        const std::string &parser = v2.parser; /*4.7*/
-        if (parser == "brigadier:bool") { /*8.0*/
+        const std::string &V_parser = v2.parser; /*4.7*/
+        if (V_parser == "brigadier:bool") { /*8.0*/
         }
-        else if (parser == "brigadier:float") { /*8.0*/
+        else if (V_parser == "brigadier:float") { /*8.0*/
             const pdef::pc1_18_login_toServer::command_node::ExtraNodeData2::PropertiesBrigadierFloat &v4 = *v2.properties_brigadier_float; /*8.5*/
             uint8_t flags_val = 0;
             flags_val |= (uint8_t)v4.flags.unused << 0;
             flags_val |= (uint8_t)v4.flags.max_present << 6;
             flags_val |= (uint8_t)v4.flags.min_present << 7;
             WRITE_OR_BAIL(writeUByte, flags_val); /*flags: bitfield*/ /*4.2*/
-            const pdef::pc1_18_login_toServer::command_node::ExtraNodeData2::PropertiesBrigadierFloat::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_login_toServer::command_node::ExtraNodeData2::PropertiesBrigadierFloat::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeFloatBE, (float)v4.min); /*0.4*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeFloatBE, (float)v4.max); /*0.4*/
             }
         }
-        else if (parser == "brigadier:double") { /*8.0*/
+        else if (V_parser == "brigadier:double") { /*8.0*/
             const pdef::pc1_18_login_toServer::command_node::ExtraNodeData2::PropertiesBrigadierDouble &v4 = *v2.properties_brigadier_double; /*8.5*/
             uint8_t flags_val = 0;
             flags_val |= (uint8_t)v4.flags.unused << 0;
             flags_val |= (uint8_t)v4.flags.max_present << 6;
             flags_val |= (uint8_t)v4.flags.min_present << 7;
             WRITE_OR_BAIL(writeUByte, flags_val); /*flags: bitfield*/ /*4.2*/
-            const pdef::pc1_18_login_toServer::command_node::ExtraNodeData2::PropertiesBrigadierDouble::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_login_toServer::command_node::ExtraNodeData2::PropertiesBrigadierDouble::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeDoubleBE, (double)v4.min); /*0.4*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeDoubleBE, (double)v4.max); /*0.4*/
             }
         }
-        else if (parser == "brigadier:integer") { /*8.0*/
+        else if (V_parser == "brigadier:integer") { /*8.0*/
             const pdef::pc1_18_login_toServer::command_node::ExtraNodeData2::PropertiesBrigadierInteger &v4 = *v2.properties_brigadier_integer; /*8.5*/
             uint8_t flags_val = 0;
             flags_val |= (uint8_t)v4.flags.unused << 0;
             flags_val |= (uint8_t)v4.flags.max_present << 6;
             flags_val |= (uint8_t)v4.flags.min_present << 7;
             WRITE_OR_BAIL(writeUByte, flags_val); /*flags: bitfield*/ /*4.2*/
-            const pdef::pc1_18_login_toServer::command_node::ExtraNodeData2::PropertiesBrigadierInteger::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_login_toServer::command_node::ExtraNodeData2::PropertiesBrigadierInteger::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeIntBE, (int32_t)v4.min); /*0.4*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeIntBE, (int32_t)v4.max); /*0.4*/
             }
         }
-        else if (parser == "brigadier:long") { /*8.0*/
+        else if (V_parser == "brigadier:long") { /*8.0*/
             const pdef::pc1_18_login_toServer::command_node::ExtraNodeData2::PropertiesBrigadierLong &v4 = *v2.properties_brigadier_long; /*8.5*/
             uint8_t flags_val = 0;
             flags_val |= (uint8_t)v4.flags.unused << 0;
             flags_val |= (uint8_t)v4.flags.max_present << 6;
             flags_val |= (uint8_t)v4.flags.min_present << 7;
             WRITE_OR_BAIL(writeUByte, flags_val); /*flags: bitfield*/ /*4.2*/
-            const pdef::pc1_18_login_toServer::command_node::ExtraNodeData2::PropertiesBrigadierLong::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_login_toServer::command_node::ExtraNodeData2::PropertiesBrigadierLong::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeLongBE, (int64_t)v4.min); /*0.4*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeLongBE, (int64_t)v4.max); /*0.4*/
             }
         }
-        else if (parser == "brigadier:string") { /*8.0*/
+        else if (V_parser == "brigadier:string") { /*8.0*/
         }
-        else if (parser == "minecraft:entity") { /*8.0*/
+        else if (V_parser == "minecraft:entity") { /*8.0*/
           uint8_t properties_minecraft_entity_val = 0;
           properties_minecraft_entity_val |= (uint8_t)v2.properties_minecraft_entity.unused << 0;
           properties_minecraft_entity_val |= (uint8_t)v2.properties_minecraft_entity.onlyAllowPlayers << 6;
           properties_minecraft_entity_val |= (uint8_t)v2.properties_minecraft_entity.onlyAllowEntities << 7;
           WRITE_OR_BAIL(writeUByte, properties_minecraft_entity_val); /*properties_minecraft_entity: bitfield*/ /*4.2*/
         }
-        else if (parser == "minecraft:game_profile") { /*8.0*/
+        else if (V_parser == "minecraft:game_profile") { /*8.0*/
         }
-        else if (parser == "minecraft:block_pos") { /*8.0*/
+        else if (V_parser == "minecraft:block_pos") { /*8.0*/
         }
-        else if (parser == "minecraft:column_pos") { /*8.0*/
+        else if (V_parser == "minecraft:column_pos") { /*8.0*/
         }
-        else if (parser == "minecraft:vec3") { /*8.0*/
+        else if (V_parser == "minecraft:vec3") { /*8.0*/
         }
-        else if (parser == "minecraft:vec2") { /*8.0*/
+        else if (V_parser == "minecraft:vec2") { /*8.0*/
         }
-        else if (parser == "minecraft:block_state") { /*8.0*/
+        else if (V_parser == "minecraft:block_state") { /*8.0*/
         }
-        else if (parser == "minecraft:block_predicate") { /*8.0*/
+        else if (V_parser == "minecraft:block_predicate") { /*8.0*/
         }
-        else if (parser == "minecraft:item_stack") { /*8.0*/
+        else if (V_parser == "minecraft:item_stack") { /*8.0*/
         }
-        else if (parser == "minecraft:item_predicate") { /*8.0*/
+        else if (V_parser == "minecraft:item_predicate") { /*8.0*/
         }
-        else if (parser == "minecraft:color") { /*8.0*/
+        else if (V_parser == "minecraft:color") { /*8.0*/
         }
-        else if (parser == "minecraft:component") { /*8.0*/
+        else if (V_parser == "minecraft:component") { /*8.0*/
         }
-        else if (parser == "minecraft:message") { /*8.0*/
+        else if (V_parser == "minecraft:message") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt") { /*8.0*/
+        else if (V_parser == "minecraft:nbt") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt_path") { /*8.0*/
+        else if (V_parser == "minecraft:nbt_path") { /*8.0*/
         }
-        else if (parser == "minecraft:objective") { /*8.0*/
+        else if (V_parser == "minecraft:objective") { /*8.0*/
         }
-        else if (parser == "minecraft:objective_criteria") { /*8.0*/
+        else if (V_parser == "minecraft:objective_criteria") { /*8.0*/
         }
-        else if (parser == "minecraft:operation") { /*8.0*/
+        else if (V_parser == "minecraft:operation") { /*8.0*/
         }
-        else if (parser == "minecraft:particle") { /*8.0*/
+        else if (V_parser == "minecraft:particle") { /*8.0*/
         }
-        else if (parser == "minecraft:angle") { /*8.0*/
+        else if (V_parser == "minecraft:angle") { /*8.0*/
         }
-        else if (parser == "minecraft:rotation") { /*8.0*/
+        else if (V_parser == "minecraft:rotation") { /*8.0*/
         }
-        else if (parser == "minecraft:scoreboard_slot") { /*8.0*/
+        else if (V_parser == "minecraft:scoreboard_slot") { /*8.0*/
         }
-        else if (parser == "minecraft:score_holder") { /*8.0*/
+        else if (V_parser == "minecraft:score_holder") { /*8.0*/
           uint8_t properties_minecraft_score_holder_val = 0;
           properties_minecraft_score_holder_val |= (uint8_t)v2.properties_minecraft_score_holder.unused << 0;
           properties_minecraft_score_holder_val |= (uint8_t)v2.properties_minecraft_score_holder.allowMultiple << 7;
           WRITE_OR_BAIL(writeUByte, properties_minecraft_score_holder_val); /*properties_minecraft_score_holder: bitfield*/ /*4.2*/
         }
-        else if (parser == "minecraft:swizzle") { /*8.0*/
+        else if (V_parser == "minecraft:swizzle") { /*8.0*/
         }
-        else if (parser == "minecraft:team") { /*8.0*/
+        else if (V_parser == "minecraft:team") { /*8.0*/
         }
-        else if (parser == "minecraft:item_slot") { /*8.0*/
+        else if (V_parser == "minecraft:item_slot") { /*8.0*/
         }
-        else if (parser == "minecraft:resource_location") { /*8.0*/
+        else if (V_parser == "minecraft:resource_location") { /*8.0*/
         }
-        else if (parser == "minecraft:mob_effect") { /*8.0*/
+        else if (V_parser == "minecraft:mob_effect") { /*8.0*/
         }
-        else if (parser == "minecraft:function") { /*8.0*/
+        else if (V_parser == "minecraft:function") { /*8.0*/
         }
-        else if (parser == "minecraft:entity_anchor") { /*8.0*/
+        else if (V_parser == "minecraft:entity_anchor") { /*8.0*/
         }
-        else if (parser == "minecraft:range") { /*8.0*/
+        else if (V_parser == "minecraft:range") { /*8.0*/
             const pdef::pc1_18_login_toServer::command_node::ExtraNodeData2::PropertiesMinecraftRange &v4 = *v2.properties_minecraft_range; /*8.5*/
             WRITE_OR_BAIL(writeBool, (bool)v4.allowDecimals); /*0.4*/
         }
-        else if (parser == "minecraft:int_range") { /*8.0*/
+        else if (V_parser == "minecraft:int_range") { /*8.0*/
         }
-        else if (parser == "minecraft:float_range") { /*8.0*/
+        else if (V_parser == "minecraft:float_range") { /*8.0*/
         }
-        else if (parser == "minecraft:item_enchantment") { /*8.0*/
+        else if (V_parser == "minecraft:item_enchantment") { /*8.0*/
         }
-        else if (parser == "minecraft:entity_summon") { /*8.0*/
+        else if (V_parser == "minecraft:entity_summon") { /*8.0*/
         }
-        else if (parser == "minecraft:dimension") { /*8.0*/
+        else if (V_parser == "minecraft:dimension") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt_compound_tag") { /*8.0*/
+        else if (V_parser == "minecraft:nbt_compound_tag") { /*8.0*/
         }
-        else if (parser == "minecraft:time") { /*8.0*/
+        else if (V_parser == "minecraft:time") { /*8.0*/
         }
-        else if (parser == "minecraft:resource_or_tag") { /*8.0*/
+        else if (V_parser == "minecraft:resource_or_tag") { /*8.0*/
             const pdef::pc1_18_login_toServer::command_node::ExtraNodeData2::PropertiesMinecraftResourceOrTagOrMinecraftResource &v4 = *v2.properties_minecraft_resource_or_tag_or_minecraft_resource; /*8.5*/
             WRITE_OR_BAIL(writeUnsignedVarInt, (int)v4.registry.length());
             WRITE_OR_BAIL(writeString, v4.registry); /*registry: pstring*/ /*4.2*/
         }
-        else if (parser == "minecraft:resource") { /*8.0*/
+        else if (V_parser == "minecraft:resource") { /*8.0*/
             const pdef::pc1_18_login_toServer::command_node::ExtraNodeData2::PropertiesMinecraftResourceOrTagOrMinecraftResource &v4 = *v2.properties_minecraft_resource_or_tag_or_minecraft_resource; /*8.5*/
             WRITE_OR_BAIL(writeUnsignedVarInt, (int)v4.registry.length());
             WRITE_OR_BAIL(writeString, v4.registry); /*registry: pstring*/ /*4.2*/
         }
-        else if (parser == "minecraft:uuid") { /*8.0*/
+        else if (V_parser == "minecraft:uuid") { /*8.0*/
         }
-        if (flags.has_custom_suggestions == 1) { /*8.2*/
+        if (V_flags.has_custom_suggestions == 1) { /*8.2*/
           WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.suggestionType.length());
           WRITE_OR_BAIL(writeString, v2.suggestionType); /*suggestionType: pstring*/ /*4.2*/
         }
@@ -909,9 +909,9 @@ bool tags(pdef::Stream &stream, const pdef::pc1_18_login_toServer::tags &obj, bo
   }
   bool packet(pdef::Stream &stream, const pdef::pc1_18_login_toServer::packet &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::pc1_18_login_toServer::size::packet(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const pdef::pc1_18_login_toServer::packet::Name &name = obj.name; /*0.3*/
+    const pdef::pc1_18_login_toServer::packet::Name &V_name = obj.name; /*0.3*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)(int&)obj.name); /*7.1*/
-    switch (name) { /*8.0*/
+    switch (V_name) { /*8.0*/
       case pdef::pc1_18_login_toServer::packet::Name::LoginStart: { /*8.5*/
         pdef::pc1_18_login_toServer::encode::packet_login_start(stream, *obj.params_packet_login_start); /*packet_login_start*/ /*4.5*/
         break;
@@ -943,10 +943,10 @@ bool packet_login_plugin_response(pdef::Stream &stream, pdef::pc1_18_login_toSer
 bool packet(pdef::Stream &stream, pdef::pc1_18_login_toServer::packet &obj);
   bool slot(pdef::Stream &stream, pdef::pc1_18_login_toServer::slot &obj) {
     READ_OR_BAIL(readBool, (bool&)obj.present); /*0.5*/
-    bool &present = obj.present; /*0.6*/
-    if (present == false) { /*8.1*/
+    bool &V_present = obj.present; /*0.6*/
+    if (V_present == false) { /*8.1*/
     }
-    else if (present == true) { /*8.1*/
+    else if (V_present == true) { /*8.1*/
         READ_OR_BAIL(readUnsignedVarInt, obj.itemId); /*0.5*/
         READ_OR_BAIL(readByte, obj.itemCount); /*0.5*/
         READ_OR_BAIL(readByte, obj.nbtData); /*0.5*/
@@ -955,23 +955,23 @@ bool packet(pdef::Stream &stream, pdef::pc1_18_login_toServer::packet &obj);
   }
   bool particle(pdef::Stream &stream, pdef::pc1_18_login_toServer::particle &obj) {
     READ_OR_BAIL(readUnsignedVarInt, obj.particleId); /*0.5*/
-    int &particleId = obj.particleId; /*0.6*/
-    if (particleId == 2) { /*8.2*/
+    int &V_particleId = obj.particleId; /*0.6*/
+    if (V_particleId == 2) { /*8.2*/
          obj.data_2_or_3_or_24 = {}; pdef::pc1_18_login_toServer::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.4*/
         READ_OR_BAIL(readUnsignedVarInt, v2.blockState); /*0.5*/
     }
-    else if (particleId == 3) { /*8.2*/
+    else if (V_particleId == 3) { /*8.2*/
          obj.data_2_or_3_or_24 = {}; pdef::pc1_18_login_toServer::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.4*/
         READ_OR_BAIL(readUnsignedVarInt, v2.blockState); /*0.5*/
     }
-    else if (particleId == 14) { /*8.2*/
+    else if (V_particleId == 14) { /*8.2*/
          obj.data_14 = {}; pdef::pc1_18_login_toServer::particle::Data14 &v2 = *obj.data_14; /*8.4*/
         READ_OR_BAIL(readFloatBE, v2.red); /*0.5*/
         READ_OR_BAIL(readFloatBE, v2.green); /*0.5*/
         READ_OR_BAIL(readFloatBE, v2.blue); /*0.5*/
         READ_OR_BAIL(readFloatBE, v2.scale); /*0.5*/
     }
-    else if (particleId == 15) { /*8.2*/
+    else if (V_particleId == 15) { /*8.2*/
          obj.data_15 = {}; pdef::pc1_18_login_toServer::particle::Data15 &v2 = *obj.data_15; /*8.4*/
         READ_OR_BAIL(readFloatBE, v2.fromRed); /*0.5*/
         READ_OR_BAIL(readFloatBE, v2.fromGreen); /*0.5*/
@@ -981,15 +981,15 @@ bool packet(pdef::Stream &stream, pdef::pc1_18_login_toServer::packet &obj);
         READ_OR_BAIL(readFloatBE, v2.toGreen); /*0.5*/
         READ_OR_BAIL(readFloatBE, v2.toBlue); /*0.5*/
     }
-    else if (particleId == 24) { /*8.2*/
+    else if (V_particleId == 24) { /*8.2*/
          obj.data_2_or_3_or_24 = {}; pdef::pc1_18_login_toServer::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.4*/
         READ_OR_BAIL(readUnsignedVarInt, v2.blockState); /*0.5*/
     }
-    else if (particleId == 35) { /*8.2*/
+    else if (V_particleId == 35) { /*8.2*/
          obj.data_35 = {}; pdef::pc1_18_login_toServer::particle::Data35 &v2 = *obj.data_35; /*8.4*/
         READ_OR_BAIL(readByte, v2.item); /*0.5*/
     }
-    else if (particleId == 36) { /*8.2*/
+    else if (V_particleId == 36) { /*8.2*/
          obj.data_36 = {}; pdef::pc1_18_login_toServer::particle::Data36 &v2 = *obj.data_36; /*8.4*/
         uint64_t origin_val;
         READ_OR_BAIL(readULongBE, origin_val);
@@ -998,15 +998,15 @@ bool packet(pdef::Stream &stream, pdef::pc1_18_login_toServer::packet &obj);
         v2.origin.y = origin_val >> 52 & 12; /*origin: bitfield*/ /*4.3*/
         int positionType_strlen; READ_OR_BAIL(readUnsignedVarInt, positionType_strlen);
         if (!stream.readString(v2.positionType, positionType_strlen)) return false; /*positionType: pstring*/ /*4.3*/
-        std::string &positionType = v2.positionType; /*4.8*/
-        if (positionType == "minecraft:block") { /*8.0*/
+        std::string &V_positionType = v2.positionType; /*4.8*/
+        if (V_positionType == "minecraft:block") { /*8.0*/
           uint64_t destination_position_val;
           READ_OR_BAIL(readULongBE, destination_position_val);
           v2.destination_position.x = destination_position_val >> 0 & 26;
           v2.destination_position.z = destination_position_val >> 26 & 26;
           v2.destination_position.y = destination_position_val >> 52 & 12; /*destination_position: bitfield*/ /*4.3*/
         }
-        else if (positionType == "minecraft:entity") { /*8.0*/
+        else if (V_positionType == "minecraft:entity") { /*8.0*/
           READ_OR_BAIL(readUnsignedVarInt, v2.destination_varint); /*0.5*/
         }
         READ_OR_BAIL(readUnsignedVarInt, v2.ticks); /*0.5*/
@@ -1018,7 +1018,7 @@ bool packet(pdef::Stream &stream, pdef::pc1_18_login_toServer::packet &obj);
     if (!stream.readString(obj.group, group_strlen)) return false; /*group: pstring*/ /*4.3*/
     int ingredient_len; READ_OR_BAIL(readUnsignedVarInt, ingredient_len); /*1.5*/
     obj.ingredient.resize(ingredient_len); /*1.6*/
-    for (int i = 0; i < ingredient_len; i++) {
+    for (int i = 0; i < ingredient_len; i++) { /*3.3*/
       auto &v2 = obj.ingredient[i]; /*3.4*/
       READ_OR_BAIL(readByte, v2); /*0.5*/
     }
@@ -1032,7 +1032,7 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_login_toServer::tags &obj) {
     if (!stream.readString(obj.tagName, tagName_strlen)) return false; /*tagName: pstring*/ /*4.3*/
     int entries_len; READ_OR_BAIL(readUnsignedVarInt, entries_len); /*1.5*/
     obj.entries.resize(entries_len); /*1.6*/
-    for (int i = 0; i < entries_len; i++) {
+    for (int i = 0; i < entries_len; i++) { /*3.3*/
       auto &v2 = obj.entries[i]; /*3.4*/
       READ_OR_BAIL(readUnsignedVarInt, v2); /*0.5*/
     }
@@ -1056,194 +1056,194 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_login_toServer::tags &obj) {
     obj.flags.has_redirect_node = flags_val >> 4 & 1;
     obj.flags.has_command = flags_val >> 5 & 1;
     obj.flags.command_node_type = flags_val >> 6 & 2; /*flags: bitfield*/ /*4.3*/
-    pdef::pc1_18_login_toServer::command_node::flags_t &flags = obj.flags; /*4.8*/
+    pdef::pc1_18_login_toServer::command_node::flags_t &V_flags = obj.flags; /*4.8*/
     int children_len; READ_OR_BAIL(readUnsignedVarInt, children_len); /*1.5*/
     obj.children.resize(children_len); /*1.6*/
-    for (int i = 0; i < children_len; i++) {
+    for (int i = 0; i < children_len; i++) { /*3.3*/
       auto &v2 = obj.children[i]; /*3.4*/
       READ_OR_BAIL(readUnsignedVarInt, v2); /*0.5*/
     }
-    if (flags.has_redirect_node == 1) { /*8.2*/
+    if (V_flags.has_redirect_node == 1) { /*8.2*/
       READ_OR_BAIL(readUnsignedVarInt, obj.redirectNode); /*0.5*/
     }
-    if (flags.command_node_type == 0) { /*8.2*/
+    if (V_flags.command_node_type == 0) { /*8.2*/
     }
-    else if (flags.command_node_type == 1) { /*8.2*/
+    else if (V_flags.command_node_type == 1) { /*8.2*/
          obj.extraNodeData_1 = {}; pdef::pc1_18_login_toServer::command_node::ExtraNodeData1 &v2 = *obj.extraNodeData_1; /*8.4*/
         int name_strlen; READ_OR_BAIL(readUnsignedVarInt, name_strlen);
         if (!stream.readString(v2.name, name_strlen)) return false; /*name: pstring*/ /*4.3*/
     }
-    else if (flags.command_node_type == 2) { /*8.2*/
+    else if (V_flags.command_node_type == 2) { /*8.2*/
          obj.extraNodeData_2 = {}; pdef::pc1_18_login_toServer::command_node::ExtraNodeData2 &v2 = *obj.extraNodeData_2; /*8.4*/
         int name_strlen; READ_OR_BAIL(readUnsignedVarInt, name_strlen);
         if (!stream.readString(v2.name, name_strlen)) return false; /*name: pstring*/ /*4.3*/
         int parser_strlen; READ_OR_BAIL(readUnsignedVarInt, parser_strlen);
         if (!stream.readString(v2.parser, parser_strlen)) return false; /*parser: pstring*/ /*4.3*/
-        std::string &parser = v2.parser; /*4.8*/
-        if (parser == "brigadier:bool") { /*8.0*/
+        std::string &V_parser = v2.parser; /*4.8*/
+        if (V_parser == "brigadier:bool") { /*8.0*/
         }
-        else if (parser == "brigadier:float") { /*8.0*/
+        else if (V_parser == "brigadier:float") { /*8.0*/
              v2.properties_brigadier_float = {}; pdef::pc1_18_login_toServer::command_node::ExtraNodeData2::PropertiesBrigadierFloat &v4 = *v2.properties_brigadier_float; /*8.4*/
             uint8_t flags_val;
             READ_OR_BAIL(readUByte, flags_val);
             v4.flags.unused = flags_val >> 0 & 6;
             v4.flags.max_present = flags_val >> 6 & 1;
             v4.flags.min_present = flags_val >> 7 & 1; /*flags: bitfield*/ /*4.3*/
-            pdef::pc1_18_login_toServer::command_node::ExtraNodeData2::PropertiesBrigadierFloat::flags_t &flags = v4.flags; /*4.8*/
-            if (flags.min_present == 1) { /*8.2*/
+            pdef::pc1_18_login_toServer::command_node::ExtraNodeData2::PropertiesBrigadierFloat::flags_t &V_flags = v4.flags; /*4.8*/
+            if (V_flags.min_present == 1) { /*8.2*/
               READ_OR_BAIL(readFloatBE, v4.min); /*0.5*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               READ_OR_BAIL(readFloatBE, v4.max); /*0.5*/
             }
         }
-        else if (parser == "brigadier:double") { /*8.0*/
+        else if (V_parser == "brigadier:double") { /*8.0*/
              v2.properties_brigadier_double = {}; pdef::pc1_18_login_toServer::command_node::ExtraNodeData2::PropertiesBrigadierDouble &v4 = *v2.properties_brigadier_double; /*8.4*/
             uint8_t flags_val;
             READ_OR_BAIL(readUByte, flags_val);
             v4.flags.unused = flags_val >> 0 & 6;
             v4.flags.max_present = flags_val >> 6 & 1;
             v4.flags.min_present = flags_val >> 7 & 1; /*flags: bitfield*/ /*4.3*/
-            pdef::pc1_18_login_toServer::command_node::ExtraNodeData2::PropertiesBrigadierDouble::flags_t &flags = v4.flags; /*4.8*/
-            if (flags.min_present == 1) { /*8.2*/
+            pdef::pc1_18_login_toServer::command_node::ExtraNodeData2::PropertiesBrigadierDouble::flags_t &V_flags = v4.flags; /*4.8*/
+            if (V_flags.min_present == 1) { /*8.2*/
               READ_OR_BAIL(readDoubleBE, v4.min); /*0.5*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               READ_OR_BAIL(readDoubleBE, v4.max); /*0.5*/
             }
         }
-        else if (parser == "brigadier:integer") { /*8.0*/
+        else if (V_parser == "brigadier:integer") { /*8.0*/
              v2.properties_brigadier_integer = {}; pdef::pc1_18_login_toServer::command_node::ExtraNodeData2::PropertiesBrigadierInteger &v4 = *v2.properties_brigadier_integer; /*8.4*/
             uint8_t flags_val;
             READ_OR_BAIL(readUByte, flags_val);
             v4.flags.unused = flags_val >> 0 & 6;
             v4.flags.max_present = flags_val >> 6 & 1;
             v4.flags.min_present = flags_val >> 7 & 1; /*flags: bitfield*/ /*4.3*/
-            pdef::pc1_18_login_toServer::command_node::ExtraNodeData2::PropertiesBrigadierInteger::flags_t &flags = v4.flags; /*4.8*/
-            if (flags.min_present == 1) { /*8.2*/
+            pdef::pc1_18_login_toServer::command_node::ExtraNodeData2::PropertiesBrigadierInteger::flags_t &V_flags = v4.flags; /*4.8*/
+            if (V_flags.min_present == 1) { /*8.2*/
               READ_OR_BAIL(readIntBE, v4.min); /*0.5*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               READ_OR_BAIL(readIntBE, v4.max); /*0.5*/
             }
         }
-        else if (parser == "brigadier:long") { /*8.0*/
+        else if (V_parser == "brigadier:long") { /*8.0*/
              v2.properties_brigadier_long = {}; pdef::pc1_18_login_toServer::command_node::ExtraNodeData2::PropertiesBrigadierLong &v4 = *v2.properties_brigadier_long; /*8.4*/
             uint8_t flags_val;
             READ_OR_BAIL(readUByte, flags_val);
             v4.flags.unused = flags_val >> 0 & 6;
             v4.flags.max_present = flags_val >> 6 & 1;
             v4.flags.min_present = flags_val >> 7 & 1; /*flags: bitfield*/ /*4.3*/
-            pdef::pc1_18_login_toServer::command_node::ExtraNodeData2::PropertiesBrigadierLong::flags_t &flags = v4.flags; /*4.8*/
-            if (flags.min_present == 1) { /*8.2*/
+            pdef::pc1_18_login_toServer::command_node::ExtraNodeData2::PropertiesBrigadierLong::flags_t &V_flags = v4.flags; /*4.8*/
+            if (V_flags.min_present == 1) { /*8.2*/
               READ_OR_BAIL(readLongBE, v4.min); /*0.5*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               READ_OR_BAIL(readLongBE, v4.max); /*0.5*/
             }
         }
-        else if (parser == "brigadier:string") { /*8.0*/
+        else if (V_parser == "brigadier:string") { /*8.0*/
         }
-        else if (parser == "minecraft:entity") { /*8.0*/
+        else if (V_parser == "minecraft:entity") { /*8.0*/
           uint8_t properties_minecraft_entity_val;
           READ_OR_BAIL(readUByte, properties_minecraft_entity_val);
           v2.properties_minecraft_entity.unused = properties_minecraft_entity_val >> 0 & 6;
           v2.properties_minecraft_entity.onlyAllowPlayers = properties_minecraft_entity_val >> 6 & 1;
           v2.properties_minecraft_entity.onlyAllowEntities = properties_minecraft_entity_val >> 7 & 1; /*properties_minecraft_entity: bitfield*/ /*4.3*/
         }
-        else if (parser == "minecraft:game_profile") { /*8.0*/
+        else if (V_parser == "minecraft:game_profile") { /*8.0*/
         }
-        else if (parser == "minecraft:block_pos") { /*8.0*/
+        else if (V_parser == "minecraft:block_pos") { /*8.0*/
         }
-        else if (parser == "minecraft:column_pos") { /*8.0*/
+        else if (V_parser == "minecraft:column_pos") { /*8.0*/
         }
-        else if (parser == "minecraft:vec3") { /*8.0*/
+        else if (V_parser == "minecraft:vec3") { /*8.0*/
         }
-        else if (parser == "minecraft:vec2") { /*8.0*/
+        else if (V_parser == "minecraft:vec2") { /*8.0*/
         }
-        else if (parser == "minecraft:block_state") { /*8.0*/
+        else if (V_parser == "minecraft:block_state") { /*8.0*/
         }
-        else if (parser == "minecraft:block_predicate") { /*8.0*/
+        else if (V_parser == "minecraft:block_predicate") { /*8.0*/
         }
-        else if (parser == "minecraft:item_stack") { /*8.0*/
+        else if (V_parser == "minecraft:item_stack") { /*8.0*/
         }
-        else if (parser == "minecraft:item_predicate") { /*8.0*/
+        else if (V_parser == "minecraft:item_predicate") { /*8.0*/
         }
-        else if (parser == "minecraft:color") { /*8.0*/
+        else if (V_parser == "minecraft:color") { /*8.0*/
         }
-        else if (parser == "minecraft:component") { /*8.0*/
+        else if (V_parser == "minecraft:component") { /*8.0*/
         }
-        else if (parser == "minecraft:message") { /*8.0*/
+        else if (V_parser == "minecraft:message") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt") { /*8.0*/
+        else if (V_parser == "minecraft:nbt") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt_path") { /*8.0*/
+        else if (V_parser == "minecraft:nbt_path") { /*8.0*/
         }
-        else if (parser == "minecraft:objective") { /*8.0*/
+        else if (V_parser == "minecraft:objective") { /*8.0*/
         }
-        else if (parser == "minecraft:objective_criteria") { /*8.0*/
+        else if (V_parser == "minecraft:objective_criteria") { /*8.0*/
         }
-        else if (parser == "minecraft:operation") { /*8.0*/
+        else if (V_parser == "minecraft:operation") { /*8.0*/
         }
-        else if (parser == "minecraft:particle") { /*8.0*/
+        else if (V_parser == "minecraft:particle") { /*8.0*/
         }
-        else if (parser == "minecraft:angle") { /*8.0*/
+        else if (V_parser == "minecraft:angle") { /*8.0*/
         }
-        else if (parser == "minecraft:rotation") { /*8.0*/
+        else if (V_parser == "minecraft:rotation") { /*8.0*/
         }
-        else if (parser == "minecraft:scoreboard_slot") { /*8.0*/
+        else if (V_parser == "minecraft:scoreboard_slot") { /*8.0*/
         }
-        else if (parser == "minecraft:score_holder") { /*8.0*/
+        else if (V_parser == "minecraft:score_holder") { /*8.0*/
           uint8_t properties_minecraft_score_holder_val;
           READ_OR_BAIL(readUByte, properties_minecraft_score_holder_val);
           v2.properties_minecraft_score_holder.unused = properties_minecraft_score_holder_val >> 0 & 7;
           v2.properties_minecraft_score_holder.allowMultiple = properties_minecraft_score_holder_val >> 7 & 1; /*properties_minecraft_score_holder: bitfield*/ /*4.3*/
         }
-        else if (parser == "minecraft:swizzle") { /*8.0*/
+        else if (V_parser == "minecraft:swizzle") { /*8.0*/
         }
-        else if (parser == "minecraft:team") { /*8.0*/
+        else if (V_parser == "minecraft:team") { /*8.0*/
         }
-        else if (parser == "minecraft:item_slot") { /*8.0*/
+        else if (V_parser == "minecraft:item_slot") { /*8.0*/
         }
-        else if (parser == "minecraft:resource_location") { /*8.0*/
+        else if (V_parser == "minecraft:resource_location") { /*8.0*/
         }
-        else if (parser == "minecraft:mob_effect") { /*8.0*/
+        else if (V_parser == "minecraft:mob_effect") { /*8.0*/
         }
-        else if (parser == "minecraft:function") { /*8.0*/
+        else if (V_parser == "minecraft:function") { /*8.0*/
         }
-        else if (parser == "minecraft:entity_anchor") { /*8.0*/
+        else if (V_parser == "minecraft:entity_anchor") { /*8.0*/
         }
-        else if (parser == "minecraft:range") { /*8.0*/
+        else if (V_parser == "minecraft:range") { /*8.0*/
              v2.properties_minecraft_range = {}; pdef::pc1_18_login_toServer::command_node::ExtraNodeData2::PropertiesMinecraftRange &v4 = *v2.properties_minecraft_range; /*8.4*/
             READ_OR_BAIL(readBool, (bool&)v4.allowDecimals); /*0.5*/
         }
-        else if (parser == "minecraft:int_range") { /*8.0*/
+        else if (V_parser == "minecraft:int_range") { /*8.0*/
         }
-        else if (parser == "minecraft:float_range") { /*8.0*/
+        else if (V_parser == "minecraft:float_range") { /*8.0*/
         }
-        else if (parser == "minecraft:item_enchantment") { /*8.0*/
+        else if (V_parser == "minecraft:item_enchantment") { /*8.0*/
         }
-        else if (parser == "minecraft:entity_summon") { /*8.0*/
+        else if (V_parser == "minecraft:entity_summon") { /*8.0*/
         }
-        else if (parser == "minecraft:dimension") { /*8.0*/
+        else if (V_parser == "minecraft:dimension") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt_compound_tag") { /*8.0*/
+        else if (V_parser == "minecraft:nbt_compound_tag") { /*8.0*/
         }
-        else if (parser == "minecraft:time") { /*8.0*/
+        else if (V_parser == "minecraft:time") { /*8.0*/
         }
-        else if (parser == "minecraft:resource_or_tag") { /*8.0*/
+        else if (V_parser == "minecraft:resource_or_tag") { /*8.0*/
              v2.properties_minecraft_resource_or_tag_or_minecraft_resource = {}; pdef::pc1_18_login_toServer::command_node::ExtraNodeData2::PropertiesMinecraftResourceOrTagOrMinecraftResource &v4 = *v2.properties_minecraft_resource_or_tag_or_minecraft_resource; /*8.4*/
             int registry_strlen; READ_OR_BAIL(readUnsignedVarInt, registry_strlen);
             if (!stream.readString(v4.registry, registry_strlen)) return false; /*registry: pstring*/ /*4.3*/
         }
-        else if (parser == "minecraft:resource") { /*8.0*/
+        else if (V_parser == "minecraft:resource") { /*8.0*/
              v2.properties_minecraft_resource_or_tag_or_minecraft_resource = {}; pdef::pc1_18_login_toServer::command_node::ExtraNodeData2::PropertiesMinecraftResourceOrTagOrMinecraftResource &v4 = *v2.properties_minecraft_resource_or_tag_or_minecraft_resource; /*8.4*/
             int registry_strlen; READ_OR_BAIL(readUnsignedVarInt, registry_strlen);
             if (!stream.readString(v4.registry, registry_strlen)) return false; /*registry: pstring*/ /*4.3*/
         }
-        else if (parser == "minecraft:uuid") { /*8.0*/
+        else if (V_parser == "minecraft:uuid") { /*8.0*/
         }
-        if (flags.has_custom_suggestions == 1) { /*8.2*/
+        if (V_flags.has_custom_suggestions == 1) { /*8.2*/
           int suggestionType_strlen; READ_OR_BAIL(readUnsignedVarInt, suggestionType_strlen);
           if (!stream.readString(v2.suggestionType, suggestionType_strlen)) return false; /*suggestionType: pstring*/ /*4.3*/
         }
@@ -1267,8 +1267,8 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_login_toServer::tags &obj) {
   }
   bool packet(pdef::Stream &stream, pdef::pc1_18_login_toServer::packet &obj) {
     READ_OR_BAIL(readUnsignedVarInt, (int&)obj.name); /*7.2*/
-    const pdef::pc1_18_login_toServer::packet::Name &name = obj.name; /*0.7*/
-    switch (name) { /*8.0*/
+    const pdef::pc1_18_login_toServer::packet::Name &V_name = obj.name; /*0.7*/
+    switch (V_name) { /*8.0*/
       case pdef::pc1_18_login_toServer::packet::Name::LoginStart: { /*8.5*/
         obj.params_packet_login_start = {}; pdef::pc1_18_login_toServer::decode::packet_login_start(stream, *obj.params_packet_login_start); /*obj*/ /*4.6*/
         break;

--- a/examples/mcpc-protocol/build/pc1_18_play_toClient.h
+++ b/examples/mcpc-protocol/build/pc1_18_play_toClient.h
@@ -1542,10 +1542,10 @@ size_t packet_simulation_distance(pdef::Stream &stream, const pdef::pc1_18_play_
 size_t packet(pdef::Stream &stream, const pdef::pc1_18_play_toClient::packet &obj);
   size_t slot(pdef::Stream &stream, const pdef::pc1_18_play_toClient::slot &obj) {
     size_t len = 0;
-    const bool &present = obj.present; /*0.1*/
-    if (present == false) { /*8.1*/
+    const bool &V_present = obj.present; /*0.1*/
+    if (V_present == false) { /*8.1*/
     }
-    else if (present == true) { /*8.1*/
+    else if (V_present == true) { /*8.1*/
         len += stream.sizeOfVarInt(obj.itemId); /*0.2*/
         len += 1; /*0.2*/
         len += 1; /*0.2*/
@@ -1554,23 +1554,23 @@ size_t packet(pdef::Stream &stream, const pdef::pc1_18_play_toClient::packet &ob
   }
   size_t particle(pdef::Stream &stream, const pdef::pc1_18_play_toClient::particle &obj) {
     size_t len = 0;
-    const int &particleId = obj.particleId; /*0.1*/
-    if (particleId == 2) { /*8.2*/
+    const int &V_particleId = obj.particleId; /*0.1*/
+    if (V_particleId == 2) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_2_or_3_or_24); const pdef::pc1_18_play_toClient::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.6*/
         len += stream.sizeOfVarInt(v2.blockState); /*0.2*/
     }
-    else if (particleId == 3) { /*8.2*/
+    else if (V_particleId == 3) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_2_or_3_or_24); const pdef::pc1_18_play_toClient::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.6*/
         len += stream.sizeOfVarInt(v2.blockState); /*0.2*/
     }
-    else if (particleId == 14) { /*8.2*/
+    else if (V_particleId == 14) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_14); const pdef::pc1_18_play_toClient::particle::Data14 &v2 = *obj.data_14; /*8.6*/
         len += 4; /*0.2*/
         len += 4; /*0.2*/
         len += 4; /*0.2*/
         len += 4; /*0.2*/
     }
-    else if (particleId == 15) { /*8.2*/
+    else if (V_particleId == 15) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_15); const pdef::pc1_18_play_toClient::particle::Data15 &v2 = *obj.data_15; /*8.6*/
         len += 4; /*0.2*/
         len += 4; /*0.2*/
@@ -1580,24 +1580,24 @@ size_t packet(pdef::Stream &stream, const pdef::pc1_18_play_toClient::packet &ob
         len += 4; /*0.2*/
         len += 4; /*0.2*/
     }
-    else if (particleId == 24) { /*8.2*/
+    else if (V_particleId == 24) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_2_or_3_or_24); const pdef::pc1_18_play_toClient::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.6*/
         len += stream.sizeOfVarInt(v2.blockState); /*0.2*/
     }
-    else if (particleId == 35) { /*8.2*/
+    else if (V_particleId == 35) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_35); const pdef::pc1_18_play_toClient::particle::Data35 &v2 = *obj.data_35; /*8.6*/
         len += 1; /*0.2*/
     }
-    else if (particleId == 36) { /*8.2*/
+    else if (V_particleId == 36) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_36); const pdef::pc1_18_play_toClient::particle::Data36 &v2 = *obj.data_36; /*8.6*/
         len += 1; /*origin: bitfield*/ /*4.1*/
         len += stream.sizeOfVarInt(v2.positionType.length());
         len += v2.positionType.length(); /*positionType^: pstring*/ /*4.1*/
-        const std::string &positionType = v2.positionType; /*4.7*/
-        if (positionType == "minecraft:block") { /*8.0*/
+        const std::string &V_positionType = v2.positionType; /*4.7*/
+        if (V_positionType == "minecraft:block") { /*8.0*/
           len += 1; /*destination: bitfield*/ /*4.1*/
         }
-        else if (positionType == "minecraft:entity") { /*8.0*/
+        else if (V_positionType == "minecraft:entity") { /*8.0*/
           len += stream.sizeOfVarInt(v2.destination_varint); /*0.2*/
         }
         len += stream.sizeOfVarInt(v2.ticks); /*0.2*/
@@ -1609,7 +1609,7 @@ size_t packet(pdef::Stream &stream, const pdef::pc1_18_play_toClient::packet &ob
     len += stream.sizeOfVarInt(obj.group.length());
     len += obj.group.length(); /*group: pstring*/ /*4.1*/
     len += stream.sizeOfVarInt(obj.ingredient.size()); /*1.3*/
-    for (const auto &v2 : obj.ingredient) {
+    for (const auto &v2 : obj.ingredient) { /*3.2*/
       len += 1; /*0.2*/
     }
     len += 1; /*0.2*/
@@ -1622,7 +1622,7 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj) {
     len += stream.sizeOfVarInt(obj.tagName.length());
     len += obj.tagName.length(); /*tagName: pstring*/ /*4.1*/
     len += stream.sizeOfVarInt(obj.entries.size()); /*1.3*/
-    for (const auto &v2 : obj.entries) {
+    for (const auto &v2 : obj.entries) { /*3.2*/
       len += stream.sizeOfVarInt(v2); /*0.2*/
     }
   PDEF_SIZE_DBG; return len;
@@ -1638,169 +1638,169 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj) {
   size_t command_node(pdef::Stream &stream, const pdef::pc1_18_play_toClient::command_node &obj) {
     size_t len = 0;
     len += 1; /*flags^: bitfield*/ /*4.1*/
-    const pdef::pc1_18_play_toClient::command_node::flags_t &flags = obj.flags; /*4.7*/
+    const pdef::pc1_18_play_toClient::command_node::flags_t &V_flags = obj.flags; /*4.7*/
     len += stream.sizeOfVarInt(obj.children.size()); /*1.3*/
-    for (const auto &v2 : obj.children) {
+    for (const auto &v2 : obj.children) { /*3.2*/
       len += stream.sizeOfVarInt(v2); /*0.2*/
     }
-    if (flags.has_redirect_node == 1) { /*8.2*/
+    if (V_flags.has_redirect_node == 1) { /*8.2*/
       len += stream.sizeOfVarInt(obj.redirectNode); /*0.2*/
     }
-    if (flags.command_node_type == 0) { /*8.2*/
+    if (V_flags.command_node_type == 0) { /*8.2*/
     }
-    else if (flags.command_node_type == 1) { /*8.2*/
+    else if (V_flags.command_node_type == 1) { /*8.2*/
         EXPECT_OR_BAIL(obj.extraNodeData_1); const pdef::pc1_18_play_toClient::command_node::ExtraNodeData1 &v2 = *obj.extraNodeData_1; /*8.6*/
         len += stream.sizeOfVarInt(v2.name.length());
         len += v2.name.length(); /*name: pstring*/ /*4.1*/
     }
-    else if (flags.command_node_type == 2) { /*8.2*/
+    else if (V_flags.command_node_type == 2) { /*8.2*/
         EXPECT_OR_BAIL(obj.extraNodeData_2); const pdef::pc1_18_play_toClient::command_node::ExtraNodeData2 &v2 = *obj.extraNodeData_2; /*8.6*/
         len += stream.sizeOfVarInt(v2.name.length());
         len += v2.name.length(); /*name: pstring*/ /*4.1*/
         len += stream.sizeOfVarInt(v2.parser.length());
         len += v2.parser.length(); /*parser^: pstring*/ /*4.1*/
-        const std::string &parser = v2.parser; /*4.7*/
-        if (parser == "brigadier:bool") { /*8.0*/
+        const std::string &V_parser = v2.parser; /*4.7*/
+        if (V_parser == "brigadier:bool") { /*8.0*/
         }
-        else if (parser == "brigadier:float") { /*8.0*/
+        else if (V_parser == "brigadier:float") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_brigadier_float); const pdef::pc1_18_play_toClient::command_node::ExtraNodeData2::PropertiesBrigadierFloat &v4 = *v2.properties_brigadier_float; /*8.6*/
             len += 1; /*flags^: bitfield*/ /*4.1*/
-            const pdef::pc1_18_play_toClient::command_node::ExtraNodeData2::PropertiesBrigadierFloat::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_play_toClient::command_node::ExtraNodeData2::PropertiesBrigadierFloat::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               len += 4; /*0.2*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               len += 4; /*0.2*/
             }
         }
-        else if (parser == "brigadier:double") { /*8.0*/
+        else if (V_parser == "brigadier:double") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_brigadier_double); const pdef::pc1_18_play_toClient::command_node::ExtraNodeData2::PropertiesBrigadierDouble &v4 = *v2.properties_brigadier_double; /*8.6*/
             len += 1; /*flags^: bitfield*/ /*4.1*/
-            const pdef::pc1_18_play_toClient::command_node::ExtraNodeData2::PropertiesBrigadierDouble::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_play_toClient::command_node::ExtraNodeData2::PropertiesBrigadierDouble::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               len += 8; /*0.2*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               len += 8; /*0.2*/
             }
         }
-        else if (parser == "brigadier:integer") { /*8.0*/
+        else if (V_parser == "brigadier:integer") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_brigadier_integer); const pdef::pc1_18_play_toClient::command_node::ExtraNodeData2::PropertiesBrigadierInteger &v4 = *v2.properties_brigadier_integer; /*8.6*/
             len += 1; /*flags^: bitfield*/ /*4.1*/
-            const pdef::pc1_18_play_toClient::command_node::ExtraNodeData2::PropertiesBrigadierInteger::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_play_toClient::command_node::ExtraNodeData2::PropertiesBrigadierInteger::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               len += 4; /*0.2*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               len += 4; /*0.2*/
             }
         }
-        else if (parser == "brigadier:long") { /*8.0*/
+        else if (V_parser == "brigadier:long") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_brigadier_long); const pdef::pc1_18_play_toClient::command_node::ExtraNodeData2::PropertiesBrigadierLong &v4 = *v2.properties_brigadier_long; /*8.6*/
             len += 1; /*flags^: bitfield*/ /*4.1*/
-            const pdef::pc1_18_play_toClient::command_node::ExtraNodeData2::PropertiesBrigadierLong::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_play_toClient::command_node::ExtraNodeData2::PropertiesBrigadierLong::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               len += 8; /*0.2*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               len += 8; /*0.2*/
             }
         }
-        else if (parser == "brigadier:string") { /*8.0*/
+        else if (V_parser == "brigadier:string") { /*8.0*/
         }
-        else if (parser == "minecraft:entity") { /*8.0*/
+        else if (V_parser == "minecraft:entity") { /*8.0*/
           len += 1; /*properties: bitfield*/ /*4.1*/
         }
-        else if (parser == "minecraft:game_profile") { /*8.0*/
+        else if (V_parser == "minecraft:game_profile") { /*8.0*/
         }
-        else if (parser == "minecraft:block_pos") { /*8.0*/
+        else if (V_parser == "minecraft:block_pos") { /*8.0*/
         }
-        else if (parser == "minecraft:column_pos") { /*8.0*/
+        else if (V_parser == "minecraft:column_pos") { /*8.0*/
         }
-        else if (parser == "minecraft:vec3") { /*8.0*/
+        else if (V_parser == "minecraft:vec3") { /*8.0*/
         }
-        else if (parser == "minecraft:vec2") { /*8.0*/
+        else if (V_parser == "minecraft:vec2") { /*8.0*/
         }
-        else if (parser == "minecraft:block_state") { /*8.0*/
+        else if (V_parser == "minecraft:block_state") { /*8.0*/
         }
-        else if (parser == "minecraft:block_predicate") { /*8.0*/
+        else if (V_parser == "minecraft:block_predicate") { /*8.0*/
         }
-        else if (parser == "minecraft:item_stack") { /*8.0*/
+        else if (V_parser == "minecraft:item_stack") { /*8.0*/
         }
-        else if (parser == "minecraft:item_predicate") { /*8.0*/
+        else if (V_parser == "minecraft:item_predicate") { /*8.0*/
         }
-        else if (parser == "minecraft:color") { /*8.0*/
+        else if (V_parser == "minecraft:color") { /*8.0*/
         }
-        else if (parser == "minecraft:component") { /*8.0*/
+        else if (V_parser == "minecraft:component") { /*8.0*/
         }
-        else if (parser == "minecraft:message") { /*8.0*/
+        else if (V_parser == "minecraft:message") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt") { /*8.0*/
+        else if (V_parser == "minecraft:nbt") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt_path") { /*8.0*/
+        else if (V_parser == "minecraft:nbt_path") { /*8.0*/
         }
-        else if (parser == "minecraft:objective") { /*8.0*/
+        else if (V_parser == "minecraft:objective") { /*8.0*/
         }
-        else if (parser == "minecraft:objective_criteria") { /*8.0*/
+        else if (V_parser == "minecraft:objective_criteria") { /*8.0*/
         }
-        else if (parser == "minecraft:operation") { /*8.0*/
+        else if (V_parser == "minecraft:operation") { /*8.0*/
         }
-        else if (parser == "minecraft:particle") { /*8.0*/
+        else if (V_parser == "minecraft:particle") { /*8.0*/
         }
-        else if (parser == "minecraft:angle") { /*8.0*/
+        else if (V_parser == "minecraft:angle") { /*8.0*/
         }
-        else if (parser == "minecraft:rotation") { /*8.0*/
+        else if (V_parser == "minecraft:rotation") { /*8.0*/
         }
-        else if (parser == "minecraft:scoreboard_slot") { /*8.0*/
+        else if (V_parser == "minecraft:scoreboard_slot") { /*8.0*/
         }
-        else if (parser == "minecraft:score_holder") { /*8.0*/
+        else if (V_parser == "minecraft:score_holder") { /*8.0*/
           len += 1; /*properties: bitfield*/ /*4.1*/
         }
-        else if (parser == "minecraft:swizzle") { /*8.0*/
+        else if (V_parser == "minecraft:swizzle") { /*8.0*/
         }
-        else if (parser == "minecraft:team") { /*8.0*/
+        else if (V_parser == "minecraft:team") { /*8.0*/
         }
-        else if (parser == "minecraft:item_slot") { /*8.0*/
+        else if (V_parser == "minecraft:item_slot") { /*8.0*/
         }
-        else if (parser == "minecraft:resource_location") { /*8.0*/
+        else if (V_parser == "minecraft:resource_location") { /*8.0*/
         }
-        else if (parser == "minecraft:mob_effect") { /*8.0*/
+        else if (V_parser == "minecraft:mob_effect") { /*8.0*/
         }
-        else if (parser == "minecraft:function") { /*8.0*/
+        else if (V_parser == "minecraft:function") { /*8.0*/
         }
-        else if (parser == "minecraft:entity_anchor") { /*8.0*/
+        else if (V_parser == "minecraft:entity_anchor") { /*8.0*/
         }
-        else if (parser == "minecraft:range") { /*8.0*/
+        else if (V_parser == "minecraft:range") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_minecraft_range); const pdef::pc1_18_play_toClient::command_node::ExtraNodeData2::PropertiesMinecraftRange &v4 = *v2.properties_minecraft_range; /*8.6*/
             len += 1; /*0.2*/
         }
-        else if (parser == "minecraft:int_range") { /*8.0*/
+        else if (V_parser == "minecraft:int_range") { /*8.0*/
         }
-        else if (parser == "minecraft:float_range") { /*8.0*/
+        else if (V_parser == "minecraft:float_range") { /*8.0*/
         }
-        else if (parser == "minecraft:item_enchantment") { /*8.0*/
+        else if (V_parser == "minecraft:item_enchantment") { /*8.0*/
         }
-        else if (parser == "minecraft:entity_summon") { /*8.0*/
+        else if (V_parser == "minecraft:entity_summon") { /*8.0*/
         }
-        else if (parser == "minecraft:dimension") { /*8.0*/
+        else if (V_parser == "minecraft:dimension") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt_compound_tag") { /*8.0*/
+        else if (V_parser == "minecraft:nbt_compound_tag") { /*8.0*/
         }
-        else if (parser == "minecraft:time") { /*8.0*/
+        else if (V_parser == "minecraft:time") { /*8.0*/
         }
-        else if (parser == "minecraft:resource_or_tag") { /*8.0*/
+        else if (V_parser == "minecraft:resource_or_tag") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_minecraft_resource_or_tag_or_minecraft_resource); const pdef::pc1_18_play_toClient::command_node::ExtraNodeData2::PropertiesMinecraftResourceOrTagOrMinecraftResource &v4 = *v2.properties_minecraft_resource_or_tag_or_minecraft_resource; /*8.6*/
             len += stream.sizeOfVarInt(v4.registry.length());
             len += v4.registry.length(); /*registry: pstring*/ /*4.1*/
         }
-        else if (parser == "minecraft:resource") { /*8.0*/
+        else if (V_parser == "minecraft:resource") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_minecraft_resource_or_tag_or_minecraft_resource); const pdef::pc1_18_play_toClient::command_node::ExtraNodeData2::PropertiesMinecraftResourceOrTagOrMinecraftResource &v4 = *v2.properties_minecraft_resource_or_tag_or_minecraft_resource; /*8.6*/
             len += stream.sizeOfVarInt(v4.registry.length());
             len += v4.registry.length(); /*registry: pstring*/ /*4.1*/
         }
-        else if (parser == "minecraft:uuid") { /*8.0*/
+        else if (V_parser == "minecraft:uuid") { /*8.0*/
         }
-        if (flags.has_custom_suggestions == 1) { /*8.2*/
+        if (V_flags.has_custom_suggestions == 1) { /*8.2*/
           len += stream.sizeOfVarInt(v2.suggestionType.length());
           len += v2.suggestionType.length(); /*suggestionType: pstring*/ /*4.1*/
         }
@@ -1894,7 +1894,7 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj) {
       const pdef::pc1_18_play_toClient::packet_advancements::AdvancementMapping::Value &v = v2.value; /*["packet_advancements","AdvancementMapping"]*/ /*7.4*/
     }
     len += stream.sizeOfVarInt(obj.identifiers.size()); /*1.3*/
-    for (const auto &v2 : obj.identifiers) {
+    for (const auto &v2 : obj.identifiers) { /*3.2*/
       len += stream.sizeOfVarInt(v2.length());
       len += v2.length(); /*: pstring*/ /*4.1*/
     }
@@ -1942,37 +1942,37 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj) {
   size_t packet_boss_bar(pdef::Stream &stream, const pdef::pc1_18_play_toClient::packet_boss_bar &obj) {
     size_t len = 0;
     len += 8; /*0.2*/
-    const int &action = obj.action; /*0.1*/
-    if (action == 0) { /*8.2*/
+    const int &V_action = obj.action; /*0.1*/
+    if (V_action == 0) { /*8.2*/
       len += stream.sizeOfVarInt(obj.title.length());
       len += obj.title.length(); /*title: pstring*/ /*4.1*/
     }
-    else if (action == 3) { /*8.2*/
+    else if (V_action == 3) { /*8.2*/
       len += stream.sizeOfVarInt(obj.title.length());
       len += obj.title.length(); /*title: pstring*/ /*4.1*/
     }
-    if (action == 0) { /*8.2*/
+    if (V_action == 0) { /*8.2*/
       len += 4; /*0.2*/
     }
-    else if (action == 2) { /*8.2*/
+    else if (V_action == 2) { /*8.2*/
       len += 4; /*0.2*/
     }
-    if (action == 0) { /*8.2*/
+    if (V_action == 0) { /*8.2*/
       len += stream.sizeOfVarInt(obj.color); /*0.2*/
     }
-    else if (action == 4) { /*8.2*/
+    else if (V_action == 4) { /*8.2*/
       len += stream.sizeOfVarInt(obj.color); /*0.2*/
     }
-    if (action == 0) { /*8.2*/
+    if (V_action == 0) { /*8.2*/
       len += stream.sizeOfVarInt(obj.dividers); /*0.2*/
     }
-    else if (action == 4) { /*8.2*/
+    else if (V_action == 4) { /*8.2*/
       len += stream.sizeOfVarInt(obj.dividers); /*0.2*/
     }
-    if (action == 0) { /*8.2*/
+    if (V_action == 0) { /*8.2*/
       len += 1; /*0.2*/
     }
-    else if (action == 5) { /*8.2*/
+    else if (V_action == 5) { /*8.2*/
       len += 1; /*0.2*/
     }
     PDEF_SIZE_DBG; return len;
@@ -1999,7 +1999,7 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj) {
   size_t packet_declare_commands(pdef::Stream &stream, const pdef::pc1_18_play_toClient::packet_declare_commands &obj) {
     size_t len = 0;
     len += stream.sizeOfVarInt(obj.nodes.size()); /*1.3*/
-    for (const auto &v2 : obj.nodes) {
+    for (const auto &v2 : obj.nodes) { /*3.2*/
       size_t len_0 = pdef::pc1_18_play_toClient::size::command_node(stream, v2); EXPECT_OR_BAIL(len_0); len += len_0; /**/ /*4.4*/
     }
     len += stream.sizeOfVarInt(obj.rootIndex); /*0.2*/
@@ -2011,11 +2011,11 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj) {
     len += 8; /*0.2*/
     len += 8; /*0.2*/
     len += 8; /*0.2*/
-    const bool &isEntity = obj.isEntity; /*0.1*/
-    if (isEntity == true) { /*8.1*/
+    const bool &V_isEntity = obj.isEntity; /*0.1*/
+    if (V_isEntity == true) { /*8.1*/
       len += stream.sizeOfVarInt(obj.entityId); /*0.2*/
     }
-    if (isEntity == true) { /*8.1*/
+    if (V_isEntity == true) { /*8.1*/
       len += stream.sizeOfVarInt(obj.entity_feet_eyes.length());
       len += obj.entity_feet_eyes.length(); /*entity_feet_eyes: pstring*/ /*4.1*/
     }
@@ -2040,7 +2040,7 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj) {
     len += 1; /*chunkCoordinates: bitfield*/ /*4.1*/
     len += 1; /*0.2*/
     len += stream.sizeOfVarInt(obj.records.size()); /*1.3*/
-    for (const auto &v2 : obj.records) {
+    for (const auto &v2 : obj.records) { /*3.2*/
       len += stream.sizeOfVarInt(v2); /*0.2*/
     }
     PDEF_SIZE_DBG; return len;
@@ -2063,7 +2063,7 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj) {
     len += 1; /*0.2*/
     len += stream.sizeOfVarInt(obj.stateId); /*0.2*/
     len += stream.sizeOfVarInt(obj.items.size()); /*1.3*/
-    for (const auto &v2 : obj.items) {
+    for (const auto &v2 : obj.items) { /*3.2*/
       len += 1; /*0.2*/
     }
     len += 1; /*0.2*/
@@ -2170,24 +2170,24 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj) {
     len += stream.sizeOfVarInt(obj.chunkData.size());
     len += obj.chunkData.size(); /*chunkData: buffer*/ /*4.1*/
     len += stream.sizeOfVarInt(obj.blockEntities.size()); /*1.3*/
-    for (const auto &v2 : obj.blockEntities) {
+    for (const auto &v2 : obj.blockEntities) { /*3.2*/
       size_t len_1 = pdef::pc1_18_play_toClient::size::chunkBlockEntity(stream, v2); EXPECT_OR_BAIL(len_1); len += len_1; /**/ /*4.4*/
     }
     len += 1; /*0.2*/
     len += stream.sizeOfVarInt(obj.skyLightMask.size()); /*1.3*/
-    for (const auto &v2 : obj.skyLightMask) {
+    for (const auto &v2 : obj.skyLightMask) { /*3.2*/
       len += 8; /*0.2*/
     }
     len += stream.sizeOfVarInt(obj.blockLightMask.size()); /*1.3*/
-    for (const auto &v2 : obj.blockLightMask) {
+    for (const auto &v2 : obj.blockLightMask) { /*3.2*/
       len += 8; /*0.2*/
     }
     len += stream.sizeOfVarInt(obj.emptySkyLightMask.size()); /*1.3*/
-    for (const auto &v2 : obj.emptySkyLightMask) {
+    for (const auto &v2 : obj.emptySkyLightMask) { /*3.2*/
       len += 8; /*0.2*/
     }
     len += stream.sizeOfVarInt(obj.emptyBlockLightMask.size()); /*1.3*/
-    for (const auto &v2 : obj.emptyBlockLightMask) {
+    for (const auto &v2 : obj.emptyBlockLightMask) { /*3.2*/
       len += 8; /*0.2*/
     }
     len += stream.sizeOfVarInt(obj.skyLight.size()); /*1.3*/
@@ -2216,7 +2216,7 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj) {
   }
   size_t packet_world_particles(pdef::Stream &stream, const pdef::pc1_18_play_toClient::packet_world_particles &obj) {
     size_t len = 0;
-    const int32_t &particleId = obj.particleId; /*0.1*/
+    const int32_t &V_particleId = obj.particleId; /*0.1*/
     len += 1; /*0.2*/
     len += 8; /*0.2*/
     len += 8; /*0.2*/
@@ -2226,22 +2226,22 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj) {
     len += 4; /*0.2*/
     len += 4; /*0.2*/
     len += 4; /*0.2*/
-    if (particleId == 2) { /*8.2*/
+    if (V_particleId == 2) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_2_or_3_or_24); const pdef::pc1_18_play_toClient::packet_world_particles::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.6*/
         len += stream.sizeOfVarInt(v2.blockState); /*0.2*/
     }
-    else if (particleId == 3) { /*8.2*/
+    else if (V_particleId == 3) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_2_or_3_or_24); const pdef::pc1_18_play_toClient::packet_world_particles::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.6*/
         len += stream.sizeOfVarInt(v2.blockState); /*0.2*/
     }
-    else if (particleId == 14) { /*8.2*/
+    else if (V_particleId == 14) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_14); const pdef::pc1_18_play_toClient::packet_world_particles::Data14 &v2 = *obj.data_14; /*8.6*/
         len += 4; /*0.2*/
         len += 4; /*0.2*/
         len += 4; /*0.2*/
         len += 4; /*0.2*/
     }
-    else if (particleId == 15) { /*8.2*/
+    else if (V_particleId == 15) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_15); const pdef::pc1_18_play_toClient::packet_world_particles::Data15 &v2 = *obj.data_15; /*8.6*/
         len += 4; /*0.2*/
         len += 4; /*0.2*/
@@ -2251,24 +2251,24 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj) {
         len += 4; /*0.2*/
         len += 4; /*0.2*/
     }
-    else if (particleId == 24) { /*8.2*/
+    else if (V_particleId == 24) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_2_or_3_or_24); const pdef::pc1_18_play_toClient::packet_world_particles::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.6*/
         len += stream.sizeOfVarInt(v2.blockState); /*0.2*/
     }
-    else if (particleId == 35) { /*8.2*/
+    else if (V_particleId == 35) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_35); const pdef::pc1_18_play_toClient::packet_world_particles::Data35 &v2 = *obj.data_35; /*8.6*/
         len += 1; /*0.2*/
     }
-    else if (particleId == 36) { /*8.2*/
+    else if (V_particleId == 36) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_36); const pdef::pc1_18_play_toClient::packet_world_particles::Data36 &v2 = *obj.data_36; /*8.6*/
         len += 1; /*origin: bitfield*/ /*4.1*/
         len += stream.sizeOfVarInt(v2.positionType.length());
         len += v2.positionType.length(); /*positionType^: pstring*/ /*4.1*/
-        const std::string &positionType = v2.positionType; /*4.7*/
-        if (positionType == "minecraft:block") { /*8.0*/
+        const std::string &V_positionType = v2.positionType; /*4.7*/
+        if (V_positionType == "minecraft:block") { /*8.0*/
           len += 1; /*destination: bitfield*/ /*4.1*/
         }
-        else if (positionType == "minecraft:entity") { /*8.0*/
+        else if (V_positionType == "minecraft:entity") { /*8.0*/
           len += stream.sizeOfVarInt(v2.destination_varint); /*0.2*/
         }
         len += stream.sizeOfVarInt(v2.ticks); /*0.2*/
@@ -2281,19 +2281,19 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj) {
     len += stream.sizeOfVarInt(obj.chunkZ); /*0.2*/
     len += 1; /*0.2*/
     len += stream.sizeOfVarInt(obj.skyLightMask.size()); /*1.3*/
-    for (const auto &v2 : obj.skyLightMask) {
+    for (const auto &v2 : obj.skyLightMask) { /*3.2*/
       len += 8; /*0.2*/
     }
     len += stream.sizeOfVarInt(obj.blockLightMask.size()); /*1.3*/
-    for (const auto &v2 : obj.blockLightMask) {
+    for (const auto &v2 : obj.blockLightMask) { /*3.2*/
       len += 8; /*0.2*/
     }
     len += stream.sizeOfVarInt(obj.emptySkyLightMask.size()); /*1.3*/
-    for (const auto &v2 : obj.emptySkyLightMask) {
+    for (const auto &v2 : obj.emptySkyLightMask) { /*3.2*/
       len += 8; /*0.2*/
     }
     len += stream.sizeOfVarInt(obj.emptyBlockLightMask.size()); /*1.3*/
-    for (const auto &v2 : obj.emptyBlockLightMask) {
+    for (const auto &v2 : obj.emptyBlockLightMask) { /*3.2*/
       len += 8; /*0.2*/
     }
     len += stream.sizeOfVarInt(obj.skyLight.size()); /*1.3*/
@@ -2319,7 +2319,7 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj) {
     len += 1; /*0.2*/
     len += 1; /*0.2*/
     len += stream.sizeOfVarInt(obj.worldNames.size()); /*1.3*/
-    for (const auto &v2 : obj.worldNames) {
+    for (const auto &v2 : obj.worldNames) { /*3.2*/
       len += stream.sizeOfVarInt(v2.length());
       len += v2.length(); /*: pstring*/ /*4.1*/
     }
@@ -2343,23 +2343,23 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj) {
     len += 1; /*0.2*/
     len += 1; /*0.2*/
     const pdef::pc1_18_play_toClient::packet_map::Icons &v = obj.icons; /*["packet_map"]*/ /*7.4*/
-    const uint8_t &columns = obj.columns; /*0.1*/
-    if (columns == 0) { /*8.2*/
+    const uint8_t &V_columns = obj.columns; /*0.1*/
+    if (V_columns == 0) { /*8.2*/
     }
     else {
       len += 1; /*0.2*/
     }
-    if (columns == 0) { /*8.2*/
+    if (V_columns == 0) { /*8.2*/
     }
     else {
       len += 1; /*0.2*/
     }
-    if (columns == 0) { /*8.2*/
+    if (V_columns == 0) { /*8.2*/
     }
     else {
       len += 1; /*0.2*/
     }
-    if (columns == 0) { /*8.2*/
+    if (V_columns == 0) { /*8.2*/
     }
     else {
       len += stream.sizeOfVarInt(obj.data.size());
@@ -2470,15 +2470,15 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj) {
   }
   size_t packet_player_info(pdef::Stream &stream, const pdef::pc1_18_play_toClient::packet_player_info &obj) {
     size_t len = 0;
-    const int &action = obj.action; /*0.1*/
+    const int &V_action = obj.action; /*0.1*/
     len += stream.sizeOfVarInt(obj.data.size()); /*1.3*/
     for (const auto &v2 : obj.data) { /*5.20*/
       len += 8; /*0.2*/
-      if (action == 0) { /*8.2*/
+      if (V_action == 0) { /*8.2*/
         len += stream.sizeOfVarInt(v2.name.length());
         len += v2.name.length(); /*name: pstring*/ /*4.1*/
       }
-      if (action == 0) { /*8.2*/
+      if (V_action == 0) { /*8.2*/
         len += stream.sizeOfVarInt(v2.properties.size()); /*1.3*/
         for (const auto &v4 : v2.properties) { /*5.20*/
           len += stream.sizeOfVarInt(v4.name.length());
@@ -2488,30 +2488,30 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj) {
           const pdef::pc1_18_play_toClient::packet_player_info::Data::Properties::Signature &v = v4.signature; /*["packet_player_info","Data","Properties"]*/ /*7.4*/
         }
       }
-      if (action == 0) { /*8.2*/
+      if (V_action == 0) { /*8.2*/
         len += stream.sizeOfVarInt(v2.gamemode); /*0.2*/
       }
-      else if (action == 1) { /*8.2*/
+      else if (V_action == 1) { /*8.2*/
         len += stream.sizeOfVarInt(v2.gamemode); /*0.2*/
       }
-      if (action == 0) { /*8.2*/
+      if (V_action == 0) { /*8.2*/
         len += stream.sizeOfVarInt(v2.ping); /*0.2*/
       }
-      else if (action == 2) { /*8.2*/
+      else if (V_action == 2) { /*8.2*/
         len += stream.sizeOfVarInt(v2.ping); /*0.2*/
       }
-      if (action == 0) { /*8.2*/
+      if (V_action == 0) { /*8.2*/
           EXPECT_OR_BAIL(v2.displayName); const pdef::pc1_18_play_toClient::packet_player_info::Data::DisplayName &v3 = *v2.displayName; /*8.6*/
-          const bool &has = v3.has; /*0.1*/
-          if (has == true) { /*8.1*/
+          const bool &V_has = v3.has; /*0.1*/
+          if (V_has == true) { /*8.1*/
             len += stream.sizeOfVarInt(v3.value.length());
             len += v3.value.length(); /*value: pstring*/ /*4.1*/
           }
       }
-      else if (action == 3) { /*8.2*/
+      else if (V_action == 3) { /*8.2*/
           EXPECT_OR_BAIL(v2.displayName); const pdef::pc1_18_play_toClient::packet_player_info::Data::DisplayName &v3 = *v2.displayName; /*8.6*/
-          const bool &has = v3.has; /*0.1*/
-          if (has == true) { /*8.1*/
+          const bool &V_has = v3.has; /*0.1*/
+          if (V_has == true) { /*8.1*/
             len += stream.sizeOfVarInt(v3.value.length());
             len += v3.value.length(); /*value: pstring*/ /*4.1*/
           }
@@ -2533,7 +2533,7 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj) {
   }
   size_t packet_unlock_recipes(pdef::Stream &stream, const pdef::pc1_18_play_toClient::packet_unlock_recipes &obj) {
     size_t len = 0;
-    const int &action = obj.action; /*0.1*/
+    const int &V_action = obj.action; /*0.1*/
     len += 1; /*0.2*/
     len += 1; /*0.2*/
     len += 1; /*0.2*/
@@ -2543,13 +2543,13 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj) {
     len += 1; /*0.2*/
     len += 1; /*0.2*/
     len += stream.sizeOfVarInt(obj.recipes1.size()); /*1.3*/
-    for (const auto &v2 : obj.recipes1) {
+    for (const auto &v2 : obj.recipes1) { /*3.2*/
       len += stream.sizeOfVarInt(v2.length());
       len += v2.length(); /*: pstring*/ /*4.1*/
     }
-    if (action == 0) { /*8.2*/
+    if (V_action == 0) { /*8.2*/
       len += stream.sizeOfVarInt(obj.recipes2.size()); /*1.3*/
-      for (const auto &v3 : obj.recipes2) {
+      for (const auto &v3 : obj.recipes2) { /*3.2*/
         len += stream.sizeOfVarInt(v3.length());
         len += v3.length(); /*: pstring*/ /*4.1*/
       }
@@ -2559,7 +2559,7 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj) {
   size_t packet_entity_destroy(pdef::Stream &stream, const pdef::pc1_18_play_toClient::packet_entity_destroy &obj) {
     size_t len = 0;
     len += stream.sizeOfVarInt(obj.entityIds.size()); /*1.3*/
-    for (const auto &v2 : obj.entityIds) {
+    for (const auto &v2 : obj.entityIds) { /*3.2*/
       len += stream.sizeOfVarInt(v2); /*0.2*/
     }
     PDEF_SIZE_DBG; return len;
@@ -2671,19 +2671,19 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj) {
     size_t len = 0;
     len += stream.sizeOfVarInt(obj.name.length());
     len += obj.name.length(); /*name: pstring*/ /*4.1*/
-    const int8_t &action = obj.action; /*0.1*/
-    if (action == 0) { /*8.2*/
+    const int8_t &V_action = obj.action; /*0.1*/
+    if (V_action == 0) { /*8.2*/
       len += stream.sizeOfVarInt(obj.displayText.length());
       len += obj.displayText.length(); /*displayText: pstring*/ /*4.1*/
     }
-    else if (action == 2) { /*8.2*/
+    else if (V_action == 2) { /*8.2*/
       len += stream.sizeOfVarInt(obj.displayText.length());
       len += obj.displayText.length(); /*displayText: pstring*/ /*4.1*/
     }
-    if (action == 0) { /*8.2*/
+    if (V_action == 0) { /*8.2*/
       len += stream.sizeOfVarInt(obj.type); /*0.2*/
     }
-    else if (action == 2) { /*8.2*/
+    else if (V_action == 2) { /*8.2*/
       len += stream.sizeOfVarInt(obj.type); /*0.2*/
     }
     PDEF_SIZE_DBG; return len;
@@ -2692,7 +2692,7 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj) {
     size_t len = 0;
     len += stream.sizeOfVarInt(obj.entityId); /*0.2*/
     len += stream.sizeOfVarInt(obj.passengers.size()); /*1.3*/
-    for (const auto &v2 : obj.passengers) {
+    for (const auto &v2 : obj.passengers) { /*3.2*/
       len += stream.sizeOfVarInt(v2); /*0.2*/
     }
     PDEF_SIZE_DBG; return len;
@@ -2701,76 +2701,76 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj) {
     size_t len = 0;
     len += stream.sizeOfVarInt(obj.team.length());
     len += obj.team.length(); /*team: pstring*/ /*4.1*/
-    const int8_t &mode = obj.mode; /*0.1*/
-    if (mode == 0) { /*8.2*/
+    const int8_t &V_mode = obj.mode; /*0.1*/
+    if (V_mode == 0) { /*8.2*/
       len += stream.sizeOfVarInt(obj.name.length());
       len += obj.name.length(); /*name: pstring*/ /*4.1*/
     }
-    else if (mode == 2) { /*8.2*/
+    else if (V_mode == 2) { /*8.2*/
       len += stream.sizeOfVarInt(obj.name.length());
       len += obj.name.length(); /*name: pstring*/ /*4.1*/
     }
-    if (mode == 0) { /*8.2*/
+    if (V_mode == 0) { /*8.2*/
       len += 1; /*0.2*/
     }
-    else if (mode == 2) { /*8.2*/
+    else if (V_mode == 2) { /*8.2*/
       len += 1; /*0.2*/
     }
-    if (mode == 0) { /*8.2*/
+    if (V_mode == 0) { /*8.2*/
       len += stream.sizeOfVarInt(obj.nameTagVisibility.length());
       len += obj.nameTagVisibility.length(); /*nameTagVisibility: pstring*/ /*4.1*/
     }
-    else if (mode == 2) { /*8.2*/
+    else if (V_mode == 2) { /*8.2*/
       len += stream.sizeOfVarInt(obj.nameTagVisibility.length());
       len += obj.nameTagVisibility.length(); /*nameTagVisibility: pstring*/ /*4.1*/
     }
-    if (mode == 0) { /*8.2*/
+    if (V_mode == 0) { /*8.2*/
       len += stream.sizeOfVarInt(obj.collisionRule.length());
       len += obj.collisionRule.length(); /*collisionRule: pstring*/ /*4.1*/
     }
-    else if (mode == 2) { /*8.2*/
+    else if (V_mode == 2) { /*8.2*/
       len += stream.sizeOfVarInt(obj.collisionRule.length());
       len += obj.collisionRule.length(); /*collisionRule: pstring*/ /*4.1*/
     }
-    if (mode == 0) { /*8.2*/
+    if (V_mode == 0) { /*8.2*/
       len += stream.sizeOfVarInt(obj.formatting); /*0.2*/
     }
-    else if (mode == 2) { /*8.2*/
+    else if (V_mode == 2) { /*8.2*/
       len += stream.sizeOfVarInt(obj.formatting); /*0.2*/
     }
-    if (mode == 0) { /*8.2*/
+    if (V_mode == 0) { /*8.2*/
       len += stream.sizeOfVarInt(obj.prefix.length());
       len += obj.prefix.length(); /*prefix: pstring*/ /*4.1*/
     }
-    else if (mode == 2) { /*8.2*/
+    else if (V_mode == 2) { /*8.2*/
       len += stream.sizeOfVarInt(obj.prefix.length());
       len += obj.prefix.length(); /*prefix: pstring*/ /*4.1*/
     }
-    if (mode == 0) { /*8.2*/
+    if (V_mode == 0) { /*8.2*/
       len += stream.sizeOfVarInt(obj.suffix.length());
       len += obj.suffix.length(); /*suffix: pstring*/ /*4.1*/
     }
-    else if (mode == 2) { /*8.2*/
+    else if (V_mode == 2) { /*8.2*/
       len += stream.sizeOfVarInt(obj.suffix.length());
       len += obj.suffix.length(); /*suffix: pstring*/ /*4.1*/
     }
-    if (mode == 0) { /*8.2*/
+    if (V_mode == 0) { /*8.2*/
       len += stream.sizeOfVarInt(obj.players.size()); /*1.3*/
-      for (const auto &v3 : obj.players) {
+      for (const auto &v3 : obj.players) { /*3.2*/
         len += stream.sizeOfVarInt(v3.length());
         len += v3.length(); /*: pstring*/ /*4.1*/
       }
     }
-    else if (mode == 3) { /*8.2*/
+    else if (V_mode == 3) { /*8.2*/
       len += stream.sizeOfVarInt(obj.players.size()); /*1.3*/
-      for (const auto &v3 : obj.players) {
+      for (const auto &v3 : obj.players) { /*3.2*/
         len += stream.sizeOfVarInt(v3.length());
         len += v3.length(); /*: pstring*/ /*4.1*/
       }
     }
-    else if (mode == 4) { /*8.2*/
+    else if (V_mode == 4) { /*8.2*/
       len += stream.sizeOfVarInt(obj.players.size()); /*1.3*/
-      for (const auto &v3 : obj.players) {
+      for (const auto &v3 : obj.players) { /*3.2*/
         len += stream.sizeOfVarInt(v3.length());
         len += v3.length(); /*: pstring*/ /*4.1*/
       }
@@ -2781,10 +2781,10 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj) {
     size_t len = 0;
     len += stream.sizeOfVarInt(obj.itemName.length());
     len += obj.itemName.length(); /*itemName: pstring*/ /*4.1*/
-    const int &action = obj.action; /*0.1*/
+    const int &V_action = obj.action; /*0.1*/
     len += stream.sizeOfVarInt(obj.scoreName.length());
     len += obj.scoreName.length(); /*scoreName: pstring*/ /*4.1*/
-    if (action == 1) { /*8.2*/
+    if (V_action == 1) { /*8.2*/
     }
     else {
       len += stream.sizeOfVarInt(obj.value); /*0.2*/
@@ -2814,18 +2814,18 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj) {
   }
   size_t packet_stop_sound(pdef::Stream &stream, const pdef::pc1_18_play_toClient::packet_stop_sound &obj) {
     size_t len = 0;
-    const int8_t &flags = obj.flags; /*0.1*/
-    if (flags == 1) { /*8.2*/
+    const int8_t &V_flags = obj.flags; /*0.1*/
+    if (V_flags == 1) { /*8.2*/
       len += stream.sizeOfVarInt(obj.source); /*0.2*/
     }
-    else if (flags == 3) { /*8.2*/
+    else if (V_flags == 3) { /*8.2*/
       len += stream.sizeOfVarInt(obj.source); /*0.2*/
     }
-    if (flags == 2) { /*8.2*/
+    if (V_flags == 2) { /*8.2*/
       len += stream.sizeOfVarInt(obj.sound.length());
       len += obj.sound.length(); /*sound: pstring*/ /*4.1*/
     }
-    else if (flags == 3) { /*8.2*/
+    else if (V_flags == 3) { /*8.2*/
       len += stream.sizeOfVarInt(obj.sound.length());
       len += obj.sound.length(); /*sound: pstring*/ /*4.1*/
     }
@@ -2905,98 +2905,98 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj) {
     for (const auto &v2 : obj.recipes) { /*5.20*/
       len += stream.sizeOfVarInt(v2.type.length());
       len += v2.type.length(); /*type^: pstring*/ /*4.1*/
-      const std::string &type = v2.type; /*4.7*/
+      const std::string &V_type = v2.type; /*4.7*/
       len += stream.sizeOfVarInt(v2.recipeId.length());
       len += v2.recipeId.length(); /*recipeId: pstring*/ /*4.1*/
-      if (type == "minecraft:crafting_shapeless") { /*8.0*/
+      if (V_type == "minecraft:crafting_shapeless") { /*8.0*/
           EXPECT_OR_BAIL(v2.data_minecraft_crafting_shapeless); const pdef::pc1_18_play_toClient::packet_declare_recipes::Recipes::DataMinecraftCraftingShapeless &v3 = *v2.data_minecraft_crafting_shapeless; /*8.6*/
           len += stream.sizeOfVarInt(v3.group.length());
           len += v3.group.length(); /*group: pstring*/ /*4.1*/
           len += stream.sizeOfVarInt(v3.ingredients.size()); /*1.3*/
-          for (const auto &v5 : v3.ingredients) {
+          for (const auto &v5 : v3.ingredients) { /*3.2*/
             len += stream.sizeOfVarInt(v5.size()); /*1.3*/
-            for (const auto &v6 : v5) {
+            for (const auto &v6 : v5) { /*3.2*/
               len += 1; /*0.2*/
             }
           }
           len += 1; /*0.2*/
       }
-      else if (type == "minecraft:crafting_shaped") { /*8.0*/
+      else if (V_type == "minecraft:crafting_shaped") { /*8.0*/
           EXPECT_OR_BAIL(v2.data_minecraft_crafting_shaped); const pdef::pc1_18_play_toClient::packet_declare_recipes::Recipes::DataMinecraftCraftingShaped &v3 = *v2.data_minecraft_crafting_shaped; /*8.6*/
-          const int &width = v3.width; /*0.1*/
-          const int &height = v3.height; /*0.1*/
+          const int &V_width = v3.width; /*0.1*/
+          const int &V_height = v3.height; /*0.1*/
           len += stream.sizeOfVarInt(v3.group.length());
           len += v3.group.length(); /*group: pstring*/ /*4.1*/
-          len += stream.sizeOfVarInt(width); /*1.1*/
+          len += stream.sizeOfVarInt(V_width); /*1.1*/
           for (const auto &v : v3.ingredients) { /*5.1*/
-            len += stream.sizeOfVarInt(height); /*5.3*/
+            len += stream.sizeOfVarInt(V_height); /*5.3*/
             for (const auto &v : v) { /*5.10*/
               len += stream.sizeOfVarInt(v.size()); /*1.3*/
-              for (const auto &v7 : v) {
+              for (const auto &v7 : v) { /*3.2*/
                 len += 1; /*0.2*/
               }
             }
           }
           len += 1; /*0.2*/
       }
-      else if (type == "minecraft:crafting_special_armordye") { /*8.0*/
+      else if (V_type == "minecraft:crafting_special_armordye") { /*8.0*/
       }
-      else if (type == "minecraft:crafting_special_bookcloning") { /*8.0*/
+      else if (V_type == "minecraft:crafting_special_bookcloning") { /*8.0*/
       }
-      else if (type == "minecraft:crafting_special_mapcloning") { /*8.0*/
+      else if (V_type == "minecraft:crafting_special_mapcloning") { /*8.0*/
       }
-      else if (type == "minecraft:crafting_special_mapextending") { /*8.0*/
+      else if (V_type == "minecraft:crafting_special_mapextending") { /*8.0*/
       }
-      else if (type == "minecraft:crafting_special_firework_rocket") { /*8.0*/
+      else if (V_type == "minecraft:crafting_special_firework_rocket") { /*8.0*/
       }
-      else if (type == "minecraft:crafting_special_firework_star") { /*8.0*/
+      else if (V_type == "minecraft:crafting_special_firework_star") { /*8.0*/
       }
-      else if (type == "minecraft:crafting_special_firework_star_fade") { /*8.0*/
+      else if (V_type == "minecraft:crafting_special_firework_star_fade") { /*8.0*/
       }
-      else if (type == "minecraft:crafting_special_repairitem") { /*8.0*/
+      else if (V_type == "minecraft:crafting_special_repairitem") { /*8.0*/
       }
-      else if (type == "minecraft:crafting_special_tippedarrow") { /*8.0*/
+      else if (V_type == "minecraft:crafting_special_tippedarrow") { /*8.0*/
       }
-      else if (type == "minecraft:crafting_special_bannerduplicate") { /*8.0*/
+      else if (V_type == "minecraft:crafting_special_bannerduplicate") { /*8.0*/
       }
-      else if (type == "minecraft:crafting_special_banneraddpattern") { /*8.0*/
+      else if (V_type == "minecraft:crafting_special_banneraddpattern") { /*8.0*/
       }
-      else if (type == "minecraft:crafting_special_shielddecoration") { /*8.0*/
+      else if (V_type == "minecraft:crafting_special_shielddecoration") { /*8.0*/
       }
-      else if (type == "minecraft:crafting_special_shulkerboxcoloring") { /*8.0*/
+      else if (V_type == "minecraft:crafting_special_shulkerboxcoloring") { /*8.0*/
       }
-      else if (type == "minecraft:crafting_special_suspiciousstew") { /*8.0*/
+      else if (V_type == "minecraft:crafting_special_suspiciousstew") { /*8.0*/
       }
-      else if (type == "minecraft:smelting") { /*8.0*/
+      else if (V_type == "minecraft:smelting") { /*8.0*/
         EXPECT_OR_BAIL(v2.data_minecraft_smelting_format); size_t len_2 = pdef::pc1_18_play_toClient::size::minecraft_smelting_format(stream, *v2.data_minecraft_smelting_format); EXPECT_OR_BAIL(len_2); len += len_2; /*data_minecraft_smelting_format*/ /*4.4*/
       }
-      else if (type == "minecraft:blasting") { /*8.0*/
+      else if (V_type == "minecraft:blasting") { /*8.0*/
         EXPECT_OR_BAIL(v2.data_minecraft_smelting_format); size_t len_3 = pdef::pc1_18_play_toClient::size::minecraft_smelting_format(stream, *v2.data_minecraft_smelting_format); EXPECT_OR_BAIL(len_3); len += len_3; /*data_minecraft_smelting_format*/ /*4.4*/
       }
-      else if (type == "minecraft:smoking") { /*8.0*/
+      else if (V_type == "minecraft:smoking") { /*8.0*/
         EXPECT_OR_BAIL(v2.data_minecraft_smelting_format); size_t len_4 = pdef::pc1_18_play_toClient::size::minecraft_smelting_format(stream, *v2.data_minecraft_smelting_format); EXPECT_OR_BAIL(len_4); len += len_4; /*data_minecraft_smelting_format*/ /*4.4*/
       }
-      else if (type == "minecraft:campfire_cooking") { /*8.0*/
+      else if (V_type == "minecraft:campfire_cooking") { /*8.0*/
         EXPECT_OR_BAIL(v2.data_minecraft_smelting_format); size_t len_5 = pdef::pc1_18_play_toClient::size::minecraft_smelting_format(stream, *v2.data_minecraft_smelting_format); EXPECT_OR_BAIL(len_5); len += len_5; /*data_minecraft_smelting_format*/ /*4.4*/
       }
-      else if (type == "minecraft:stonecutting") { /*8.0*/
+      else if (V_type == "minecraft:stonecutting") { /*8.0*/
           EXPECT_OR_BAIL(v2.data_minecraft_stonecutting); const pdef::pc1_18_play_toClient::packet_declare_recipes::Recipes::DataMinecraftStonecutting &v3 = *v2.data_minecraft_stonecutting; /*8.6*/
           len += stream.sizeOfVarInt(v3.group.length());
           len += v3.group.length(); /*group: pstring*/ /*4.1*/
           len += stream.sizeOfVarInt(v3.ingredient.size()); /*1.3*/
-          for (const auto &v5 : v3.ingredient) {
+          for (const auto &v5 : v3.ingredient) { /*3.2*/
             len += 1; /*0.2*/
           }
           len += 1; /*0.2*/
       }
-      else if (type == "minecraft:smithing") { /*8.0*/
+      else if (V_type == "minecraft:smithing") { /*8.0*/
           EXPECT_OR_BAIL(v2.data_minecraft_smithing); const pdef::pc1_18_play_toClient::packet_declare_recipes::Recipes::DataMinecraftSmithing &v3 = *v2.data_minecraft_smithing; /*8.6*/
           len += stream.sizeOfVarInt(v3.base.size()); /*1.3*/
-          for (const auto &v5 : v3.base) {
+          for (const auto &v5 : v3.base) { /*3.2*/
             len += 1; /*0.2*/
           }
           len += stream.sizeOfVarInt(v3.addition.size()); /*1.3*/
-          for (const auto &v5 : v3.addition) {
+          for (const auto &v5 : v3.addition) { /*3.2*/
             len += 1; /*0.2*/
           }
           len += 1; /*0.2*/
@@ -3028,11 +3028,11 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj) {
     len += 1; /*sourcePosition: bitfield*/ /*4.1*/
     len += stream.sizeOfVarInt(obj.destinationIdentifier.length());
     len += obj.destinationIdentifier.length(); /*destinationIdentifier^: pstring*/ /*4.1*/
-    const std::string &destinationIdentifier = obj.destinationIdentifier; /*4.7*/
-    if (destinationIdentifier == "block") { /*8.0*/
+    const std::string &V_destinationIdentifier = obj.destinationIdentifier; /*4.7*/
+    if (V_destinationIdentifier == "block") { /*8.0*/
       len += 1; /*destination: bitfield*/ /*4.1*/
     }
-    else if (destinationIdentifier == "entityId") { /*8.0*/
+    else if (V_destinationIdentifier == "entityId") { /*8.0*/
       len += stream.sizeOfVarInt(obj.destination_varint); /*0.2*/
     }
     len += stream.sizeOfVarInt(obj.arrivalTicks); /*0.2*/
@@ -3120,9 +3120,9 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj) {
   }
   size_t packet(pdef::Stream &stream, const pdef::pc1_18_play_toClient::packet &obj) {
     size_t len = 0;
-    const pdef::pc1_18_play_toClient::packet::Name &name = obj.name; /*0.3*/
+    const pdef::pc1_18_play_toClient::packet::Name &V_name = obj.name; /*0.3*/
     len += stream.sizeOfVarInt((int&)obj.name); /*name^: varint*/ /*7.0*/
-    switch (name) { /*8.0*/
+    switch (V_name) { /*8.0*/
       case pdef::pc1_18_play_toClient::packet::Name::SpawnEntity: { /*8.5*/
         EXPECT_OR_BAIL(obj.params_packet_spawn_entity); size_t len_7 = pdef::pc1_18_play_toClient::size::packet_spawn_entity(stream, *obj.params_packet_spawn_entity); EXPECT_OR_BAIL(len_7); len += len_7; /*params_packet_spawn_entity*/ /*4.4*/
         break;
@@ -3659,11 +3659,11 @@ bool packet_simulation_distance(pdef::Stream &stream, const pdef::pc1_18_play_to
 bool packet(pdef::Stream &stream, const pdef::pc1_18_play_toClient::packet &obj, bool allocate);
   bool slot(pdef::Stream &stream, const pdef::pc1_18_play_toClient::slot &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::pc1_18_play_toClient::size::slot(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const bool &present = obj.present; /*0.1*/
+    const bool &V_present = obj.present; /*0.1*/
     WRITE_OR_BAIL(writeBool, (bool)obj.present); /*0.4*/
-    if (present == false) { /*8.1*/
+    if (V_present == false) { /*8.1*/
     }
-    else if (present == true) { /*8.1*/
+    else if (V_present == true) { /*8.1*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.itemId); /*0.4*/
         WRITE_OR_BAIL(writeByte, (int8_t)obj.itemCount); /*0.4*/
         WRITE_OR_BAIL(writeByte, (int8_t)obj.nbtData); /*0.4*/
@@ -3672,24 +3672,24 @@ bool packet(pdef::Stream &stream, const pdef::pc1_18_play_toClient::packet &obj,
   }
   bool particle(pdef::Stream &stream, const pdef::pc1_18_play_toClient::particle &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::pc1_18_play_toClient::size::particle(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const int &particleId = obj.particleId; /*0.1*/
+    const int &V_particleId = obj.particleId; /*0.1*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.particleId); /*0.4*/
-    if (particleId == 2) { /*8.2*/
+    if (V_particleId == 2) { /*8.2*/
         const pdef::pc1_18_play_toClient::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.5*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.blockState); /*0.4*/
     }
-    else if (particleId == 3) { /*8.2*/
+    else if (V_particleId == 3) { /*8.2*/
         const pdef::pc1_18_play_toClient::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.5*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.blockState); /*0.4*/
     }
-    else if (particleId == 14) { /*8.2*/
+    else if (V_particleId == 14) { /*8.2*/
         const pdef::pc1_18_play_toClient::particle::Data14 &v2 = *obj.data_14; /*8.5*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.red); /*0.4*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.green); /*0.4*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.blue); /*0.4*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.scale); /*0.4*/
     }
-    else if (particleId == 15) { /*8.2*/
+    else if (V_particleId == 15) { /*8.2*/
         const pdef::pc1_18_play_toClient::particle::Data15 &v2 = *obj.data_15; /*8.5*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.fromRed); /*0.4*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.fromGreen); /*0.4*/
@@ -3699,15 +3699,15 @@ bool packet(pdef::Stream &stream, const pdef::pc1_18_play_toClient::packet &obj,
         WRITE_OR_BAIL(writeFloatBE, (float)v2.toGreen); /*0.4*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.toBlue); /*0.4*/
     }
-    else if (particleId == 24) { /*8.2*/
+    else if (V_particleId == 24) { /*8.2*/
         const pdef::pc1_18_play_toClient::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.5*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.blockState); /*0.4*/
     }
-    else if (particleId == 35) { /*8.2*/
+    else if (V_particleId == 35) { /*8.2*/
         const pdef::pc1_18_play_toClient::particle::Data35 &v2 = *obj.data_35; /*8.5*/
         WRITE_OR_BAIL(writeByte, (int8_t)v2.item); /*0.4*/
     }
-    else if (particleId == 36) { /*8.2*/
+    else if (V_particleId == 36) { /*8.2*/
         const pdef::pc1_18_play_toClient::particle::Data36 &v2 = *obj.data_36; /*8.5*/
         uint64_t origin_val = 0;
         origin_val |= (uint64_t)v2.origin.x << 0;
@@ -3716,15 +3716,15 @@ bool packet(pdef::Stream &stream, const pdef::pc1_18_play_toClient::packet &obj,
         WRITE_OR_BAIL(writeULongBE, origin_val); /*origin: bitfield*/ /*4.2*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.positionType.length());
         WRITE_OR_BAIL(writeString, v2.positionType); /*positionType: pstring*/ /*4.2*/
-        const std::string &positionType = v2.positionType; /*4.7*/
-        if (positionType == "minecraft:block") { /*8.0*/
+        const std::string &V_positionType = v2.positionType; /*4.7*/
+        if (V_positionType == "minecraft:block") { /*8.0*/
           uint64_t destination_position_val = 0;
           destination_position_val |= (uint64_t)v2.destination_position.x << 0;
           destination_position_val |= (uint64_t)v2.destination_position.z << 26;
           destination_position_val |= (uint64_t)v2.destination_position.y << 52;
           WRITE_OR_BAIL(writeULongBE, destination_position_val); /*destination_position: bitfield*/ /*4.2*/
         }
-        else if (positionType == "minecraft:entity") { /*8.0*/
+        else if (V_positionType == "minecraft:entity") { /*8.0*/
           WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.destination_varint); /*0.4*/
         }
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.ticks); /*0.4*/
@@ -3774,192 +3774,192 @@ bool tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj, boo
     flags_val |= (uint8_t)obj.flags.has_command << 5;
     flags_val |= (uint8_t)obj.flags.command_node_type << 6;
     WRITE_OR_BAIL(writeUByte, flags_val); /*flags: bitfield*/ /*4.2*/
-    const pdef::pc1_18_play_toClient::command_node::flags_t &flags = obj.flags; /*4.7*/
+    const pdef::pc1_18_play_toClient::command_node::flags_t &V_flags = obj.flags; /*4.7*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.children.size()); /*1.4*/
     for (const auto &v2 : obj.children) { /*3.1*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2); /*0.4*/
     }
-    if (flags.has_redirect_node == 1) { /*8.2*/
+    if (V_flags.has_redirect_node == 1) { /*8.2*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.redirectNode); /*0.4*/
     }
-    if (flags.command_node_type == 0) { /*8.2*/
+    if (V_flags.command_node_type == 0) { /*8.2*/
     }
-    else if (flags.command_node_type == 1) { /*8.2*/
+    else if (V_flags.command_node_type == 1) { /*8.2*/
         const pdef::pc1_18_play_toClient::command_node::ExtraNodeData1 &v2 = *obj.extraNodeData_1; /*8.5*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.name.length());
         WRITE_OR_BAIL(writeString, v2.name); /*name: pstring*/ /*4.2*/
     }
-    else if (flags.command_node_type == 2) { /*8.2*/
+    else if (V_flags.command_node_type == 2) { /*8.2*/
         const pdef::pc1_18_play_toClient::command_node::ExtraNodeData2 &v2 = *obj.extraNodeData_2; /*8.5*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.name.length());
         WRITE_OR_BAIL(writeString, v2.name); /*name: pstring*/ /*4.2*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.parser.length());
         WRITE_OR_BAIL(writeString, v2.parser); /*parser: pstring*/ /*4.2*/
-        const std::string &parser = v2.parser; /*4.7*/
-        if (parser == "brigadier:bool") { /*8.0*/
+        const std::string &V_parser = v2.parser; /*4.7*/
+        if (V_parser == "brigadier:bool") { /*8.0*/
         }
-        else if (parser == "brigadier:float") { /*8.0*/
+        else if (V_parser == "brigadier:float") { /*8.0*/
             const pdef::pc1_18_play_toClient::command_node::ExtraNodeData2::PropertiesBrigadierFloat &v4 = *v2.properties_brigadier_float; /*8.5*/
             uint8_t flags_val = 0;
             flags_val |= (uint8_t)v4.flags.unused << 0;
             flags_val |= (uint8_t)v4.flags.max_present << 6;
             flags_val |= (uint8_t)v4.flags.min_present << 7;
             WRITE_OR_BAIL(writeUByte, flags_val); /*flags: bitfield*/ /*4.2*/
-            const pdef::pc1_18_play_toClient::command_node::ExtraNodeData2::PropertiesBrigadierFloat::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_play_toClient::command_node::ExtraNodeData2::PropertiesBrigadierFloat::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeFloatBE, (float)v4.min); /*0.4*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeFloatBE, (float)v4.max); /*0.4*/
             }
         }
-        else if (parser == "brigadier:double") { /*8.0*/
+        else if (V_parser == "brigadier:double") { /*8.0*/
             const pdef::pc1_18_play_toClient::command_node::ExtraNodeData2::PropertiesBrigadierDouble &v4 = *v2.properties_brigadier_double; /*8.5*/
             uint8_t flags_val = 0;
             flags_val |= (uint8_t)v4.flags.unused << 0;
             flags_val |= (uint8_t)v4.flags.max_present << 6;
             flags_val |= (uint8_t)v4.flags.min_present << 7;
             WRITE_OR_BAIL(writeUByte, flags_val); /*flags: bitfield*/ /*4.2*/
-            const pdef::pc1_18_play_toClient::command_node::ExtraNodeData2::PropertiesBrigadierDouble::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_play_toClient::command_node::ExtraNodeData2::PropertiesBrigadierDouble::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeDoubleBE, (double)v4.min); /*0.4*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeDoubleBE, (double)v4.max); /*0.4*/
             }
         }
-        else if (parser == "brigadier:integer") { /*8.0*/
+        else if (V_parser == "brigadier:integer") { /*8.0*/
             const pdef::pc1_18_play_toClient::command_node::ExtraNodeData2::PropertiesBrigadierInteger &v4 = *v2.properties_brigadier_integer; /*8.5*/
             uint8_t flags_val = 0;
             flags_val |= (uint8_t)v4.flags.unused << 0;
             flags_val |= (uint8_t)v4.flags.max_present << 6;
             flags_val |= (uint8_t)v4.flags.min_present << 7;
             WRITE_OR_BAIL(writeUByte, flags_val); /*flags: bitfield*/ /*4.2*/
-            const pdef::pc1_18_play_toClient::command_node::ExtraNodeData2::PropertiesBrigadierInteger::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_play_toClient::command_node::ExtraNodeData2::PropertiesBrigadierInteger::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeIntBE, (int32_t)v4.min); /*0.4*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeIntBE, (int32_t)v4.max); /*0.4*/
             }
         }
-        else if (parser == "brigadier:long") { /*8.0*/
+        else if (V_parser == "brigadier:long") { /*8.0*/
             const pdef::pc1_18_play_toClient::command_node::ExtraNodeData2::PropertiesBrigadierLong &v4 = *v2.properties_brigadier_long; /*8.5*/
             uint8_t flags_val = 0;
             flags_val |= (uint8_t)v4.flags.unused << 0;
             flags_val |= (uint8_t)v4.flags.max_present << 6;
             flags_val |= (uint8_t)v4.flags.min_present << 7;
             WRITE_OR_BAIL(writeUByte, flags_val); /*flags: bitfield*/ /*4.2*/
-            const pdef::pc1_18_play_toClient::command_node::ExtraNodeData2::PropertiesBrigadierLong::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_play_toClient::command_node::ExtraNodeData2::PropertiesBrigadierLong::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeLongBE, (int64_t)v4.min); /*0.4*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeLongBE, (int64_t)v4.max); /*0.4*/
             }
         }
-        else if (parser == "brigadier:string") { /*8.0*/
+        else if (V_parser == "brigadier:string") { /*8.0*/
         }
-        else if (parser == "minecraft:entity") { /*8.0*/
+        else if (V_parser == "minecraft:entity") { /*8.0*/
           uint8_t properties_minecraft_entity_val = 0;
           properties_minecraft_entity_val |= (uint8_t)v2.properties_minecraft_entity.unused << 0;
           properties_minecraft_entity_val |= (uint8_t)v2.properties_minecraft_entity.onlyAllowPlayers << 6;
           properties_minecraft_entity_val |= (uint8_t)v2.properties_minecraft_entity.onlyAllowEntities << 7;
           WRITE_OR_BAIL(writeUByte, properties_minecraft_entity_val); /*properties_minecraft_entity: bitfield*/ /*4.2*/
         }
-        else if (parser == "minecraft:game_profile") { /*8.0*/
+        else if (V_parser == "minecraft:game_profile") { /*8.0*/
         }
-        else if (parser == "minecraft:block_pos") { /*8.0*/
+        else if (V_parser == "minecraft:block_pos") { /*8.0*/
         }
-        else if (parser == "minecraft:column_pos") { /*8.0*/
+        else if (V_parser == "minecraft:column_pos") { /*8.0*/
         }
-        else if (parser == "minecraft:vec3") { /*8.0*/
+        else if (V_parser == "minecraft:vec3") { /*8.0*/
         }
-        else if (parser == "minecraft:vec2") { /*8.0*/
+        else if (V_parser == "minecraft:vec2") { /*8.0*/
         }
-        else if (parser == "minecraft:block_state") { /*8.0*/
+        else if (V_parser == "minecraft:block_state") { /*8.0*/
         }
-        else if (parser == "minecraft:block_predicate") { /*8.0*/
+        else if (V_parser == "minecraft:block_predicate") { /*8.0*/
         }
-        else if (parser == "minecraft:item_stack") { /*8.0*/
+        else if (V_parser == "minecraft:item_stack") { /*8.0*/
         }
-        else if (parser == "minecraft:item_predicate") { /*8.0*/
+        else if (V_parser == "minecraft:item_predicate") { /*8.0*/
         }
-        else if (parser == "minecraft:color") { /*8.0*/
+        else if (V_parser == "minecraft:color") { /*8.0*/
         }
-        else if (parser == "minecraft:component") { /*8.0*/
+        else if (V_parser == "minecraft:component") { /*8.0*/
         }
-        else if (parser == "minecraft:message") { /*8.0*/
+        else if (V_parser == "minecraft:message") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt") { /*8.0*/
+        else if (V_parser == "minecraft:nbt") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt_path") { /*8.0*/
+        else if (V_parser == "minecraft:nbt_path") { /*8.0*/
         }
-        else if (parser == "minecraft:objective") { /*8.0*/
+        else if (V_parser == "minecraft:objective") { /*8.0*/
         }
-        else if (parser == "minecraft:objective_criteria") { /*8.0*/
+        else if (V_parser == "minecraft:objective_criteria") { /*8.0*/
         }
-        else if (parser == "minecraft:operation") { /*8.0*/
+        else if (V_parser == "minecraft:operation") { /*8.0*/
         }
-        else if (parser == "minecraft:particle") { /*8.0*/
+        else if (V_parser == "minecraft:particle") { /*8.0*/
         }
-        else if (parser == "minecraft:angle") { /*8.0*/
+        else if (V_parser == "minecraft:angle") { /*8.0*/
         }
-        else if (parser == "minecraft:rotation") { /*8.0*/
+        else if (V_parser == "minecraft:rotation") { /*8.0*/
         }
-        else if (parser == "minecraft:scoreboard_slot") { /*8.0*/
+        else if (V_parser == "minecraft:scoreboard_slot") { /*8.0*/
         }
-        else if (parser == "minecraft:score_holder") { /*8.0*/
+        else if (V_parser == "minecraft:score_holder") { /*8.0*/
           uint8_t properties_minecraft_score_holder_val = 0;
           properties_minecraft_score_holder_val |= (uint8_t)v2.properties_minecraft_score_holder.unused << 0;
           properties_minecraft_score_holder_val |= (uint8_t)v2.properties_minecraft_score_holder.allowMultiple << 7;
           WRITE_OR_BAIL(writeUByte, properties_minecraft_score_holder_val); /*properties_minecraft_score_holder: bitfield*/ /*4.2*/
         }
-        else if (parser == "minecraft:swizzle") { /*8.0*/
+        else if (V_parser == "minecraft:swizzle") { /*8.0*/
         }
-        else if (parser == "minecraft:team") { /*8.0*/
+        else if (V_parser == "minecraft:team") { /*8.0*/
         }
-        else if (parser == "minecraft:item_slot") { /*8.0*/
+        else if (V_parser == "minecraft:item_slot") { /*8.0*/
         }
-        else if (parser == "minecraft:resource_location") { /*8.0*/
+        else if (V_parser == "minecraft:resource_location") { /*8.0*/
         }
-        else if (parser == "minecraft:mob_effect") { /*8.0*/
+        else if (V_parser == "minecraft:mob_effect") { /*8.0*/
         }
-        else if (parser == "minecraft:function") { /*8.0*/
+        else if (V_parser == "minecraft:function") { /*8.0*/
         }
-        else if (parser == "minecraft:entity_anchor") { /*8.0*/
+        else if (V_parser == "minecraft:entity_anchor") { /*8.0*/
         }
-        else if (parser == "minecraft:range") { /*8.0*/
+        else if (V_parser == "minecraft:range") { /*8.0*/
             const pdef::pc1_18_play_toClient::command_node::ExtraNodeData2::PropertiesMinecraftRange &v4 = *v2.properties_minecraft_range; /*8.5*/
             WRITE_OR_BAIL(writeBool, (bool)v4.allowDecimals); /*0.4*/
         }
-        else if (parser == "minecraft:int_range") { /*8.0*/
+        else if (V_parser == "minecraft:int_range") { /*8.0*/
         }
-        else if (parser == "minecraft:float_range") { /*8.0*/
+        else if (V_parser == "minecraft:float_range") { /*8.0*/
         }
-        else if (parser == "minecraft:item_enchantment") { /*8.0*/
+        else if (V_parser == "minecraft:item_enchantment") { /*8.0*/
         }
-        else if (parser == "minecraft:entity_summon") { /*8.0*/
+        else if (V_parser == "minecraft:entity_summon") { /*8.0*/
         }
-        else if (parser == "minecraft:dimension") { /*8.0*/
+        else if (V_parser == "minecraft:dimension") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt_compound_tag") { /*8.0*/
+        else if (V_parser == "minecraft:nbt_compound_tag") { /*8.0*/
         }
-        else if (parser == "minecraft:time") { /*8.0*/
+        else if (V_parser == "minecraft:time") { /*8.0*/
         }
-        else if (parser == "minecraft:resource_or_tag") { /*8.0*/
+        else if (V_parser == "minecraft:resource_or_tag") { /*8.0*/
             const pdef::pc1_18_play_toClient::command_node::ExtraNodeData2::PropertiesMinecraftResourceOrTagOrMinecraftResource &v4 = *v2.properties_minecraft_resource_or_tag_or_minecraft_resource; /*8.5*/
             WRITE_OR_BAIL(writeUnsignedVarInt, (int)v4.registry.length());
             WRITE_OR_BAIL(writeString, v4.registry); /*registry: pstring*/ /*4.2*/
         }
-        else if (parser == "minecraft:resource") { /*8.0*/
+        else if (V_parser == "minecraft:resource") { /*8.0*/
             const pdef::pc1_18_play_toClient::command_node::ExtraNodeData2::PropertiesMinecraftResourceOrTagOrMinecraftResource &v4 = *v2.properties_minecraft_resource_or_tag_or_minecraft_resource; /*8.5*/
             WRITE_OR_BAIL(writeUnsignedVarInt, (int)v4.registry.length());
             WRITE_OR_BAIL(writeString, v4.registry); /*registry: pstring*/ /*4.2*/
         }
-        else if (parser == "minecraft:uuid") { /*8.0*/
+        else if (V_parser == "minecraft:uuid") { /*8.0*/
         }
-        if (flags.has_custom_suggestions == 1) { /*8.2*/
+        if (V_flags.has_custom_suggestions == 1) { /*8.2*/
           WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.suggestionType.length());
           WRITE_OR_BAIL(writeString, v2.suggestionType); /*suggestionType: pstring*/ /*4.2*/
         }
@@ -4121,38 +4121,38 @@ bool tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj, boo
   bool packet_boss_bar(pdef::Stream &stream, const pdef::pc1_18_play_toClient::packet_boss_bar &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::pc1_18_play_toClient::size::packet_boss_bar(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
     WRITE_OR_BAIL(writeULongBE, (uint64_t)obj.entityUUID); /*0.4*/
-    const int &action = obj.action; /*0.1*/
+    const int &V_action = obj.action; /*0.1*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.action); /*0.4*/
-    if (action == 0) { /*8.2*/
+    if (V_action == 0) { /*8.2*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.title.length());
       WRITE_OR_BAIL(writeString, obj.title); /*title: pstring*/ /*4.2*/
     }
-    else if (action == 3) { /*8.2*/
+    else if (V_action == 3) { /*8.2*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.title.length());
       WRITE_OR_BAIL(writeString, obj.title); /*title: pstring*/ /*4.2*/
     }
-    if (action == 0) { /*8.2*/
+    if (V_action == 0) { /*8.2*/
       WRITE_OR_BAIL(writeFloatBE, (float)obj.health); /*0.4*/
     }
-    else if (action == 2) { /*8.2*/
+    else if (V_action == 2) { /*8.2*/
       WRITE_OR_BAIL(writeFloatBE, (float)obj.health); /*0.4*/
     }
-    if (action == 0) { /*8.2*/
+    if (V_action == 0) { /*8.2*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.color); /*0.4*/
     }
-    else if (action == 4) { /*8.2*/
+    else if (V_action == 4) { /*8.2*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.color); /*0.4*/
     }
-    if (action == 0) { /*8.2*/
+    if (V_action == 0) { /*8.2*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.dividers); /*0.4*/
     }
-    else if (action == 4) { /*8.2*/
+    else if (V_action == 4) { /*8.2*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.dividers); /*0.4*/
     }
-    if (action == 0) { /*8.2*/
+    if (V_action == 0) { /*8.2*/
       WRITE_OR_BAIL(writeUByte, (uint8_t)obj.flags); /*0.4*/
     }
-    else if (action == 5) { /*8.2*/
+    else if (V_action == 5) { /*8.2*/
       WRITE_OR_BAIL(writeUByte, (uint8_t)obj.flags); /*0.4*/
     }
     return true;
@@ -4191,12 +4191,12 @@ bool tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj, boo
     WRITE_OR_BAIL(writeDoubleBE, (double)obj.x); /*0.4*/
     WRITE_OR_BAIL(writeDoubleBE, (double)obj.y); /*0.4*/
     WRITE_OR_BAIL(writeDoubleBE, (double)obj.z); /*0.4*/
-    const bool &isEntity = obj.isEntity; /*0.1*/
+    const bool &V_isEntity = obj.isEntity; /*0.1*/
     WRITE_OR_BAIL(writeBool, (bool)obj.isEntity); /*0.4*/
-    if (isEntity == true) { /*8.1*/
+    if (V_isEntity == true) { /*8.1*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.entityId); /*0.4*/
     }
-    if (isEntity == true) { /*8.1*/
+    if (V_isEntity == true) { /*8.1*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.entity_feet_eyes.length());
       WRITE_OR_BAIL(writeString, obj.entity_feet_eyes); /*entity_feet_eyes: pstring*/ /*4.2*/
     }
@@ -4405,7 +4405,7 @@ bool tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj, boo
   }
   bool packet_world_particles(pdef::Stream &stream, const pdef::pc1_18_play_toClient::packet_world_particles &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::pc1_18_play_toClient::size::packet_world_particles(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const int32_t &particleId = obj.particleId; /*0.1*/
+    const int32_t &V_particleId = obj.particleId; /*0.1*/
     WRITE_OR_BAIL(writeIntBE, (int32_t)obj.particleId); /*0.4*/
     WRITE_OR_BAIL(writeBool, (bool)obj.longDistance); /*0.4*/
     WRITE_OR_BAIL(writeDoubleBE, (double)obj.x); /*0.4*/
@@ -4416,22 +4416,22 @@ bool tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj, boo
     WRITE_OR_BAIL(writeFloatBE, (float)obj.offsetZ); /*0.4*/
     WRITE_OR_BAIL(writeFloatBE, (float)obj.particleData); /*0.4*/
     WRITE_OR_BAIL(writeIntBE, (int32_t)obj.particles); /*0.4*/
-    if (particleId == 2) { /*8.2*/
+    if (V_particleId == 2) { /*8.2*/
         const pdef::pc1_18_play_toClient::packet_world_particles::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.5*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.blockState); /*0.4*/
     }
-    else if (particleId == 3) { /*8.2*/
+    else if (V_particleId == 3) { /*8.2*/
         const pdef::pc1_18_play_toClient::packet_world_particles::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.5*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.blockState); /*0.4*/
     }
-    else if (particleId == 14) { /*8.2*/
+    else if (V_particleId == 14) { /*8.2*/
         const pdef::pc1_18_play_toClient::packet_world_particles::Data14 &v2 = *obj.data_14; /*8.5*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.red); /*0.4*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.green); /*0.4*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.blue); /*0.4*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.scale); /*0.4*/
     }
-    else if (particleId == 15) { /*8.2*/
+    else if (V_particleId == 15) { /*8.2*/
         const pdef::pc1_18_play_toClient::packet_world_particles::Data15 &v2 = *obj.data_15; /*8.5*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.fromRed); /*0.4*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.fromGreen); /*0.4*/
@@ -4441,15 +4441,15 @@ bool tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj, boo
         WRITE_OR_BAIL(writeFloatBE, (float)v2.toGreen); /*0.4*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.toBlue); /*0.4*/
     }
-    else if (particleId == 24) { /*8.2*/
+    else if (V_particleId == 24) { /*8.2*/
         const pdef::pc1_18_play_toClient::packet_world_particles::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.5*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.blockState); /*0.4*/
     }
-    else if (particleId == 35) { /*8.2*/
+    else if (V_particleId == 35) { /*8.2*/
         const pdef::pc1_18_play_toClient::packet_world_particles::Data35 &v2 = *obj.data_35; /*8.5*/
         WRITE_OR_BAIL(writeByte, (int8_t)v2.item); /*0.4*/
     }
-    else if (particleId == 36) { /*8.2*/
+    else if (V_particleId == 36) { /*8.2*/
         const pdef::pc1_18_play_toClient::packet_world_particles::Data36 &v2 = *obj.data_36; /*8.5*/
         uint64_t origin_val = 0;
         origin_val |= (uint64_t)v2.origin.x << 0;
@@ -4458,15 +4458,15 @@ bool tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj, boo
         WRITE_OR_BAIL(writeULongBE, origin_val); /*origin: bitfield*/ /*4.2*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.positionType.length());
         WRITE_OR_BAIL(writeString, v2.positionType); /*positionType: pstring*/ /*4.2*/
-        const std::string &positionType = v2.positionType; /*4.7*/
-        if (positionType == "minecraft:block") { /*8.0*/
+        const std::string &V_positionType = v2.positionType; /*4.7*/
+        if (V_positionType == "minecraft:block") { /*8.0*/
           uint64_t destination_position_val = 0;
           destination_position_val |= (uint64_t)v2.destination_position.x << 0;
           destination_position_val |= (uint64_t)v2.destination_position.z << 26;
           destination_position_val |= (uint64_t)v2.destination_position.y << 52;
           WRITE_OR_BAIL(writeULongBE, destination_position_val); /*destination_position: bitfield*/ /*4.2*/
         }
-        else if (positionType == "minecraft:entity") { /*8.0*/
+        else if (V_positionType == "minecraft:entity") { /*8.0*/
           WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.destination_varint); /*0.4*/
         }
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.ticks); /*0.4*/
@@ -4541,24 +4541,24 @@ bool tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj, boo
     WRITE_OR_BAIL(writeByte, (int8_t)obj.scale); /*0.4*/
     WRITE_OR_BAIL(writeBool, (bool)obj.locked); /*0.4*/
     const pdef::pc1_18_play_toClient::packet_map::Icons &v = obj.icons; /*["packet_map"]*/ /*7.4*/
-    const uint8_t &columns = obj.columns; /*0.1*/
+    const uint8_t &V_columns = obj.columns; /*0.1*/
     WRITE_OR_BAIL(writeUByte, (uint8_t)obj.columns); /*0.4*/
-    if (columns == 0) { /*8.2*/
+    if (V_columns == 0) { /*8.2*/
     }
     else {
       WRITE_OR_BAIL(writeUByte, (uint8_t)obj.rows); /*0.4*/
     }
-    if (columns == 0) { /*8.2*/
+    if (V_columns == 0) { /*8.2*/
     }
     else {
       WRITE_OR_BAIL(writeUByte, (uint8_t)obj.x); /*0.4*/
     }
-    if (columns == 0) { /*8.2*/
+    if (V_columns == 0) { /*8.2*/
     }
     else {
       WRITE_OR_BAIL(writeUByte, (uint8_t)obj.y); /*0.4*/
     }
-    if (columns == 0) { /*8.2*/
+    if (V_columns == 0) { /*8.2*/
     }
     else {
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.data.size());
@@ -4673,16 +4673,16 @@ bool tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj, boo
   }
   bool packet_player_info(pdef::Stream &stream, const pdef::pc1_18_play_toClient::packet_player_info &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::pc1_18_play_toClient::size::packet_player_info(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const int &action = obj.action; /*0.1*/
+    const int &V_action = obj.action; /*0.1*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.action); /*0.4*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.data.size()); /*1.4*/
     for (const auto &v2 : obj.data) { /*5.20*/
       WRITE_OR_BAIL(writeULongBE, (uint64_t)v2.UUID); /*0.4*/
-      if (action == 0) { /*8.2*/
+      if (V_action == 0) { /*8.2*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.name.length());
         WRITE_OR_BAIL(writeString, v2.name); /*name: pstring*/ /*4.2*/
       }
-      if (action == 0) { /*8.2*/
+      if (V_action == 0) { /*8.2*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.properties.size()); /*1.4*/
         for (const auto &v4 : v2.properties) { /*5.20*/
           WRITE_OR_BAIL(writeUnsignedVarInt, (int)v4.name.length());
@@ -4692,32 +4692,32 @@ bool tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj, boo
           const pdef::pc1_18_play_toClient::packet_player_info::Data::Properties::Signature &v = v4.signature; /*["packet_player_info","Data","Properties"]*/ /*7.4*/
         }
       }
-      if (action == 0) { /*8.2*/
+      if (V_action == 0) { /*8.2*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.gamemode); /*0.4*/
       }
-      else if (action == 1) { /*8.2*/
+      else if (V_action == 1) { /*8.2*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.gamemode); /*0.4*/
       }
-      if (action == 0) { /*8.2*/
+      if (V_action == 0) { /*8.2*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.ping); /*0.4*/
       }
-      else if (action == 2) { /*8.2*/
+      else if (V_action == 2) { /*8.2*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.ping); /*0.4*/
       }
-      if (action == 0) { /*8.2*/
+      if (V_action == 0) { /*8.2*/
           const pdef::pc1_18_play_toClient::packet_player_info::Data::DisplayName &v3 = *v2.displayName; /*8.5*/
-          const bool &has = v3.has; /*0.1*/
+          const bool &V_has = v3.has; /*0.1*/
           WRITE_OR_BAIL(writeBool, (bool)v3.has); /*0.4*/
-          if (has == true) { /*8.1*/
+          if (V_has == true) { /*8.1*/
             WRITE_OR_BAIL(writeUnsignedVarInt, (int)v3.value.length());
             WRITE_OR_BAIL(writeString, v3.value); /*value: pstring*/ /*4.2*/
           }
       }
-      else if (action == 3) { /*8.2*/
+      else if (V_action == 3) { /*8.2*/
           const pdef::pc1_18_play_toClient::packet_player_info::Data::DisplayName &v3 = *v2.displayName; /*8.5*/
-          const bool &has = v3.has; /*0.1*/
+          const bool &V_has = v3.has; /*0.1*/
           WRITE_OR_BAIL(writeBool, (bool)v3.has); /*0.4*/
-          if (has == true) { /*8.1*/
+          if (V_has == true) { /*8.1*/
             WRITE_OR_BAIL(writeUnsignedVarInt, (int)v3.value.length());
             WRITE_OR_BAIL(writeString, v3.value); /*value: pstring*/ /*4.2*/
           }
@@ -4739,7 +4739,7 @@ bool tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj, boo
   }
   bool packet_unlock_recipes(pdef::Stream &stream, const pdef::pc1_18_play_toClient::packet_unlock_recipes &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::pc1_18_play_toClient::size::packet_unlock_recipes(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const int &action = obj.action; /*0.1*/
+    const int &V_action = obj.action; /*0.1*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.action); /*0.4*/
     WRITE_OR_BAIL(writeBool, (bool)obj.craftingBookOpen); /*0.4*/
     WRITE_OR_BAIL(writeBool, (bool)obj.filteringCraftable); /*0.4*/
@@ -4754,7 +4754,7 @@ bool tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj, boo
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.length());
       WRITE_OR_BAIL(writeString, v2); /*: pstring*/ /*4.2*/
     }
-    if (action == 0) { /*8.2*/
+    if (V_action == 0) { /*8.2*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.recipes2.size()); /*1.4*/
       for (const auto &v3 : obj.recipes2) { /*3.1*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v3.length());
@@ -4878,20 +4878,20 @@ bool tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj, boo
     if (allocate) { auto writeSize = pdef::pc1_18_play_toClient::size::packet_scoreboard_objective(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.name.length());
     WRITE_OR_BAIL(writeString, obj.name); /*name: pstring*/ /*4.2*/
-    const int8_t &action = obj.action; /*0.1*/
+    const int8_t &V_action = obj.action; /*0.1*/
     WRITE_OR_BAIL(writeByte, (int8_t)obj.action); /*0.4*/
-    if (action == 0) { /*8.2*/
+    if (V_action == 0) { /*8.2*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.displayText.length());
       WRITE_OR_BAIL(writeString, obj.displayText); /*displayText: pstring*/ /*4.2*/
     }
-    else if (action == 2) { /*8.2*/
+    else if (V_action == 2) { /*8.2*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.displayText.length());
       WRITE_OR_BAIL(writeString, obj.displayText); /*displayText: pstring*/ /*4.2*/
     }
-    if (action == 0) { /*8.2*/
+    if (V_action == 0) { /*8.2*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.type); /*0.4*/
     }
-    else if (action == 2) { /*8.2*/
+    else if (V_action == 2) { /*8.2*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.type); /*0.4*/
     }
     return true;
@@ -4909,75 +4909,75 @@ bool tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj, boo
     if (allocate) { auto writeSize = pdef::pc1_18_play_toClient::size::packet_teams(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.team.length());
     WRITE_OR_BAIL(writeString, obj.team); /*team: pstring*/ /*4.2*/
-    const int8_t &mode = obj.mode; /*0.1*/
+    const int8_t &V_mode = obj.mode; /*0.1*/
     WRITE_OR_BAIL(writeByte, (int8_t)obj.mode); /*0.4*/
-    if (mode == 0) { /*8.2*/
+    if (V_mode == 0) { /*8.2*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.name.length());
       WRITE_OR_BAIL(writeString, obj.name); /*name: pstring*/ /*4.2*/
     }
-    else if (mode == 2) { /*8.2*/
+    else if (V_mode == 2) { /*8.2*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.name.length());
       WRITE_OR_BAIL(writeString, obj.name); /*name: pstring*/ /*4.2*/
     }
-    if (mode == 0) { /*8.2*/
+    if (V_mode == 0) { /*8.2*/
       WRITE_OR_BAIL(writeByte, (int8_t)obj.friendlyFire); /*0.4*/
     }
-    else if (mode == 2) { /*8.2*/
+    else if (V_mode == 2) { /*8.2*/
       WRITE_OR_BAIL(writeByte, (int8_t)obj.friendlyFire); /*0.4*/
     }
-    if (mode == 0) { /*8.2*/
+    if (V_mode == 0) { /*8.2*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.nameTagVisibility.length());
       WRITE_OR_BAIL(writeString, obj.nameTagVisibility); /*nameTagVisibility: pstring*/ /*4.2*/
     }
-    else if (mode == 2) { /*8.2*/
+    else if (V_mode == 2) { /*8.2*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.nameTagVisibility.length());
       WRITE_OR_BAIL(writeString, obj.nameTagVisibility); /*nameTagVisibility: pstring*/ /*4.2*/
     }
-    if (mode == 0) { /*8.2*/
+    if (V_mode == 0) { /*8.2*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.collisionRule.length());
       WRITE_OR_BAIL(writeString, obj.collisionRule); /*collisionRule: pstring*/ /*4.2*/
     }
-    else if (mode == 2) { /*8.2*/
+    else if (V_mode == 2) { /*8.2*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.collisionRule.length());
       WRITE_OR_BAIL(writeString, obj.collisionRule); /*collisionRule: pstring*/ /*4.2*/
     }
-    if (mode == 0) { /*8.2*/
+    if (V_mode == 0) { /*8.2*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.formatting); /*0.4*/
     }
-    else if (mode == 2) { /*8.2*/
+    else if (V_mode == 2) { /*8.2*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.formatting); /*0.4*/
     }
-    if (mode == 0) { /*8.2*/
+    if (V_mode == 0) { /*8.2*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.prefix.length());
       WRITE_OR_BAIL(writeString, obj.prefix); /*prefix: pstring*/ /*4.2*/
     }
-    else if (mode == 2) { /*8.2*/
+    else if (V_mode == 2) { /*8.2*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.prefix.length());
       WRITE_OR_BAIL(writeString, obj.prefix); /*prefix: pstring*/ /*4.2*/
     }
-    if (mode == 0) { /*8.2*/
+    if (V_mode == 0) { /*8.2*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.suffix.length());
       WRITE_OR_BAIL(writeString, obj.suffix); /*suffix: pstring*/ /*4.2*/
     }
-    else if (mode == 2) { /*8.2*/
+    else if (V_mode == 2) { /*8.2*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.suffix.length());
       WRITE_OR_BAIL(writeString, obj.suffix); /*suffix: pstring*/ /*4.2*/
     }
-    if (mode == 0) { /*8.2*/
+    if (V_mode == 0) { /*8.2*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.players.size()); /*1.4*/
       for (const auto &v3 : obj.players) { /*3.1*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v3.length());
         WRITE_OR_BAIL(writeString, v3); /*: pstring*/ /*4.2*/
       }
     }
-    else if (mode == 3) { /*8.2*/
+    else if (V_mode == 3) { /*8.2*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.players.size()); /*1.4*/
       for (const auto &v3 : obj.players) { /*3.1*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v3.length());
         WRITE_OR_BAIL(writeString, v3); /*: pstring*/ /*4.2*/
       }
     }
-    else if (mode == 4) { /*8.2*/
+    else if (V_mode == 4) { /*8.2*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.players.size()); /*1.4*/
       for (const auto &v3 : obj.players) { /*3.1*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v3.length());
@@ -4990,11 +4990,11 @@ bool tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj, boo
     if (allocate) { auto writeSize = pdef::pc1_18_play_toClient::size::packet_scoreboard_score(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.itemName.length());
     WRITE_OR_BAIL(writeString, obj.itemName); /*itemName: pstring*/ /*4.2*/
-    const int &action = obj.action; /*0.1*/
+    const int &V_action = obj.action; /*0.1*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.action); /*0.4*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.scoreName.length());
     WRITE_OR_BAIL(writeString, obj.scoreName); /*scoreName: pstring*/ /*4.2*/
-    if (action == 1) { /*8.2*/
+    if (V_action == 1) { /*8.2*/
     }
     else {
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.value); /*0.4*/
@@ -5028,19 +5028,19 @@ bool tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj, boo
   }
   bool packet_stop_sound(pdef::Stream &stream, const pdef::pc1_18_play_toClient::packet_stop_sound &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::pc1_18_play_toClient::size::packet_stop_sound(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const int8_t &flags = obj.flags; /*0.1*/
+    const int8_t &V_flags = obj.flags; /*0.1*/
     WRITE_OR_BAIL(writeByte, (int8_t)obj.flags); /*0.4*/
-    if (flags == 1) { /*8.2*/
+    if (V_flags == 1) { /*8.2*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.source); /*0.4*/
     }
-    else if (flags == 3) { /*8.2*/
+    else if (V_flags == 3) { /*8.2*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.source); /*0.4*/
     }
-    if (flags == 2) { /*8.2*/
+    if (V_flags == 2) { /*8.2*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.sound.length());
       WRITE_OR_BAIL(writeString, obj.sound); /*sound: pstring*/ /*4.2*/
     }
-    else if (flags == 3) { /*8.2*/
+    else if (V_flags == 3) { /*8.2*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.sound.length());
       WRITE_OR_BAIL(writeString, obj.sound); /*sound: pstring*/ /*4.2*/
     }
@@ -5120,10 +5120,10 @@ bool tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj, boo
     for (const auto &v2 : obj.recipes) { /*5.20*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.type.length());
       WRITE_OR_BAIL(writeString, v2.type); /*type: pstring*/ /*4.2*/
-      const std::string &type = v2.type; /*4.7*/
+      const std::string &V_type = v2.type; /*4.7*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.recipeId.length());
       WRITE_OR_BAIL(writeString, v2.recipeId); /*recipeId: pstring*/ /*4.2*/
-      if (type == "minecraft:crafting_shapeless") { /*8.0*/
+      if (V_type == "minecraft:crafting_shapeless") { /*8.0*/
           const pdef::pc1_18_play_toClient::packet_declare_recipes::Recipes::DataMinecraftCraftingShapeless &v3 = *v2.data_minecraft_crafting_shapeless; /*8.5*/
           WRITE_OR_BAIL(writeUnsignedVarInt, (int)v3.group.length());
           WRITE_OR_BAIL(writeString, v3.group); /*group: pstring*/ /*4.2*/
@@ -5136,16 +5136,16 @@ bool tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj, boo
           }
           WRITE_OR_BAIL(writeByte, (int8_t)v3.result); /*0.4*/
       }
-      else if (type == "minecraft:crafting_shaped") { /*8.0*/
+      else if (V_type == "minecraft:crafting_shaped") { /*8.0*/
           const pdef::pc1_18_play_toClient::packet_declare_recipes::Recipes::DataMinecraftCraftingShaped &v3 = *v2.data_minecraft_crafting_shaped; /*8.5*/
-          const int &width = v3.width; /*0.1*/
+          const int &V_width = v3.width; /*0.1*/
           WRITE_OR_BAIL(writeUnsignedVarInt, (int)v3.width); /*0.4*/
-          const int &height = v3.height; /*0.1*/
+          const int &V_height = v3.height; /*0.1*/
           WRITE_OR_BAIL(writeUnsignedVarInt, (int)v3.height); /*0.4*/
           WRITE_OR_BAIL(writeUnsignedVarInt, (int)v3.group.length());
           WRITE_OR_BAIL(writeString, v3.group); /*group: pstring*/ /*4.2*/
           for (const auto &v : v3.ingredients) { /*5.1*/
-            WRITE_OR_BAIL(writeUnsignedVarInt, (int)height); /*5.4*/
+            WRITE_OR_BAIL(writeUnsignedVarInt, (int)V_height); /*5.4*/
             for (const auto &v : v) { /*5.10*/
               WRITE_OR_BAIL(writeUnsignedVarInt, (int)v.size()); /*1.4*/
               for (const auto &v7 : v) { /*3.1*/
@@ -5155,47 +5155,47 @@ bool tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj, boo
           }
           WRITE_OR_BAIL(writeByte, (int8_t)v3.result); /*0.4*/
       }
-      else if (type == "minecraft:crafting_special_armordye") { /*8.0*/
+      else if (V_type == "minecraft:crafting_special_armordye") { /*8.0*/
       }
-      else if (type == "minecraft:crafting_special_bookcloning") { /*8.0*/
+      else if (V_type == "minecraft:crafting_special_bookcloning") { /*8.0*/
       }
-      else if (type == "minecraft:crafting_special_mapcloning") { /*8.0*/
+      else if (V_type == "minecraft:crafting_special_mapcloning") { /*8.0*/
       }
-      else if (type == "minecraft:crafting_special_mapextending") { /*8.0*/
+      else if (V_type == "minecraft:crafting_special_mapextending") { /*8.0*/
       }
-      else if (type == "minecraft:crafting_special_firework_rocket") { /*8.0*/
+      else if (V_type == "minecraft:crafting_special_firework_rocket") { /*8.0*/
       }
-      else if (type == "minecraft:crafting_special_firework_star") { /*8.0*/
+      else if (V_type == "minecraft:crafting_special_firework_star") { /*8.0*/
       }
-      else if (type == "minecraft:crafting_special_firework_star_fade") { /*8.0*/
+      else if (V_type == "minecraft:crafting_special_firework_star_fade") { /*8.0*/
       }
-      else if (type == "minecraft:crafting_special_repairitem") { /*8.0*/
+      else if (V_type == "minecraft:crafting_special_repairitem") { /*8.0*/
       }
-      else if (type == "minecraft:crafting_special_tippedarrow") { /*8.0*/
+      else if (V_type == "minecraft:crafting_special_tippedarrow") { /*8.0*/
       }
-      else if (type == "minecraft:crafting_special_bannerduplicate") { /*8.0*/
+      else if (V_type == "minecraft:crafting_special_bannerduplicate") { /*8.0*/
       }
-      else if (type == "minecraft:crafting_special_banneraddpattern") { /*8.0*/
+      else if (V_type == "minecraft:crafting_special_banneraddpattern") { /*8.0*/
       }
-      else if (type == "minecraft:crafting_special_shielddecoration") { /*8.0*/
+      else if (V_type == "minecraft:crafting_special_shielddecoration") { /*8.0*/
       }
-      else if (type == "minecraft:crafting_special_shulkerboxcoloring") { /*8.0*/
+      else if (V_type == "minecraft:crafting_special_shulkerboxcoloring") { /*8.0*/
       }
-      else if (type == "minecraft:crafting_special_suspiciousstew") { /*8.0*/
+      else if (V_type == "minecraft:crafting_special_suspiciousstew") { /*8.0*/
       }
-      else if (type == "minecraft:smelting") { /*8.0*/
+      else if (V_type == "minecraft:smelting") { /*8.0*/
         pdef::pc1_18_play_toClient::encode::minecraft_smelting_format(stream, *v2.data_minecraft_smelting_format); /*minecraft_smelting_format*/ /*4.5*/
       }
-      else if (type == "minecraft:blasting") { /*8.0*/
+      else if (V_type == "minecraft:blasting") { /*8.0*/
         pdef::pc1_18_play_toClient::encode::minecraft_smelting_format(stream, *v2.data_minecraft_smelting_format); /*minecraft_smelting_format*/ /*4.5*/
       }
-      else if (type == "minecraft:smoking") { /*8.0*/
+      else if (V_type == "minecraft:smoking") { /*8.0*/
         pdef::pc1_18_play_toClient::encode::minecraft_smelting_format(stream, *v2.data_minecraft_smelting_format); /*minecraft_smelting_format*/ /*4.5*/
       }
-      else if (type == "minecraft:campfire_cooking") { /*8.0*/
+      else if (V_type == "minecraft:campfire_cooking") { /*8.0*/
         pdef::pc1_18_play_toClient::encode::minecraft_smelting_format(stream, *v2.data_minecraft_smelting_format); /*minecraft_smelting_format*/ /*4.5*/
       }
-      else if (type == "minecraft:stonecutting") { /*8.0*/
+      else if (V_type == "minecraft:stonecutting") { /*8.0*/
           const pdef::pc1_18_play_toClient::packet_declare_recipes::Recipes::DataMinecraftStonecutting &v3 = *v2.data_minecraft_stonecutting; /*8.5*/
           WRITE_OR_BAIL(writeUnsignedVarInt, (int)v3.group.length());
           WRITE_OR_BAIL(writeString, v3.group); /*group: pstring*/ /*4.2*/
@@ -5205,7 +5205,7 @@ bool tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj, boo
           }
           WRITE_OR_BAIL(writeByte, (int8_t)v3.result); /*0.4*/
       }
-      else if (type == "minecraft:smithing") { /*8.0*/
+      else if (V_type == "minecraft:smithing") { /*8.0*/
           const pdef::pc1_18_play_toClient::packet_declare_recipes::Recipes::DataMinecraftSmithing &v3 = *v2.data_minecraft_smithing; /*8.5*/
           WRITE_OR_BAIL(writeUnsignedVarInt, (int)v3.base.size()); /*1.4*/
           for (const auto &v5 : v3.base) { /*3.1*/
@@ -5252,15 +5252,15 @@ bool tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj, boo
     WRITE_OR_BAIL(writeULongBE, sourcePosition_val); /*sourcePosition: bitfield*/ /*4.2*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.destinationIdentifier.length());
     WRITE_OR_BAIL(writeString, obj.destinationIdentifier); /*destinationIdentifier: pstring*/ /*4.2*/
-    const std::string &destinationIdentifier = obj.destinationIdentifier; /*4.7*/
-    if (destinationIdentifier == "block") { /*8.0*/
+    const std::string &V_destinationIdentifier = obj.destinationIdentifier; /*4.7*/
+    if (V_destinationIdentifier == "block") { /*8.0*/
       uint64_t destination_position_val = 0;
       destination_position_val |= (uint64_t)obj.destination_position.x << 0;
       destination_position_val |= (uint64_t)obj.destination_position.z << 26;
       destination_position_val |= (uint64_t)obj.destination_position.y << 52;
       WRITE_OR_BAIL(writeULongBE, destination_position_val); /*destination_position: bitfield*/ /*4.2*/
     }
-    else if (destinationIdentifier == "entityId") { /*8.0*/
+    else if (V_destinationIdentifier == "entityId") { /*8.0*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.destination_varint); /*0.4*/
     }
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.arrivalTicks); /*0.4*/
@@ -5348,9 +5348,9 @@ bool tags(pdef::Stream &stream, const pdef::pc1_18_play_toClient::tags &obj, boo
   }
   bool packet(pdef::Stream &stream, const pdef::pc1_18_play_toClient::packet &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::pc1_18_play_toClient::size::packet(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const pdef::pc1_18_play_toClient::packet::Name &name = obj.name; /*0.3*/
+    const pdef::pc1_18_play_toClient::packet::Name &V_name = obj.name; /*0.3*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)(int&)obj.name); /*7.1*/
-    switch (name) { /*8.0*/
+    switch (V_name) { /*8.0*/
       case pdef::pc1_18_play_toClient::packet::Name::SpawnEntity: { /*8.5*/
         pdef::pc1_18_play_toClient::encode::packet_spawn_entity(stream, *obj.params_packet_spawn_entity); /*packet_spawn_entity*/ /*4.5*/
         break;
@@ -5887,10 +5887,10 @@ bool packet_simulation_distance(pdef::Stream &stream, pdef::pc1_18_play_toClient
 bool packet(pdef::Stream &stream, pdef::pc1_18_play_toClient::packet &obj);
   bool slot(pdef::Stream &stream, pdef::pc1_18_play_toClient::slot &obj) {
     READ_OR_BAIL(readBool, (bool&)obj.present); /*0.5*/
-    bool &present = obj.present; /*0.6*/
-    if (present == false) { /*8.1*/
+    bool &V_present = obj.present; /*0.6*/
+    if (V_present == false) { /*8.1*/
     }
-    else if (present == true) { /*8.1*/
+    else if (V_present == true) { /*8.1*/
         READ_OR_BAIL(readUnsignedVarInt, obj.itemId); /*0.5*/
         READ_OR_BAIL(readByte, obj.itemCount); /*0.5*/
         READ_OR_BAIL(readByte, obj.nbtData); /*0.5*/
@@ -5899,23 +5899,23 @@ bool packet(pdef::Stream &stream, pdef::pc1_18_play_toClient::packet &obj);
   }
   bool particle(pdef::Stream &stream, pdef::pc1_18_play_toClient::particle &obj) {
     READ_OR_BAIL(readUnsignedVarInt, obj.particleId); /*0.5*/
-    int &particleId = obj.particleId; /*0.6*/
-    if (particleId == 2) { /*8.2*/
+    int &V_particleId = obj.particleId; /*0.6*/
+    if (V_particleId == 2) { /*8.2*/
          obj.data_2_or_3_or_24 = {}; pdef::pc1_18_play_toClient::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.4*/
         READ_OR_BAIL(readUnsignedVarInt, v2.blockState); /*0.5*/
     }
-    else if (particleId == 3) { /*8.2*/
+    else if (V_particleId == 3) { /*8.2*/
          obj.data_2_or_3_or_24 = {}; pdef::pc1_18_play_toClient::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.4*/
         READ_OR_BAIL(readUnsignedVarInt, v2.blockState); /*0.5*/
     }
-    else if (particleId == 14) { /*8.2*/
+    else if (V_particleId == 14) { /*8.2*/
          obj.data_14 = {}; pdef::pc1_18_play_toClient::particle::Data14 &v2 = *obj.data_14; /*8.4*/
         READ_OR_BAIL(readFloatBE, v2.red); /*0.5*/
         READ_OR_BAIL(readFloatBE, v2.green); /*0.5*/
         READ_OR_BAIL(readFloatBE, v2.blue); /*0.5*/
         READ_OR_BAIL(readFloatBE, v2.scale); /*0.5*/
     }
-    else if (particleId == 15) { /*8.2*/
+    else if (V_particleId == 15) { /*8.2*/
          obj.data_15 = {}; pdef::pc1_18_play_toClient::particle::Data15 &v2 = *obj.data_15; /*8.4*/
         READ_OR_BAIL(readFloatBE, v2.fromRed); /*0.5*/
         READ_OR_BAIL(readFloatBE, v2.fromGreen); /*0.5*/
@@ -5925,15 +5925,15 @@ bool packet(pdef::Stream &stream, pdef::pc1_18_play_toClient::packet &obj);
         READ_OR_BAIL(readFloatBE, v2.toGreen); /*0.5*/
         READ_OR_BAIL(readFloatBE, v2.toBlue); /*0.5*/
     }
-    else if (particleId == 24) { /*8.2*/
+    else if (V_particleId == 24) { /*8.2*/
          obj.data_2_or_3_or_24 = {}; pdef::pc1_18_play_toClient::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.4*/
         READ_OR_BAIL(readUnsignedVarInt, v2.blockState); /*0.5*/
     }
-    else if (particleId == 35) { /*8.2*/
+    else if (V_particleId == 35) { /*8.2*/
          obj.data_35 = {}; pdef::pc1_18_play_toClient::particle::Data35 &v2 = *obj.data_35; /*8.4*/
         READ_OR_BAIL(readByte, v2.item); /*0.5*/
     }
-    else if (particleId == 36) { /*8.2*/
+    else if (V_particleId == 36) { /*8.2*/
          obj.data_36 = {}; pdef::pc1_18_play_toClient::particle::Data36 &v2 = *obj.data_36; /*8.4*/
         uint64_t origin_val;
         READ_OR_BAIL(readULongBE, origin_val);
@@ -5942,15 +5942,15 @@ bool packet(pdef::Stream &stream, pdef::pc1_18_play_toClient::packet &obj);
         v2.origin.y = origin_val >> 52 & 12; /*origin: bitfield*/ /*4.3*/
         int positionType_strlen; READ_OR_BAIL(readUnsignedVarInt, positionType_strlen);
         if (!stream.readString(v2.positionType, positionType_strlen)) return false; /*positionType: pstring*/ /*4.3*/
-        std::string &positionType = v2.positionType; /*4.8*/
-        if (positionType == "minecraft:block") { /*8.0*/
+        std::string &V_positionType = v2.positionType; /*4.8*/
+        if (V_positionType == "minecraft:block") { /*8.0*/
           uint64_t destination_position_val;
           READ_OR_BAIL(readULongBE, destination_position_val);
           v2.destination_position.x = destination_position_val >> 0 & 26;
           v2.destination_position.z = destination_position_val >> 26 & 26;
           v2.destination_position.y = destination_position_val >> 52 & 12; /*destination_position: bitfield*/ /*4.3*/
         }
-        else if (positionType == "minecraft:entity") { /*8.0*/
+        else if (V_positionType == "minecraft:entity") { /*8.0*/
           READ_OR_BAIL(readUnsignedVarInt, v2.destination_varint); /*0.5*/
         }
         READ_OR_BAIL(readUnsignedVarInt, v2.ticks); /*0.5*/
@@ -5962,7 +5962,7 @@ bool packet(pdef::Stream &stream, pdef::pc1_18_play_toClient::packet &obj);
     if (!stream.readString(obj.group, group_strlen)) return false; /*group: pstring*/ /*4.3*/
     int ingredient_len; READ_OR_BAIL(readUnsignedVarInt, ingredient_len); /*1.5*/
     obj.ingredient.resize(ingredient_len); /*1.6*/
-    for (int i = 0; i < ingredient_len; i++) {
+    for (int i = 0; i < ingredient_len; i++) { /*3.3*/
       auto &v2 = obj.ingredient[i]; /*3.4*/
       READ_OR_BAIL(readByte, v2); /*0.5*/
     }
@@ -5976,7 +5976,7 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_play_toClient::tags &obj) {
     if (!stream.readString(obj.tagName, tagName_strlen)) return false; /*tagName: pstring*/ /*4.3*/
     int entries_len; READ_OR_BAIL(readUnsignedVarInt, entries_len); /*1.5*/
     obj.entries.resize(entries_len); /*1.6*/
-    for (int i = 0; i < entries_len; i++) {
+    for (int i = 0; i < entries_len; i++) { /*3.3*/
       auto &v2 = obj.entries[i]; /*3.4*/
       READ_OR_BAIL(readUnsignedVarInt, v2); /*0.5*/
     }
@@ -6000,194 +6000,194 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_play_toClient::tags &obj) {
     obj.flags.has_redirect_node = flags_val >> 4 & 1;
     obj.flags.has_command = flags_val >> 5 & 1;
     obj.flags.command_node_type = flags_val >> 6 & 2; /*flags: bitfield*/ /*4.3*/
-    pdef::pc1_18_play_toClient::command_node::flags_t &flags = obj.flags; /*4.8*/
+    pdef::pc1_18_play_toClient::command_node::flags_t &V_flags = obj.flags; /*4.8*/
     int children_len; READ_OR_BAIL(readUnsignedVarInt, children_len); /*1.5*/
     obj.children.resize(children_len); /*1.6*/
-    for (int i = 0; i < children_len; i++) {
+    for (int i = 0; i < children_len; i++) { /*3.3*/
       auto &v2 = obj.children[i]; /*3.4*/
       READ_OR_BAIL(readUnsignedVarInt, v2); /*0.5*/
     }
-    if (flags.has_redirect_node == 1) { /*8.2*/
+    if (V_flags.has_redirect_node == 1) { /*8.2*/
       READ_OR_BAIL(readUnsignedVarInt, obj.redirectNode); /*0.5*/
     }
-    if (flags.command_node_type == 0) { /*8.2*/
+    if (V_flags.command_node_type == 0) { /*8.2*/
     }
-    else if (flags.command_node_type == 1) { /*8.2*/
+    else if (V_flags.command_node_type == 1) { /*8.2*/
          obj.extraNodeData_1 = {}; pdef::pc1_18_play_toClient::command_node::ExtraNodeData1 &v2 = *obj.extraNodeData_1; /*8.4*/
         int name_strlen; READ_OR_BAIL(readUnsignedVarInt, name_strlen);
         if (!stream.readString(v2.name, name_strlen)) return false; /*name: pstring*/ /*4.3*/
     }
-    else if (flags.command_node_type == 2) { /*8.2*/
+    else if (V_flags.command_node_type == 2) { /*8.2*/
          obj.extraNodeData_2 = {}; pdef::pc1_18_play_toClient::command_node::ExtraNodeData2 &v2 = *obj.extraNodeData_2; /*8.4*/
         int name_strlen; READ_OR_BAIL(readUnsignedVarInt, name_strlen);
         if (!stream.readString(v2.name, name_strlen)) return false; /*name: pstring*/ /*4.3*/
         int parser_strlen; READ_OR_BAIL(readUnsignedVarInt, parser_strlen);
         if (!stream.readString(v2.parser, parser_strlen)) return false; /*parser: pstring*/ /*4.3*/
-        std::string &parser = v2.parser; /*4.8*/
-        if (parser == "brigadier:bool") { /*8.0*/
+        std::string &V_parser = v2.parser; /*4.8*/
+        if (V_parser == "brigadier:bool") { /*8.0*/
         }
-        else if (parser == "brigadier:float") { /*8.0*/
+        else if (V_parser == "brigadier:float") { /*8.0*/
              v2.properties_brigadier_float = {}; pdef::pc1_18_play_toClient::command_node::ExtraNodeData2::PropertiesBrigadierFloat &v4 = *v2.properties_brigadier_float; /*8.4*/
             uint8_t flags_val;
             READ_OR_BAIL(readUByte, flags_val);
             v4.flags.unused = flags_val >> 0 & 6;
             v4.flags.max_present = flags_val >> 6 & 1;
             v4.flags.min_present = flags_val >> 7 & 1; /*flags: bitfield*/ /*4.3*/
-            pdef::pc1_18_play_toClient::command_node::ExtraNodeData2::PropertiesBrigadierFloat::flags_t &flags = v4.flags; /*4.8*/
-            if (flags.min_present == 1) { /*8.2*/
+            pdef::pc1_18_play_toClient::command_node::ExtraNodeData2::PropertiesBrigadierFloat::flags_t &V_flags = v4.flags; /*4.8*/
+            if (V_flags.min_present == 1) { /*8.2*/
               READ_OR_BAIL(readFloatBE, v4.min); /*0.5*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               READ_OR_BAIL(readFloatBE, v4.max); /*0.5*/
             }
         }
-        else if (parser == "brigadier:double") { /*8.0*/
+        else if (V_parser == "brigadier:double") { /*8.0*/
              v2.properties_brigadier_double = {}; pdef::pc1_18_play_toClient::command_node::ExtraNodeData2::PropertiesBrigadierDouble &v4 = *v2.properties_brigadier_double; /*8.4*/
             uint8_t flags_val;
             READ_OR_BAIL(readUByte, flags_val);
             v4.flags.unused = flags_val >> 0 & 6;
             v4.flags.max_present = flags_val >> 6 & 1;
             v4.flags.min_present = flags_val >> 7 & 1; /*flags: bitfield*/ /*4.3*/
-            pdef::pc1_18_play_toClient::command_node::ExtraNodeData2::PropertiesBrigadierDouble::flags_t &flags = v4.flags; /*4.8*/
-            if (flags.min_present == 1) { /*8.2*/
+            pdef::pc1_18_play_toClient::command_node::ExtraNodeData2::PropertiesBrigadierDouble::flags_t &V_flags = v4.flags; /*4.8*/
+            if (V_flags.min_present == 1) { /*8.2*/
               READ_OR_BAIL(readDoubleBE, v4.min); /*0.5*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               READ_OR_BAIL(readDoubleBE, v4.max); /*0.5*/
             }
         }
-        else if (parser == "brigadier:integer") { /*8.0*/
+        else if (V_parser == "brigadier:integer") { /*8.0*/
              v2.properties_brigadier_integer = {}; pdef::pc1_18_play_toClient::command_node::ExtraNodeData2::PropertiesBrigadierInteger &v4 = *v2.properties_brigadier_integer; /*8.4*/
             uint8_t flags_val;
             READ_OR_BAIL(readUByte, flags_val);
             v4.flags.unused = flags_val >> 0 & 6;
             v4.flags.max_present = flags_val >> 6 & 1;
             v4.flags.min_present = flags_val >> 7 & 1; /*flags: bitfield*/ /*4.3*/
-            pdef::pc1_18_play_toClient::command_node::ExtraNodeData2::PropertiesBrigadierInteger::flags_t &flags = v4.flags; /*4.8*/
-            if (flags.min_present == 1) { /*8.2*/
+            pdef::pc1_18_play_toClient::command_node::ExtraNodeData2::PropertiesBrigadierInteger::flags_t &V_flags = v4.flags; /*4.8*/
+            if (V_flags.min_present == 1) { /*8.2*/
               READ_OR_BAIL(readIntBE, v4.min); /*0.5*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               READ_OR_BAIL(readIntBE, v4.max); /*0.5*/
             }
         }
-        else if (parser == "brigadier:long") { /*8.0*/
+        else if (V_parser == "brigadier:long") { /*8.0*/
              v2.properties_brigadier_long = {}; pdef::pc1_18_play_toClient::command_node::ExtraNodeData2::PropertiesBrigadierLong &v4 = *v2.properties_brigadier_long; /*8.4*/
             uint8_t flags_val;
             READ_OR_BAIL(readUByte, flags_val);
             v4.flags.unused = flags_val >> 0 & 6;
             v4.flags.max_present = flags_val >> 6 & 1;
             v4.flags.min_present = flags_val >> 7 & 1; /*flags: bitfield*/ /*4.3*/
-            pdef::pc1_18_play_toClient::command_node::ExtraNodeData2::PropertiesBrigadierLong::flags_t &flags = v4.flags; /*4.8*/
-            if (flags.min_present == 1) { /*8.2*/
+            pdef::pc1_18_play_toClient::command_node::ExtraNodeData2::PropertiesBrigadierLong::flags_t &V_flags = v4.flags; /*4.8*/
+            if (V_flags.min_present == 1) { /*8.2*/
               READ_OR_BAIL(readLongBE, v4.min); /*0.5*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               READ_OR_BAIL(readLongBE, v4.max); /*0.5*/
             }
         }
-        else if (parser == "brigadier:string") { /*8.0*/
+        else if (V_parser == "brigadier:string") { /*8.0*/
         }
-        else if (parser == "minecraft:entity") { /*8.0*/
+        else if (V_parser == "minecraft:entity") { /*8.0*/
           uint8_t properties_minecraft_entity_val;
           READ_OR_BAIL(readUByte, properties_minecraft_entity_val);
           v2.properties_minecraft_entity.unused = properties_minecraft_entity_val >> 0 & 6;
           v2.properties_minecraft_entity.onlyAllowPlayers = properties_minecraft_entity_val >> 6 & 1;
           v2.properties_minecraft_entity.onlyAllowEntities = properties_minecraft_entity_val >> 7 & 1; /*properties_minecraft_entity: bitfield*/ /*4.3*/
         }
-        else if (parser == "minecraft:game_profile") { /*8.0*/
+        else if (V_parser == "minecraft:game_profile") { /*8.0*/
         }
-        else if (parser == "minecraft:block_pos") { /*8.0*/
+        else if (V_parser == "minecraft:block_pos") { /*8.0*/
         }
-        else if (parser == "minecraft:column_pos") { /*8.0*/
+        else if (V_parser == "minecraft:column_pos") { /*8.0*/
         }
-        else if (parser == "minecraft:vec3") { /*8.0*/
+        else if (V_parser == "minecraft:vec3") { /*8.0*/
         }
-        else if (parser == "minecraft:vec2") { /*8.0*/
+        else if (V_parser == "minecraft:vec2") { /*8.0*/
         }
-        else if (parser == "minecraft:block_state") { /*8.0*/
+        else if (V_parser == "minecraft:block_state") { /*8.0*/
         }
-        else if (parser == "minecraft:block_predicate") { /*8.0*/
+        else if (V_parser == "minecraft:block_predicate") { /*8.0*/
         }
-        else if (parser == "minecraft:item_stack") { /*8.0*/
+        else if (V_parser == "minecraft:item_stack") { /*8.0*/
         }
-        else if (parser == "minecraft:item_predicate") { /*8.0*/
+        else if (V_parser == "minecraft:item_predicate") { /*8.0*/
         }
-        else if (parser == "minecraft:color") { /*8.0*/
+        else if (V_parser == "minecraft:color") { /*8.0*/
         }
-        else if (parser == "minecraft:component") { /*8.0*/
+        else if (V_parser == "minecraft:component") { /*8.0*/
         }
-        else if (parser == "minecraft:message") { /*8.0*/
+        else if (V_parser == "minecraft:message") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt") { /*8.0*/
+        else if (V_parser == "minecraft:nbt") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt_path") { /*8.0*/
+        else if (V_parser == "minecraft:nbt_path") { /*8.0*/
         }
-        else if (parser == "minecraft:objective") { /*8.0*/
+        else if (V_parser == "minecraft:objective") { /*8.0*/
         }
-        else if (parser == "minecraft:objective_criteria") { /*8.0*/
+        else if (V_parser == "minecraft:objective_criteria") { /*8.0*/
         }
-        else if (parser == "minecraft:operation") { /*8.0*/
+        else if (V_parser == "minecraft:operation") { /*8.0*/
         }
-        else if (parser == "minecraft:particle") { /*8.0*/
+        else if (V_parser == "minecraft:particle") { /*8.0*/
         }
-        else if (parser == "minecraft:angle") { /*8.0*/
+        else if (V_parser == "minecraft:angle") { /*8.0*/
         }
-        else if (parser == "minecraft:rotation") { /*8.0*/
+        else if (V_parser == "minecraft:rotation") { /*8.0*/
         }
-        else if (parser == "minecraft:scoreboard_slot") { /*8.0*/
+        else if (V_parser == "minecraft:scoreboard_slot") { /*8.0*/
         }
-        else if (parser == "minecraft:score_holder") { /*8.0*/
+        else if (V_parser == "minecraft:score_holder") { /*8.0*/
           uint8_t properties_minecraft_score_holder_val;
           READ_OR_BAIL(readUByte, properties_minecraft_score_holder_val);
           v2.properties_minecraft_score_holder.unused = properties_minecraft_score_holder_val >> 0 & 7;
           v2.properties_minecraft_score_holder.allowMultiple = properties_minecraft_score_holder_val >> 7 & 1; /*properties_minecraft_score_holder: bitfield*/ /*4.3*/
         }
-        else if (parser == "minecraft:swizzle") { /*8.0*/
+        else if (V_parser == "minecraft:swizzle") { /*8.0*/
         }
-        else if (parser == "minecraft:team") { /*8.0*/
+        else if (V_parser == "minecraft:team") { /*8.0*/
         }
-        else if (parser == "minecraft:item_slot") { /*8.0*/
+        else if (V_parser == "minecraft:item_slot") { /*8.0*/
         }
-        else if (parser == "minecraft:resource_location") { /*8.0*/
+        else if (V_parser == "minecraft:resource_location") { /*8.0*/
         }
-        else if (parser == "minecraft:mob_effect") { /*8.0*/
+        else if (V_parser == "minecraft:mob_effect") { /*8.0*/
         }
-        else if (parser == "minecraft:function") { /*8.0*/
+        else if (V_parser == "minecraft:function") { /*8.0*/
         }
-        else if (parser == "minecraft:entity_anchor") { /*8.0*/
+        else if (V_parser == "minecraft:entity_anchor") { /*8.0*/
         }
-        else if (parser == "minecraft:range") { /*8.0*/
+        else if (V_parser == "minecraft:range") { /*8.0*/
              v2.properties_minecraft_range = {}; pdef::pc1_18_play_toClient::command_node::ExtraNodeData2::PropertiesMinecraftRange &v4 = *v2.properties_minecraft_range; /*8.4*/
             READ_OR_BAIL(readBool, (bool&)v4.allowDecimals); /*0.5*/
         }
-        else if (parser == "minecraft:int_range") { /*8.0*/
+        else if (V_parser == "minecraft:int_range") { /*8.0*/
         }
-        else if (parser == "minecraft:float_range") { /*8.0*/
+        else if (V_parser == "minecraft:float_range") { /*8.0*/
         }
-        else if (parser == "minecraft:item_enchantment") { /*8.0*/
+        else if (V_parser == "minecraft:item_enchantment") { /*8.0*/
         }
-        else if (parser == "minecraft:entity_summon") { /*8.0*/
+        else if (V_parser == "minecraft:entity_summon") { /*8.0*/
         }
-        else if (parser == "minecraft:dimension") { /*8.0*/
+        else if (V_parser == "minecraft:dimension") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt_compound_tag") { /*8.0*/
+        else if (V_parser == "minecraft:nbt_compound_tag") { /*8.0*/
         }
-        else if (parser == "minecraft:time") { /*8.0*/
+        else if (V_parser == "minecraft:time") { /*8.0*/
         }
-        else if (parser == "minecraft:resource_or_tag") { /*8.0*/
+        else if (V_parser == "minecraft:resource_or_tag") { /*8.0*/
              v2.properties_minecraft_resource_or_tag_or_minecraft_resource = {}; pdef::pc1_18_play_toClient::command_node::ExtraNodeData2::PropertiesMinecraftResourceOrTagOrMinecraftResource &v4 = *v2.properties_minecraft_resource_or_tag_or_minecraft_resource; /*8.4*/
             int registry_strlen; READ_OR_BAIL(readUnsignedVarInt, registry_strlen);
             if (!stream.readString(v4.registry, registry_strlen)) return false; /*registry: pstring*/ /*4.3*/
         }
-        else if (parser == "minecraft:resource") { /*8.0*/
+        else if (V_parser == "minecraft:resource") { /*8.0*/
              v2.properties_minecraft_resource_or_tag_or_minecraft_resource = {}; pdef::pc1_18_play_toClient::command_node::ExtraNodeData2::PropertiesMinecraftResourceOrTagOrMinecraftResource &v4 = *v2.properties_minecraft_resource_or_tag_or_minecraft_resource; /*8.4*/
             int registry_strlen; READ_OR_BAIL(readUnsignedVarInt, registry_strlen);
             if (!stream.readString(v4.registry, registry_strlen)) return false; /*registry: pstring*/ /*4.3*/
         }
-        else if (parser == "minecraft:uuid") { /*8.0*/
+        else if (V_parser == "minecraft:uuid") { /*8.0*/
         }
-        if (flags.has_custom_suggestions == 1) { /*8.2*/
+        if (V_flags.has_custom_suggestions == 1) { /*8.2*/
           int suggestionType_strlen; READ_OR_BAIL(readUnsignedVarInt, suggestionType_strlen);
           if (!stream.readString(v2.suggestionType, suggestionType_strlen)) return false; /*suggestionType: pstring*/ /*4.3*/
         }
@@ -6282,7 +6282,7 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_play_toClient::tags &obj) {
     }
     int identifiers_len; READ_OR_BAIL(readUnsignedVarInt, identifiers_len); /*1.5*/
     obj.identifiers.resize(identifiers_len); /*1.6*/
-    for (int i = 0; i < identifiers_len; i++) {
+    for (int i = 0; i < identifiers_len; i++) { /*3.3*/
       auto &v2 = obj.identifiers[i]; /*3.4*/
       int _strlen; READ_OR_BAIL(readUnsignedVarInt, _strlen);
       if (!stream.readString(v2, _strlen)) return false; /*: pstring*/ /*4.3*/
@@ -6347,37 +6347,37 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_play_toClient::tags &obj) {
   bool packet_boss_bar(pdef::Stream &stream, pdef::pc1_18_play_toClient::packet_boss_bar &obj) {
     READ_OR_BAIL(readULongBE, obj.entityUUID); /*0.5*/
     READ_OR_BAIL(readUnsignedVarInt, obj.action); /*0.5*/
-    int &action = obj.action; /*0.6*/
-    if (action == 0) { /*8.2*/
+    int &V_action = obj.action; /*0.6*/
+    if (V_action == 0) { /*8.2*/
       int title_strlen; READ_OR_BAIL(readUnsignedVarInt, title_strlen);
       if (!stream.readString(obj.title, title_strlen)) return false; /*title: pstring*/ /*4.3*/
     }
-    else if (action == 3) { /*8.2*/
+    else if (V_action == 3) { /*8.2*/
       int title_strlen; READ_OR_BAIL(readUnsignedVarInt, title_strlen);
       if (!stream.readString(obj.title, title_strlen)) return false; /*title: pstring*/ /*4.3*/
     }
-    if (action == 0) { /*8.2*/
+    if (V_action == 0) { /*8.2*/
       READ_OR_BAIL(readFloatBE, obj.health); /*0.5*/
     }
-    else if (action == 2) { /*8.2*/
+    else if (V_action == 2) { /*8.2*/
       READ_OR_BAIL(readFloatBE, obj.health); /*0.5*/
     }
-    if (action == 0) { /*8.2*/
+    if (V_action == 0) { /*8.2*/
       READ_OR_BAIL(readUnsignedVarInt, obj.color); /*0.5*/
     }
-    else if (action == 4) { /*8.2*/
+    else if (V_action == 4) { /*8.2*/
       READ_OR_BAIL(readUnsignedVarInt, obj.color); /*0.5*/
     }
-    if (action == 0) { /*8.2*/
+    if (V_action == 0) { /*8.2*/
       READ_OR_BAIL(readUnsignedVarInt, obj.dividers); /*0.5*/
     }
-    else if (action == 4) { /*8.2*/
+    else if (V_action == 4) { /*8.2*/
       READ_OR_BAIL(readUnsignedVarInt, obj.dividers); /*0.5*/
     }
-    if (action == 0) { /*8.2*/
+    if (V_action == 0) { /*8.2*/
       READ_OR_BAIL(readUByte, obj.flags); /*0.5*/
     }
-    else if (action == 5) { /*8.2*/
+    else if (V_action == 5) { /*8.2*/
       READ_OR_BAIL(readUByte, obj.flags); /*0.5*/
     }
     return true;
@@ -6404,7 +6404,7 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_play_toClient::tags &obj) {
   bool packet_declare_commands(pdef::Stream &stream, pdef::pc1_18_play_toClient::packet_declare_commands &obj) {
     int nodes_len; READ_OR_BAIL(readUnsignedVarInt, nodes_len); /*1.5*/
     obj.nodes.resize(nodes_len); /*1.6*/
-    for (int i = 0; i < nodes_len; i++) {
+    for (int i = 0; i < nodes_len; i++) { /*3.3*/
       auto &v2 = obj.nodes[i]; /*3.4*/
       pdef::pc1_18_play_toClient::decode::command_node(stream, v2); /*v2*/ /*4.6*/
     }
@@ -6417,11 +6417,11 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_play_toClient::tags &obj) {
     READ_OR_BAIL(readDoubleBE, obj.y); /*0.5*/
     READ_OR_BAIL(readDoubleBE, obj.z); /*0.5*/
     READ_OR_BAIL(readBool, (bool&)obj.isEntity); /*0.5*/
-    bool &isEntity = obj.isEntity; /*0.6*/
-    if (isEntity == true) { /*8.1*/
+    bool &V_isEntity = obj.isEntity; /*0.6*/
+    if (V_isEntity == true) { /*8.1*/
       READ_OR_BAIL(readUnsignedVarInt, obj.entityId); /*0.5*/
     }
-    if (isEntity == true) { /*8.1*/
+    if (V_isEntity == true) { /*8.1*/
       int entity_feet_eyes_strlen; READ_OR_BAIL(readUnsignedVarInt, entity_feet_eyes_strlen);
       if (!stream.readString(obj.entity_feet_eyes, entity_feet_eyes_strlen)) return false; /*entity_feet_eyes: pstring*/ /*4.3*/
     }
@@ -6448,7 +6448,7 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_play_toClient::tags &obj) {
     READ_OR_BAIL(readBool, (bool&)obj.notTrustEdges); /*0.5*/
     int records_len; READ_OR_BAIL(readUnsignedVarInt, records_len); /*1.5*/
     obj.records.resize(records_len); /*1.6*/
-    for (int i = 0; i < records_len; i++) {
+    for (int i = 0; i < records_len; i++) { /*3.3*/
       auto &v2 = obj.records[i]; /*3.4*/
       READ_OR_BAIL(readUnsignedVarInt, v2); /*0.5*/
     }
@@ -6470,7 +6470,7 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_play_toClient::tags &obj) {
     READ_OR_BAIL(readUnsignedVarInt, obj.stateId); /*0.5*/
     int items_len; READ_OR_BAIL(readUnsignedVarInt, items_len); /*1.5*/
     obj.items.resize(items_len); /*1.6*/
-    for (int i = 0; i < items_len; i++) {
+    for (int i = 0; i < items_len; i++) { /*3.3*/
       auto &v2 = obj.items[i]; /*3.4*/
       READ_OR_BAIL(readByte, v2); /*0.5*/
     }
@@ -6567,32 +6567,32 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_play_toClient::tags &obj) {
     int chunkData_len; READ_OR_BAIL(readUnsignedVarInt, chunkData_len);if (!stream.readBuffer(obj.chunkData, chunkData_len)) return false; /*chunkData: buffer*/ /*4.3*/
     int blockEntities_len; READ_OR_BAIL(readUnsignedVarInt, blockEntities_len); /*1.5*/
     obj.blockEntities.resize(blockEntities_len); /*1.6*/
-    for (int i = 0; i < blockEntities_len; i++) {
+    for (int i = 0; i < blockEntities_len; i++) { /*3.3*/
       auto &v2 = obj.blockEntities[i]; /*3.4*/
       pdef::pc1_18_play_toClient::decode::chunkBlockEntity(stream, v2); /*v2*/ /*4.6*/
     }
     READ_OR_BAIL(readBool, (bool&)obj.trustEdges); /*0.5*/
     int skyLightMask_len; READ_OR_BAIL(readUnsignedVarInt, skyLightMask_len); /*1.5*/
     obj.skyLightMask.resize(skyLightMask_len); /*1.6*/
-    for (int i = 0; i < skyLightMask_len; i++) {
+    for (int i = 0; i < skyLightMask_len; i++) { /*3.3*/
       auto &v2 = obj.skyLightMask[i]; /*3.4*/
       READ_OR_BAIL(readLongBE, v2); /*0.5*/
     }
     int blockLightMask_len; READ_OR_BAIL(readUnsignedVarInt, blockLightMask_len); /*1.5*/
     obj.blockLightMask.resize(blockLightMask_len); /*1.6*/
-    for (int i = 0; i < blockLightMask_len; i++) {
+    for (int i = 0; i < blockLightMask_len; i++) { /*3.3*/
       auto &v2 = obj.blockLightMask[i]; /*3.4*/
       READ_OR_BAIL(readLongBE, v2); /*0.5*/
     }
     int emptySkyLightMask_len; READ_OR_BAIL(readUnsignedVarInt, emptySkyLightMask_len); /*1.5*/
     obj.emptySkyLightMask.resize(emptySkyLightMask_len); /*1.6*/
-    for (int i = 0; i < emptySkyLightMask_len; i++) {
+    for (int i = 0; i < emptySkyLightMask_len; i++) { /*3.3*/
       auto &v2 = obj.emptySkyLightMask[i]; /*3.4*/
       READ_OR_BAIL(readLongBE, v2); /*0.5*/
     }
     int emptyBlockLightMask_len; READ_OR_BAIL(readUnsignedVarInt, emptyBlockLightMask_len); /*1.5*/
     obj.emptyBlockLightMask.resize(emptyBlockLightMask_len); /*1.6*/
-    for (int i = 0; i < emptyBlockLightMask_len; i++) {
+    for (int i = 0; i < emptyBlockLightMask_len; i++) { /*3.3*/
       auto &v2 = obj.emptyBlockLightMask[i]; /*3.4*/
       READ_OR_BAIL(readLongBE, v2); /*0.5*/
     }
@@ -6631,7 +6631,7 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_play_toClient::tags &obj) {
   }
   bool packet_world_particles(pdef::Stream &stream, pdef::pc1_18_play_toClient::packet_world_particles &obj) {
     READ_OR_BAIL(readIntBE, obj.particleId); /*0.5*/
-    int32_t &particleId = obj.particleId; /*0.6*/
+    int32_t &V_particleId = obj.particleId; /*0.6*/
     READ_OR_BAIL(readBool, (bool&)obj.longDistance); /*0.5*/
     READ_OR_BAIL(readDoubleBE, obj.x); /*0.5*/
     READ_OR_BAIL(readDoubleBE, obj.y); /*0.5*/
@@ -6641,22 +6641,22 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_play_toClient::tags &obj) {
     READ_OR_BAIL(readFloatBE, obj.offsetZ); /*0.5*/
     READ_OR_BAIL(readFloatBE, obj.particleData); /*0.5*/
     READ_OR_BAIL(readIntBE, obj.particles); /*0.5*/
-    if (particleId == 2) { /*8.2*/
+    if (V_particleId == 2) { /*8.2*/
          obj.data_2_or_3_or_24 = {}; pdef::pc1_18_play_toClient::packet_world_particles::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.4*/
         READ_OR_BAIL(readUnsignedVarInt, v2.blockState); /*0.5*/
     }
-    else if (particleId == 3) { /*8.2*/
+    else if (V_particleId == 3) { /*8.2*/
          obj.data_2_or_3_or_24 = {}; pdef::pc1_18_play_toClient::packet_world_particles::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.4*/
         READ_OR_BAIL(readUnsignedVarInt, v2.blockState); /*0.5*/
     }
-    else if (particleId == 14) { /*8.2*/
+    else if (V_particleId == 14) { /*8.2*/
          obj.data_14 = {}; pdef::pc1_18_play_toClient::packet_world_particles::Data14 &v2 = *obj.data_14; /*8.4*/
         READ_OR_BAIL(readFloatBE, v2.red); /*0.5*/
         READ_OR_BAIL(readFloatBE, v2.green); /*0.5*/
         READ_OR_BAIL(readFloatBE, v2.blue); /*0.5*/
         READ_OR_BAIL(readFloatBE, v2.scale); /*0.5*/
     }
-    else if (particleId == 15) { /*8.2*/
+    else if (V_particleId == 15) { /*8.2*/
          obj.data_15 = {}; pdef::pc1_18_play_toClient::packet_world_particles::Data15 &v2 = *obj.data_15; /*8.4*/
         READ_OR_BAIL(readFloatBE, v2.fromRed); /*0.5*/
         READ_OR_BAIL(readFloatBE, v2.fromGreen); /*0.5*/
@@ -6666,15 +6666,15 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_play_toClient::tags &obj) {
         READ_OR_BAIL(readFloatBE, v2.toGreen); /*0.5*/
         READ_OR_BAIL(readFloatBE, v2.toBlue); /*0.5*/
     }
-    else if (particleId == 24) { /*8.2*/
+    else if (V_particleId == 24) { /*8.2*/
          obj.data_2_or_3_or_24 = {}; pdef::pc1_18_play_toClient::packet_world_particles::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.4*/
         READ_OR_BAIL(readUnsignedVarInt, v2.blockState); /*0.5*/
     }
-    else if (particleId == 35) { /*8.2*/
+    else if (V_particleId == 35) { /*8.2*/
          obj.data_35 = {}; pdef::pc1_18_play_toClient::packet_world_particles::Data35 &v2 = *obj.data_35; /*8.4*/
         READ_OR_BAIL(readByte, v2.item); /*0.5*/
     }
-    else if (particleId == 36) { /*8.2*/
+    else if (V_particleId == 36) { /*8.2*/
          obj.data_36 = {}; pdef::pc1_18_play_toClient::packet_world_particles::Data36 &v2 = *obj.data_36; /*8.4*/
         uint64_t origin_val;
         READ_OR_BAIL(readULongBE, origin_val);
@@ -6683,15 +6683,15 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_play_toClient::tags &obj) {
         v2.origin.y = origin_val >> 52 & 12; /*origin: bitfield*/ /*4.3*/
         int positionType_strlen; READ_OR_BAIL(readUnsignedVarInt, positionType_strlen);
         if (!stream.readString(v2.positionType, positionType_strlen)) return false; /*positionType: pstring*/ /*4.3*/
-        std::string &positionType = v2.positionType; /*4.8*/
-        if (positionType == "minecraft:block") { /*8.0*/
+        std::string &V_positionType = v2.positionType; /*4.8*/
+        if (V_positionType == "minecraft:block") { /*8.0*/
           uint64_t destination_position_val;
           READ_OR_BAIL(readULongBE, destination_position_val);
           v2.destination_position.x = destination_position_val >> 0 & 26;
           v2.destination_position.z = destination_position_val >> 26 & 26;
           v2.destination_position.y = destination_position_val >> 52 & 12; /*destination_position: bitfield*/ /*4.3*/
         }
-        else if (positionType == "minecraft:entity") { /*8.0*/
+        else if (V_positionType == "minecraft:entity") { /*8.0*/
           READ_OR_BAIL(readUnsignedVarInt, v2.destination_varint); /*0.5*/
         }
         READ_OR_BAIL(readUnsignedVarInt, v2.ticks); /*0.5*/
@@ -6704,25 +6704,25 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_play_toClient::tags &obj) {
     READ_OR_BAIL(readBool, (bool&)obj.trustEdges); /*0.5*/
     int skyLightMask_len; READ_OR_BAIL(readUnsignedVarInt, skyLightMask_len); /*1.5*/
     obj.skyLightMask.resize(skyLightMask_len); /*1.6*/
-    for (int i = 0; i < skyLightMask_len; i++) {
+    for (int i = 0; i < skyLightMask_len; i++) { /*3.3*/
       auto &v2 = obj.skyLightMask[i]; /*3.4*/
       READ_OR_BAIL(readLongBE, v2); /*0.5*/
     }
     int blockLightMask_len; READ_OR_BAIL(readUnsignedVarInt, blockLightMask_len); /*1.5*/
     obj.blockLightMask.resize(blockLightMask_len); /*1.6*/
-    for (int i = 0; i < blockLightMask_len; i++) {
+    for (int i = 0; i < blockLightMask_len; i++) { /*3.3*/
       auto &v2 = obj.blockLightMask[i]; /*3.4*/
       READ_OR_BAIL(readLongBE, v2); /*0.5*/
     }
     int emptySkyLightMask_len; READ_OR_BAIL(readUnsignedVarInt, emptySkyLightMask_len); /*1.5*/
     obj.emptySkyLightMask.resize(emptySkyLightMask_len); /*1.6*/
-    for (int i = 0; i < emptySkyLightMask_len; i++) {
+    for (int i = 0; i < emptySkyLightMask_len; i++) { /*3.3*/
       auto &v2 = obj.emptySkyLightMask[i]; /*3.4*/
       READ_OR_BAIL(readLongBE, v2); /*0.5*/
     }
     int emptyBlockLightMask_len; READ_OR_BAIL(readUnsignedVarInt, emptyBlockLightMask_len); /*1.5*/
     obj.emptyBlockLightMask.resize(emptyBlockLightMask_len); /*1.6*/
-    for (int i = 0; i < emptyBlockLightMask_len; i++) {
+    for (int i = 0; i < emptyBlockLightMask_len; i++) { /*3.3*/
       auto &v2 = obj.emptyBlockLightMask[i]; /*3.4*/
       READ_OR_BAIL(readLongBE, v2); /*0.5*/
     }
@@ -6755,7 +6755,7 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_play_toClient::tags &obj) {
     READ_OR_BAIL(readByte, obj.previousGameMode); /*0.5*/
     int worldNames_len; READ_OR_BAIL(readUnsignedVarInt, worldNames_len); /*1.5*/
     obj.worldNames.resize(worldNames_len); /*1.6*/
-    for (int i = 0; i < worldNames_len; i++) {
+    for (int i = 0; i < worldNames_len; i++) { /*3.3*/
       auto &v2 = obj.worldNames[i]; /*3.4*/
       int _strlen; READ_OR_BAIL(readUnsignedVarInt, _strlen);
       if (!stream.readString(v2, _strlen)) return false; /*: pstring*/ /*4.3*/
@@ -6780,23 +6780,23 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_play_toClient::tags &obj) {
     READ_OR_BAIL(readBool, (bool&)obj.locked); /*0.5*/
     const pdef::pc1_18_play_toClient::packet_map::Icons &v = obj.icons = {}; /*["packet_map"]*/ /*7.3*/
     READ_OR_BAIL(readUByte, obj.columns); /*0.5*/
-    uint8_t &columns = obj.columns; /*0.6*/
-    if (columns == 0) { /*8.2*/
+    uint8_t &V_columns = obj.columns; /*0.6*/
+    if (V_columns == 0) { /*8.2*/
     }
     else {
       READ_OR_BAIL(readUByte, obj.rows); /*0.5*/
     }
-    if (columns == 0) { /*8.2*/
+    if (V_columns == 0) { /*8.2*/
     }
     else {
       READ_OR_BAIL(readUByte, obj.x); /*0.5*/
     }
-    if (columns == 0) { /*8.2*/
+    if (V_columns == 0) { /*8.2*/
     }
     else {
       READ_OR_BAIL(readUByte, obj.y); /*0.5*/
     }
-    if (columns == 0) { /*8.2*/
+    if (V_columns == 0) { /*8.2*/
     }
     else {
       int data_len; READ_OR_BAIL(readUnsignedVarInt, data_len);if (!stream.readBuffer(obj.data, data_len)) return false; /*data: buffer*/ /*4.3*/
@@ -6900,17 +6900,17 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_play_toClient::tags &obj) {
   }
   bool packet_player_info(pdef::Stream &stream, pdef::pc1_18_play_toClient::packet_player_info &obj) {
     READ_OR_BAIL(readUnsignedVarInt, obj.action); /*0.5*/
-    int &action = obj.action; /*0.6*/
+    int &V_action = obj.action; /*0.6*/
     int data_len; READ_OR_BAIL(readUnsignedVarInt, data_len); /*1.5*/
     obj.data.resize(data_len); /*1.6*/
     for (int i = 0; i < data_len; i++) { /*5*/
       pdef::pc1_18_play_toClient::packet_player_info::Data &v2 = obj.data[i]; /*5.23*/
       READ_OR_BAIL(readULongBE, v2.UUID); /*0.5*/
-      if (action == 0) { /*8.2*/
+      if (V_action == 0) { /*8.2*/
         int name_strlen; READ_OR_BAIL(readUnsignedVarInt, name_strlen);
         if (!stream.readString(v2.name, name_strlen)) return false; /*name: pstring*/ /*4.3*/
       }
-      if (action == 0) { /*8.2*/
+      if (V_action == 0) { /*8.2*/
         int properties_len; READ_OR_BAIL(readUnsignedVarInt, properties_len); /*1.5*/
         v2.properties.resize(properties_len); /*1.6*/
         for (int i = 0; i < properties_len; i++) { /*5*/
@@ -6922,32 +6922,32 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_play_toClient::tags &obj) {
           const pdef::pc1_18_play_toClient::packet_player_info::Data::Properties::Signature &v = v4.signature = {}; /*["packet_player_info","Data","Properties"]*/ /*7.3*/
         }
       }
-      if (action == 0) { /*8.2*/
+      if (V_action == 0) { /*8.2*/
         READ_OR_BAIL(readUnsignedVarInt, v2.gamemode); /*0.5*/
       }
-      else if (action == 1) { /*8.2*/
+      else if (V_action == 1) { /*8.2*/
         READ_OR_BAIL(readUnsignedVarInt, v2.gamemode); /*0.5*/
       }
-      if (action == 0) { /*8.2*/
+      if (V_action == 0) { /*8.2*/
         READ_OR_BAIL(readUnsignedVarInt, v2.ping); /*0.5*/
       }
-      else if (action == 2) { /*8.2*/
+      else if (V_action == 2) { /*8.2*/
         READ_OR_BAIL(readUnsignedVarInt, v2.ping); /*0.5*/
       }
-      if (action == 0) { /*8.2*/
+      if (V_action == 0) { /*8.2*/
            v2.displayName = {}; pdef::pc1_18_play_toClient::packet_player_info::Data::DisplayName &v3 = *v2.displayName; /*8.4*/
           READ_OR_BAIL(readBool, (bool&)v3.has); /*0.5*/
-          bool &has = v3.has; /*0.6*/
-          if (has == true) { /*8.1*/
+          bool &V_has = v3.has; /*0.6*/
+          if (V_has == true) { /*8.1*/
             int value_strlen; READ_OR_BAIL(readUnsignedVarInt, value_strlen);
             if (!stream.readString(v3.value, value_strlen)) return false; /*value: pstring*/ /*4.3*/
           }
       }
-      else if (action == 3) { /*8.2*/
+      else if (V_action == 3) { /*8.2*/
            v2.displayName = {}; pdef::pc1_18_play_toClient::packet_player_info::Data::DisplayName &v3 = *v2.displayName; /*8.4*/
           READ_OR_BAIL(readBool, (bool&)v3.has); /*0.5*/
-          bool &has = v3.has; /*0.6*/
-          if (has == true) { /*8.1*/
+          bool &V_has = v3.has; /*0.6*/
+          if (V_has == true) { /*8.1*/
             int value_strlen; READ_OR_BAIL(readUnsignedVarInt, value_strlen);
             if (!stream.readString(v3.value, value_strlen)) return false; /*value: pstring*/ /*4.3*/
           }
@@ -6968,7 +6968,7 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_play_toClient::tags &obj) {
   }
   bool packet_unlock_recipes(pdef::Stream &stream, pdef::pc1_18_play_toClient::packet_unlock_recipes &obj) {
     READ_OR_BAIL(readUnsignedVarInt, obj.action); /*0.5*/
-    int &action = obj.action; /*0.6*/
+    int &V_action = obj.action; /*0.6*/
     READ_OR_BAIL(readBool, (bool&)obj.craftingBookOpen); /*0.5*/
     READ_OR_BAIL(readBool, (bool&)obj.filteringCraftable); /*0.5*/
     READ_OR_BAIL(readBool, (bool&)obj.smeltingBookOpen); /*0.5*/
@@ -6979,15 +6979,15 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_play_toClient::tags &obj) {
     READ_OR_BAIL(readBool, (bool&)obj.filteringSmoker); /*0.5*/
     int recipes1_len; READ_OR_BAIL(readUnsignedVarInt, recipes1_len); /*1.5*/
     obj.recipes1.resize(recipes1_len); /*1.6*/
-    for (int i = 0; i < recipes1_len; i++) {
+    for (int i = 0; i < recipes1_len; i++) { /*3.3*/
       auto &v2 = obj.recipes1[i]; /*3.4*/
       int _strlen; READ_OR_BAIL(readUnsignedVarInt, _strlen);
       if (!stream.readString(v2, _strlen)) return false; /*: pstring*/ /*4.3*/
     }
-    if (action == 0) { /*8.2*/
+    if (V_action == 0) { /*8.2*/
       int recipes2_len; READ_OR_BAIL(readUnsignedVarInt, recipes2_len); /*1.5*/
       obj.recipes2.resize(recipes2_len); /*1.6*/
-      for (int i = 0; i < recipes2_len; i++) {
+      for (int i = 0; i < recipes2_len; i++) { /*3.3*/
         auto &v3 = obj.recipes2[i]; /*3.4*/
         int _strlen; READ_OR_BAIL(readUnsignedVarInt, _strlen);
         if (!stream.readString(v3, _strlen)) return false; /*: pstring*/ /*4.3*/
@@ -6998,7 +6998,7 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_play_toClient::tags &obj) {
   bool packet_entity_destroy(pdef::Stream &stream, pdef::pc1_18_play_toClient::packet_entity_destroy &obj) {
     int entityIds_len; READ_OR_BAIL(readUnsignedVarInt, entityIds_len); /*1.5*/
     obj.entityIds.resize(entityIds_len); /*1.6*/
-    for (int i = 0; i < entityIds_len; i++) {
+    for (int i = 0; i < entityIds_len; i++) { /*3.3*/
       auto &v2 = obj.entityIds[i]; /*3.4*/
       READ_OR_BAIL(readUnsignedVarInt, v2); /*0.5*/
     }
@@ -7096,19 +7096,19 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_play_toClient::tags &obj) {
     int name_strlen; READ_OR_BAIL(readUnsignedVarInt, name_strlen);
     if (!stream.readString(obj.name, name_strlen)) return false; /*name: pstring*/ /*4.3*/
     READ_OR_BAIL(readByte, obj.action); /*0.5*/
-    int8_t &action = obj.action; /*0.6*/
-    if (action == 0) { /*8.2*/
+    int8_t &V_action = obj.action; /*0.6*/
+    if (V_action == 0) { /*8.2*/
       int displayText_strlen; READ_OR_BAIL(readUnsignedVarInt, displayText_strlen);
       if (!stream.readString(obj.displayText, displayText_strlen)) return false; /*displayText: pstring*/ /*4.3*/
     }
-    else if (action == 2) { /*8.2*/
+    else if (V_action == 2) { /*8.2*/
       int displayText_strlen; READ_OR_BAIL(readUnsignedVarInt, displayText_strlen);
       if (!stream.readString(obj.displayText, displayText_strlen)) return false; /*displayText: pstring*/ /*4.3*/
     }
-    if (action == 0) { /*8.2*/
+    if (V_action == 0) { /*8.2*/
       READ_OR_BAIL(readUnsignedVarInt, obj.type); /*0.5*/
     }
-    else if (action == 2) { /*8.2*/
+    else if (V_action == 2) { /*8.2*/
       READ_OR_BAIL(readUnsignedVarInt, obj.type); /*0.5*/
     }
     return true;
@@ -7117,7 +7117,7 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_play_toClient::tags &obj) {
     READ_OR_BAIL(readUnsignedVarInt, obj.entityId); /*0.5*/
     int passengers_len; READ_OR_BAIL(readUnsignedVarInt, passengers_len); /*1.5*/
     obj.passengers.resize(passengers_len); /*1.6*/
-    for (int i = 0; i < passengers_len; i++) {
+    for (int i = 0; i < passengers_len; i++) { /*3.3*/
       auto &v2 = obj.passengers[i]; /*3.4*/
       READ_OR_BAIL(readUnsignedVarInt, v2); /*0.5*/
     }
@@ -7127,81 +7127,81 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_play_toClient::tags &obj) {
     int team_strlen; READ_OR_BAIL(readUnsignedVarInt, team_strlen);
     if (!stream.readString(obj.team, team_strlen)) return false; /*team: pstring*/ /*4.3*/
     READ_OR_BAIL(readByte, obj.mode); /*0.5*/
-    int8_t &mode = obj.mode; /*0.6*/
-    if (mode == 0) { /*8.2*/
+    int8_t &V_mode = obj.mode; /*0.6*/
+    if (V_mode == 0) { /*8.2*/
       int name_strlen; READ_OR_BAIL(readUnsignedVarInt, name_strlen);
       if (!stream.readString(obj.name, name_strlen)) return false; /*name: pstring*/ /*4.3*/
     }
-    else if (mode == 2) { /*8.2*/
+    else if (V_mode == 2) { /*8.2*/
       int name_strlen; READ_OR_BAIL(readUnsignedVarInt, name_strlen);
       if (!stream.readString(obj.name, name_strlen)) return false; /*name: pstring*/ /*4.3*/
     }
-    if (mode == 0) { /*8.2*/
+    if (V_mode == 0) { /*8.2*/
       READ_OR_BAIL(readByte, obj.friendlyFire); /*0.5*/
     }
-    else if (mode == 2) { /*8.2*/
+    else if (V_mode == 2) { /*8.2*/
       READ_OR_BAIL(readByte, obj.friendlyFire); /*0.5*/
     }
-    if (mode == 0) { /*8.2*/
+    if (V_mode == 0) { /*8.2*/
       int nameTagVisibility_strlen; READ_OR_BAIL(readUnsignedVarInt, nameTagVisibility_strlen);
       if (!stream.readString(obj.nameTagVisibility, nameTagVisibility_strlen)) return false; /*nameTagVisibility: pstring*/ /*4.3*/
     }
-    else if (mode == 2) { /*8.2*/
+    else if (V_mode == 2) { /*8.2*/
       int nameTagVisibility_strlen; READ_OR_BAIL(readUnsignedVarInt, nameTagVisibility_strlen);
       if (!stream.readString(obj.nameTagVisibility, nameTagVisibility_strlen)) return false; /*nameTagVisibility: pstring*/ /*4.3*/
     }
-    if (mode == 0) { /*8.2*/
+    if (V_mode == 0) { /*8.2*/
       int collisionRule_strlen; READ_OR_BAIL(readUnsignedVarInt, collisionRule_strlen);
       if (!stream.readString(obj.collisionRule, collisionRule_strlen)) return false; /*collisionRule: pstring*/ /*4.3*/
     }
-    else if (mode == 2) { /*8.2*/
+    else if (V_mode == 2) { /*8.2*/
       int collisionRule_strlen; READ_OR_BAIL(readUnsignedVarInt, collisionRule_strlen);
       if (!stream.readString(obj.collisionRule, collisionRule_strlen)) return false; /*collisionRule: pstring*/ /*4.3*/
     }
-    if (mode == 0) { /*8.2*/
+    if (V_mode == 0) { /*8.2*/
       READ_OR_BAIL(readUnsignedVarInt, obj.formatting); /*0.5*/
     }
-    else if (mode == 2) { /*8.2*/
+    else if (V_mode == 2) { /*8.2*/
       READ_OR_BAIL(readUnsignedVarInt, obj.formatting); /*0.5*/
     }
-    if (mode == 0) { /*8.2*/
+    if (V_mode == 0) { /*8.2*/
       int prefix_strlen; READ_OR_BAIL(readUnsignedVarInt, prefix_strlen);
       if (!stream.readString(obj.prefix, prefix_strlen)) return false; /*prefix: pstring*/ /*4.3*/
     }
-    else if (mode == 2) { /*8.2*/
+    else if (V_mode == 2) { /*8.2*/
       int prefix_strlen; READ_OR_BAIL(readUnsignedVarInt, prefix_strlen);
       if (!stream.readString(obj.prefix, prefix_strlen)) return false; /*prefix: pstring*/ /*4.3*/
     }
-    if (mode == 0) { /*8.2*/
+    if (V_mode == 0) { /*8.2*/
       int suffix_strlen; READ_OR_BAIL(readUnsignedVarInt, suffix_strlen);
       if (!stream.readString(obj.suffix, suffix_strlen)) return false; /*suffix: pstring*/ /*4.3*/
     }
-    else if (mode == 2) { /*8.2*/
+    else if (V_mode == 2) { /*8.2*/
       int suffix_strlen; READ_OR_BAIL(readUnsignedVarInt, suffix_strlen);
       if (!stream.readString(obj.suffix, suffix_strlen)) return false; /*suffix: pstring*/ /*4.3*/
     }
-    if (mode == 0) { /*8.2*/
+    if (V_mode == 0) { /*8.2*/
       int players_len; READ_OR_BAIL(readUnsignedVarInt, players_len); /*1.5*/
       obj.players.resize(players_len); /*1.6*/
-      for (int i = 0; i < players_len; i++) {
+      for (int i = 0; i < players_len; i++) { /*3.3*/
         auto &v3 = obj.players[i]; /*3.4*/
         int _strlen; READ_OR_BAIL(readUnsignedVarInt, _strlen);
         if (!stream.readString(v3, _strlen)) return false; /*: pstring*/ /*4.3*/
       }
     }
-    else if (mode == 3) { /*8.2*/
+    else if (V_mode == 3) { /*8.2*/
       int players_len; READ_OR_BAIL(readUnsignedVarInt, players_len); /*1.5*/
       obj.players.resize(players_len); /*1.6*/
-      for (int i = 0; i < players_len; i++) {
+      for (int i = 0; i < players_len; i++) { /*3.3*/
         auto &v3 = obj.players[i]; /*3.4*/
         int _strlen; READ_OR_BAIL(readUnsignedVarInt, _strlen);
         if (!stream.readString(v3, _strlen)) return false; /*: pstring*/ /*4.3*/
       }
     }
-    else if (mode == 4) { /*8.2*/
+    else if (V_mode == 4) { /*8.2*/
       int players_len; READ_OR_BAIL(readUnsignedVarInt, players_len); /*1.5*/
       obj.players.resize(players_len); /*1.6*/
-      for (int i = 0; i < players_len; i++) {
+      for (int i = 0; i < players_len; i++) { /*3.3*/
         auto &v3 = obj.players[i]; /*3.4*/
         int _strlen; READ_OR_BAIL(readUnsignedVarInt, _strlen);
         if (!stream.readString(v3, _strlen)) return false; /*: pstring*/ /*4.3*/
@@ -7213,10 +7213,10 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_play_toClient::tags &obj) {
     int itemName_strlen; READ_OR_BAIL(readUnsignedVarInt, itemName_strlen);
     if (!stream.readString(obj.itemName, itemName_strlen)) return false; /*itemName: pstring*/ /*4.3*/
     READ_OR_BAIL(readUnsignedVarInt, obj.action); /*0.5*/
-    int &action = obj.action; /*0.6*/
+    int &V_action = obj.action; /*0.6*/
     int scoreName_strlen; READ_OR_BAIL(readUnsignedVarInt, scoreName_strlen);
     if (!stream.readString(obj.scoreName, scoreName_strlen)) return false; /*scoreName: pstring*/ /*4.3*/
-    if (action == 1) { /*8.2*/
+    if (V_action == 1) { /*8.2*/
     }
     else {
       READ_OR_BAIL(readUnsignedVarInt, obj.value); /*0.5*/
@@ -7247,18 +7247,18 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_play_toClient::tags &obj) {
   }
   bool packet_stop_sound(pdef::Stream &stream, pdef::pc1_18_play_toClient::packet_stop_sound &obj) {
     READ_OR_BAIL(readByte, obj.flags); /*0.5*/
-    int8_t &flags = obj.flags; /*0.6*/
-    if (flags == 1) { /*8.2*/
+    int8_t &V_flags = obj.flags; /*0.6*/
+    if (V_flags == 1) { /*8.2*/
       READ_OR_BAIL(readUnsignedVarInt, obj.source); /*0.5*/
     }
-    else if (flags == 3) { /*8.2*/
+    else if (V_flags == 3) { /*8.2*/
       READ_OR_BAIL(readUnsignedVarInt, obj.source); /*0.5*/
     }
-    if (flags == 2) { /*8.2*/
+    if (V_flags == 2) { /*8.2*/
       int sound_strlen; READ_OR_BAIL(readUnsignedVarInt, sound_strlen);
       if (!stream.readString(obj.sound, sound_strlen)) return false; /*sound: pstring*/ /*4.3*/
     }
-    else if (flags == 3) { /*8.2*/
+    else if (V_flags == 3) { /*8.2*/
       int sound_strlen; READ_OR_BAIL(readUnsignedVarInt, sound_strlen);
       if (!stream.readString(obj.sound, sound_strlen)) return false; /*sound: pstring*/ /*4.3*/
     }
@@ -7336,43 +7336,43 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_play_toClient::tags &obj) {
       pdef::pc1_18_play_toClient::packet_declare_recipes::Recipes &v2 = obj.recipes[i]; /*5.23*/
       int type_strlen; READ_OR_BAIL(readUnsignedVarInt, type_strlen);
       if (!stream.readString(v2.type, type_strlen)) return false; /*type: pstring*/ /*4.3*/
-      std::string &type = v2.type; /*4.8*/
+      std::string &V_type = v2.type; /*4.8*/
       int recipeId_strlen; READ_OR_BAIL(readUnsignedVarInt, recipeId_strlen);
       if (!stream.readString(v2.recipeId, recipeId_strlen)) return false; /*recipeId: pstring*/ /*4.3*/
-      if (type == "minecraft:crafting_shapeless") { /*8.0*/
+      if (V_type == "minecraft:crafting_shapeless") { /*8.0*/
            v2.data_minecraft_crafting_shapeless = {}; pdef::pc1_18_play_toClient::packet_declare_recipes::Recipes::DataMinecraftCraftingShapeless &v3 = *v2.data_minecraft_crafting_shapeless; /*8.4*/
           int group_strlen; READ_OR_BAIL(readUnsignedVarInt, group_strlen);
           if (!stream.readString(v3.group, group_strlen)) return false; /*group: pstring*/ /*4.3*/
           int ingredients_len; READ_OR_BAIL(readUnsignedVarInt, ingredients_len); /*1.5*/
           v3.ingredients.resize(ingredients_len); /*1.6*/
-          for (int i = 0; i < ingredients_len; i++) {
+          for (int i = 0; i < ingredients_len; i++) { /*3.3*/
             auto &v5 = v3.ingredients[i]; /*3.4*/
             int _len; READ_OR_BAIL(readUnsignedVarInt, _len); /*1.5*/
             v5.resize(_len); /*1.6*/
-            for (int i = 0; i < _len; i++) {
+            for (int i = 0; i < _len; i++) { /*3.3*/
               auto &v6 = v5[i]; /*3.4*/
               READ_OR_BAIL(readByte, v6); /*0.5*/
             }
           }
           READ_OR_BAIL(readByte, v3.result); /*0.5*/
       }
-      else if (type == "minecraft:crafting_shaped") { /*8.0*/
+      else if (V_type == "minecraft:crafting_shaped") { /*8.0*/
            v2.data_minecraft_crafting_shaped = {}; pdef::pc1_18_play_toClient::packet_declare_recipes::Recipes::DataMinecraftCraftingShaped &v3 = *v2.data_minecraft_crafting_shaped; /*8.4*/
           READ_OR_BAIL(readUnsignedVarInt, v3.width); /*0.5*/
-          int &width = v3.width; /*0.6*/
+          int &V_width = v3.width; /*0.6*/
           READ_OR_BAIL(readUnsignedVarInt, v3.height); /*0.5*/
-          int &height = v3.height; /*0.6*/
+          int &V_height = v3.height; /*0.6*/
           int group_strlen; READ_OR_BAIL(readUnsignedVarInt, group_strlen);
           if (!stream.readString(v3.group, group_strlen)) return false; /*group: pstring*/ /*4.3*/
-          v3.ingredients.resize(width); /*1.6*/
-          for (int i = 0; i < width; i++) { /*5.2*/
+          v3.ingredients.resize(V_width); /*1.6*/
+          for (int i = 0; i < V_width; i++) { /*5.2*/
             int ingredients_len2; READ_OR_BAIL(readUnsignedVarInt, ingredients_len2); /*5.5*/
             v3.ingredients[i].resize(ingredients_len2); /*5.10*/
-            for (int j = 0; j < height; j++) { /*5.11*/
+            for (int j = 0; j < V_height; j++) { /*5.11*/
               auto &v = v3.ingredients[i][j]; /*5.15*/
               int _len; READ_OR_BAIL(readUnsignedVarInt, _len); /*1.5*/
               v.resize(_len); /*1.6*/
-              for (int i = 0; i < _len; i++) {
+              for (int i = 0; i < _len; i++) { /*3.3*/
                 auto &v7 = v[i]; /*3.4*/
                 READ_OR_BAIL(readByte, v7); /*0.5*/
               }
@@ -7380,69 +7380,69 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_play_toClient::tags &obj) {
           }
           READ_OR_BAIL(readByte, v3.result); /*0.5*/
       }
-      else if (type == "minecraft:crafting_special_armordye") { /*8.0*/
+      else if (V_type == "minecraft:crafting_special_armordye") { /*8.0*/
       }
-      else if (type == "minecraft:crafting_special_bookcloning") { /*8.0*/
+      else if (V_type == "minecraft:crafting_special_bookcloning") { /*8.0*/
       }
-      else if (type == "minecraft:crafting_special_mapcloning") { /*8.0*/
+      else if (V_type == "minecraft:crafting_special_mapcloning") { /*8.0*/
       }
-      else if (type == "minecraft:crafting_special_mapextending") { /*8.0*/
+      else if (V_type == "minecraft:crafting_special_mapextending") { /*8.0*/
       }
-      else if (type == "minecraft:crafting_special_firework_rocket") { /*8.0*/
+      else if (V_type == "minecraft:crafting_special_firework_rocket") { /*8.0*/
       }
-      else if (type == "minecraft:crafting_special_firework_star") { /*8.0*/
+      else if (V_type == "minecraft:crafting_special_firework_star") { /*8.0*/
       }
-      else if (type == "minecraft:crafting_special_firework_star_fade") { /*8.0*/
+      else if (V_type == "minecraft:crafting_special_firework_star_fade") { /*8.0*/
       }
-      else if (type == "minecraft:crafting_special_repairitem") { /*8.0*/
+      else if (V_type == "minecraft:crafting_special_repairitem") { /*8.0*/
       }
-      else if (type == "minecraft:crafting_special_tippedarrow") { /*8.0*/
+      else if (V_type == "minecraft:crafting_special_tippedarrow") { /*8.0*/
       }
-      else if (type == "minecraft:crafting_special_bannerduplicate") { /*8.0*/
+      else if (V_type == "minecraft:crafting_special_bannerduplicate") { /*8.0*/
       }
-      else if (type == "minecraft:crafting_special_banneraddpattern") { /*8.0*/
+      else if (V_type == "minecraft:crafting_special_banneraddpattern") { /*8.0*/
       }
-      else if (type == "minecraft:crafting_special_shielddecoration") { /*8.0*/
+      else if (V_type == "minecraft:crafting_special_shielddecoration") { /*8.0*/
       }
-      else if (type == "minecraft:crafting_special_shulkerboxcoloring") { /*8.0*/
+      else if (V_type == "minecraft:crafting_special_shulkerboxcoloring") { /*8.0*/
       }
-      else if (type == "minecraft:crafting_special_suspiciousstew") { /*8.0*/
+      else if (V_type == "minecraft:crafting_special_suspiciousstew") { /*8.0*/
       }
-      else if (type == "minecraft:smelting") { /*8.0*/
+      else if (V_type == "minecraft:smelting") { /*8.0*/
         v2.data_minecraft_smelting_format = {}; pdef::pc1_18_play_toClient::decode::minecraft_smelting_format(stream, *v2.data_minecraft_smelting_format); /*v2*/ /*4.6*/
       }
-      else if (type == "minecraft:blasting") { /*8.0*/
+      else if (V_type == "minecraft:blasting") { /*8.0*/
         v2.data_minecraft_smelting_format = {}; pdef::pc1_18_play_toClient::decode::minecraft_smelting_format(stream, *v2.data_minecraft_smelting_format); /*v2*/ /*4.6*/
       }
-      else if (type == "minecraft:smoking") { /*8.0*/
+      else if (V_type == "minecraft:smoking") { /*8.0*/
         v2.data_minecraft_smelting_format = {}; pdef::pc1_18_play_toClient::decode::minecraft_smelting_format(stream, *v2.data_minecraft_smelting_format); /*v2*/ /*4.6*/
       }
-      else if (type == "minecraft:campfire_cooking") { /*8.0*/
+      else if (V_type == "minecraft:campfire_cooking") { /*8.0*/
         v2.data_minecraft_smelting_format = {}; pdef::pc1_18_play_toClient::decode::minecraft_smelting_format(stream, *v2.data_minecraft_smelting_format); /*v2*/ /*4.6*/
       }
-      else if (type == "minecraft:stonecutting") { /*8.0*/
+      else if (V_type == "minecraft:stonecutting") { /*8.0*/
            v2.data_minecraft_stonecutting = {}; pdef::pc1_18_play_toClient::packet_declare_recipes::Recipes::DataMinecraftStonecutting &v3 = *v2.data_minecraft_stonecutting; /*8.4*/
           int group_strlen; READ_OR_BAIL(readUnsignedVarInt, group_strlen);
           if (!stream.readString(v3.group, group_strlen)) return false; /*group: pstring*/ /*4.3*/
           int ingredient_len; READ_OR_BAIL(readUnsignedVarInt, ingredient_len); /*1.5*/
           v3.ingredient.resize(ingredient_len); /*1.6*/
-          for (int i = 0; i < ingredient_len; i++) {
+          for (int i = 0; i < ingredient_len; i++) { /*3.3*/
             auto &v5 = v3.ingredient[i]; /*3.4*/
             READ_OR_BAIL(readByte, v5); /*0.5*/
           }
           READ_OR_BAIL(readByte, v3.result); /*0.5*/
       }
-      else if (type == "minecraft:smithing") { /*8.0*/
+      else if (V_type == "minecraft:smithing") { /*8.0*/
            v2.data_minecraft_smithing = {}; pdef::pc1_18_play_toClient::packet_declare_recipes::Recipes::DataMinecraftSmithing &v3 = *v2.data_minecraft_smithing; /*8.4*/
           int base_len; READ_OR_BAIL(readUnsignedVarInt, base_len); /*1.5*/
           v3.base.resize(base_len); /*1.6*/
-          for (int i = 0; i < base_len; i++) {
+          for (int i = 0; i < base_len; i++) { /*3.3*/
             auto &v5 = v3.base[i]; /*3.4*/
             READ_OR_BAIL(readByte, v5); /*0.5*/
           }
           int addition_len; READ_OR_BAIL(readUnsignedVarInt, addition_len); /*1.5*/
           v3.addition.resize(addition_len); /*1.6*/
-          for (int i = 0; i < addition_len; i++) {
+          for (int i = 0; i < addition_len; i++) { /*3.3*/
             auto &v5 = v3.addition[i]; /*3.4*/
             READ_OR_BAIL(readByte, v5); /*0.5*/
           }
@@ -7484,15 +7484,15 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_play_toClient::tags &obj) {
     obj.sourcePosition.y = sourcePosition_val >> 52 & 12; /*sourcePosition: bitfield*/ /*4.3*/
     int destinationIdentifier_strlen; READ_OR_BAIL(readUnsignedVarInt, destinationIdentifier_strlen);
     if (!stream.readString(obj.destinationIdentifier, destinationIdentifier_strlen)) return false; /*destinationIdentifier: pstring*/ /*4.3*/
-    std::string &destinationIdentifier = obj.destinationIdentifier; /*4.8*/
-    if (destinationIdentifier == "block") { /*8.0*/
+    std::string &V_destinationIdentifier = obj.destinationIdentifier; /*4.8*/
+    if (V_destinationIdentifier == "block") { /*8.0*/
       uint64_t destination_position_val;
       READ_OR_BAIL(readULongBE, destination_position_val);
       obj.destination_position.x = destination_position_val >> 0 & 26;
       obj.destination_position.z = destination_position_val >> 26 & 26;
       obj.destination_position.y = destination_position_val >> 52 & 12; /*destination_position: bitfield*/ /*4.3*/
     }
-    else if (destinationIdentifier == "entityId") { /*8.0*/
+    else if (V_destinationIdentifier == "entityId") { /*8.0*/
       READ_OR_BAIL(readUnsignedVarInt, obj.destination_varint); /*0.5*/
     }
     READ_OR_BAIL(readUnsignedVarInt, obj.arrivalTicks); /*0.5*/
@@ -7567,8 +7567,8 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_play_toClient::tags &obj) {
   }
   bool packet(pdef::Stream &stream, pdef::pc1_18_play_toClient::packet &obj) {
     READ_OR_BAIL(readUnsignedVarInt, (int&)obj.name); /*7.2*/
-    const pdef::pc1_18_play_toClient::packet::Name &name = obj.name; /*0.7*/
-    switch (name) { /*8.0*/
+    const pdef::pc1_18_play_toClient::packet::Name &V_name = obj.name; /*0.7*/
+    switch (V_name) { /*8.0*/
       case pdef::pc1_18_play_toClient::packet::Name::SpawnEntity: { /*8.5*/
         obj.params_packet_spawn_entity = {}; pdef::pc1_18_play_toClient::decode::packet_spawn_entity(stream, *obj.params_packet_spawn_entity); /*obj*/ /*4.6*/
         break;

--- a/examples/mcpc-protocol/build/pc1_18_play_toServer.h
+++ b/examples/mcpc-protocol/build/pc1_18_play_toServer.h
@@ -700,10 +700,10 @@ size_t packet_pong(pdef::Stream &stream, const pdef::pc1_18_play_toServer::packe
 size_t packet(pdef::Stream &stream, const pdef::pc1_18_play_toServer::packet &obj);
   size_t slot(pdef::Stream &stream, const pdef::pc1_18_play_toServer::slot &obj) {
     size_t len = 0;
-    const bool &present = obj.present; /*0.1*/
-    if (present == false) { /*8.1*/
+    const bool &V_present = obj.present; /*0.1*/
+    if (V_present == false) { /*8.1*/
     }
-    else if (present == true) { /*8.1*/
+    else if (V_present == true) { /*8.1*/
         len += stream.sizeOfVarInt(obj.itemId); /*0.2*/
         len += 1; /*0.2*/
         len += 1; /*0.2*/
@@ -712,23 +712,23 @@ size_t packet(pdef::Stream &stream, const pdef::pc1_18_play_toServer::packet &ob
   }
   size_t particle(pdef::Stream &stream, const pdef::pc1_18_play_toServer::particle &obj) {
     size_t len = 0;
-    const int &particleId = obj.particleId; /*0.1*/
-    if (particleId == 2) { /*8.2*/
+    const int &V_particleId = obj.particleId; /*0.1*/
+    if (V_particleId == 2) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_2_or_3_or_24); const pdef::pc1_18_play_toServer::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.6*/
         len += stream.sizeOfVarInt(v2.blockState); /*0.2*/
     }
-    else if (particleId == 3) { /*8.2*/
+    else if (V_particleId == 3) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_2_or_3_or_24); const pdef::pc1_18_play_toServer::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.6*/
         len += stream.sizeOfVarInt(v2.blockState); /*0.2*/
     }
-    else if (particleId == 14) { /*8.2*/
+    else if (V_particleId == 14) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_14); const pdef::pc1_18_play_toServer::particle::Data14 &v2 = *obj.data_14; /*8.6*/
         len += 4; /*0.2*/
         len += 4; /*0.2*/
         len += 4; /*0.2*/
         len += 4; /*0.2*/
     }
-    else if (particleId == 15) { /*8.2*/
+    else if (V_particleId == 15) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_15); const pdef::pc1_18_play_toServer::particle::Data15 &v2 = *obj.data_15; /*8.6*/
         len += 4; /*0.2*/
         len += 4; /*0.2*/
@@ -738,24 +738,24 @@ size_t packet(pdef::Stream &stream, const pdef::pc1_18_play_toServer::packet &ob
         len += 4; /*0.2*/
         len += 4; /*0.2*/
     }
-    else if (particleId == 24) { /*8.2*/
+    else if (V_particleId == 24) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_2_or_3_or_24); const pdef::pc1_18_play_toServer::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.6*/
         len += stream.sizeOfVarInt(v2.blockState); /*0.2*/
     }
-    else if (particleId == 35) { /*8.2*/
+    else if (V_particleId == 35) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_35); const pdef::pc1_18_play_toServer::particle::Data35 &v2 = *obj.data_35; /*8.6*/
         len += 1; /*0.2*/
     }
-    else if (particleId == 36) { /*8.2*/
+    else if (V_particleId == 36) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_36); const pdef::pc1_18_play_toServer::particle::Data36 &v2 = *obj.data_36; /*8.6*/
         len += 1; /*origin: bitfield*/ /*4.1*/
         len += stream.sizeOfVarInt(v2.positionType.length());
         len += v2.positionType.length(); /*positionType^: pstring*/ /*4.1*/
-        const std::string &positionType = v2.positionType; /*4.7*/
-        if (positionType == "minecraft:block") { /*8.0*/
+        const std::string &V_positionType = v2.positionType; /*4.7*/
+        if (V_positionType == "minecraft:block") { /*8.0*/
           len += 1; /*destination: bitfield*/ /*4.1*/
         }
-        else if (positionType == "minecraft:entity") { /*8.0*/
+        else if (V_positionType == "minecraft:entity") { /*8.0*/
           len += stream.sizeOfVarInt(v2.destination_varint); /*0.2*/
         }
         len += stream.sizeOfVarInt(v2.ticks); /*0.2*/
@@ -767,7 +767,7 @@ size_t packet(pdef::Stream &stream, const pdef::pc1_18_play_toServer::packet &ob
     len += stream.sizeOfVarInt(obj.group.length());
     len += obj.group.length(); /*group: pstring*/ /*4.1*/
     len += stream.sizeOfVarInt(obj.ingredient.size()); /*1.3*/
-    for (const auto &v2 : obj.ingredient) {
+    for (const auto &v2 : obj.ingredient) { /*3.2*/
       len += 1; /*0.2*/
     }
     len += 1; /*0.2*/
@@ -780,7 +780,7 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_play_toServer::tags &obj) {
     len += stream.sizeOfVarInt(obj.tagName.length());
     len += obj.tagName.length(); /*tagName: pstring*/ /*4.1*/
     len += stream.sizeOfVarInt(obj.entries.size()); /*1.3*/
-    for (const auto &v2 : obj.entries) {
+    for (const auto &v2 : obj.entries) { /*3.2*/
       len += stream.sizeOfVarInt(v2); /*0.2*/
     }
   PDEF_SIZE_DBG; return len;
@@ -796,169 +796,169 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_play_toServer::tags &obj) {
   size_t command_node(pdef::Stream &stream, const pdef::pc1_18_play_toServer::command_node &obj) {
     size_t len = 0;
     len += 1; /*flags^: bitfield*/ /*4.1*/
-    const pdef::pc1_18_play_toServer::command_node::flags_t &flags = obj.flags; /*4.7*/
+    const pdef::pc1_18_play_toServer::command_node::flags_t &V_flags = obj.flags; /*4.7*/
     len += stream.sizeOfVarInt(obj.children.size()); /*1.3*/
-    for (const auto &v2 : obj.children) {
+    for (const auto &v2 : obj.children) { /*3.2*/
       len += stream.sizeOfVarInt(v2); /*0.2*/
     }
-    if (flags.has_redirect_node == 1) { /*8.2*/
+    if (V_flags.has_redirect_node == 1) { /*8.2*/
       len += stream.sizeOfVarInt(obj.redirectNode); /*0.2*/
     }
-    if (flags.command_node_type == 0) { /*8.2*/
+    if (V_flags.command_node_type == 0) { /*8.2*/
     }
-    else if (flags.command_node_type == 1) { /*8.2*/
+    else if (V_flags.command_node_type == 1) { /*8.2*/
         EXPECT_OR_BAIL(obj.extraNodeData_1); const pdef::pc1_18_play_toServer::command_node::ExtraNodeData1 &v2 = *obj.extraNodeData_1; /*8.6*/
         len += stream.sizeOfVarInt(v2.name.length());
         len += v2.name.length(); /*name: pstring*/ /*4.1*/
     }
-    else if (flags.command_node_type == 2) { /*8.2*/
+    else if (V_flags.command_node_type == 2) { /*8.2*/
         EXPECT_OR_BAIL(obj.extraNodeData_2); const pdef::pc1_18_play_toServer::command_node::ExtraNodeData2 &v2 = *obj.extraNodeData_2; /*8.6*/
         len += stream.sizeOfVarInt(v2.name.length());
         len += v2.name.length(); /*name: pstring*/ /*4.1*/
         len += stream.sizeOfVarInt(v2.parser.length());
         len += v2.parser.length(); /*parser^: pstring*/ /*4.1*/
-        const std::string &parser = v2.parser; /*4.7*/
-        if (parser == "brigadier:bool") { /*8.0*/
+        const std::string &V_parser = v2.parser; /*4.7*/
+        if (V_parser == "brigadier:bool") { /*8.0*/
         }
-        else if (parser == "brigadier:float") { /*8.0*/
+        else if (V_parser == "brigadier:float") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_brigadier_float); const pdef::pc1_18_play_toServer::command_node::ExtraNodeData2::PropertiesBrigadierFloat &v4 = *v2.properties_brigadier_float; /*8.6*/
             len += 1; /*flags^: bitfield*/ /*4.1*/
-            const pdef::pc1_18_play_toServer::command_node::ExtraNodeData2::PropertiesBrigadierFloat::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_play_toServer::command_node::ExtraNodeData2::PropertiesBrigadierFloat::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               len += 4; /*0.2*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               len += 4; /*0.2*/
             }
         }
-        else if (parser == "brigadier:double") { /*8.0*/
+        else if (V_parser == "brigadier:double") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_brigadier_double); const pdef::pc1_18_play_toServer::command_node::ExtraNodeData2::PropertiesBrigadierDouble &v4 = *v2.properties_brigadier_double; /*8.6*/
             len += 1; /*flags^: bitfield*/ /*4.1*/
-            const pdef::pc1_18_play_toServer::command_node::ExtraNodeData2::PropertiesBrigadierDouble::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_play_toServer::command_node::ExtraNodeData2::PropertiesBrigadierDouble::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               len += 8; /*0.2*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               len += 8; /*0.2*/
             }
         }
-        else if (parser == "brigadier:integer") { /*8.0*/
+        else if (V_parser == "brigadier:integer") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_brigadier_integer); const pdef::pc1_18_play_toServer::command_node::ExtraNodeData2::PropertiesBrigadierInteger &v4 = *v2.properties_brigadier_integer; /*8.6*/
             len += 1; /*flags^: bitfield*/ /*4.1*/
-            const pdef::pc1_18_play_toServer::command_node::ExtraNodeData2::PropertiesBrigadierInteger::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_play_toServer::command_node::ExtraNodeData2::PropertiesBrigadierInteger::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               len += 4; /*0.2*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               len += 4; /*0.2*/
             }
         }
-        else if (parser == "brigadier:long") { /*8.0*/
+        else if (V_parser == "brigadier:long") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_brigadier_long); const pdef::pc1_18_play_toServer::command_node::ExtraNodeData2::PropertiesBrigadierLong &v4 = *v2.properties_brigadier_long; /*8.6*/
             len += 1; /*flags^: bitfield*/ /*4.1*/
-            const pdef::pc1_18_play_toServer::command_node::ExtraNodeData2::PropertiesBrigadierLong::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_play_toServer::command_node::ExtraNodeData2::PropertiesBrigadierLong::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               len += 8; /*0.2*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               len += 8; /*0.2*/
             }
         }
-        else if (parser == "brigadier:string") { /*8.0*/
+        else if (V_parser == "brigadier:string") { /*8.0*/
         }
-        else if (parser == "minecraft:entity") { /*8.0*/
+        else if (V_parser == "minecraft:entity") { /*8.0*/
           len += 1; /*properties: bitfield*/ /*4.1*/
         }
-        else if (parser == "minecraft:game_profile") { /*8.0*/
+        else if (V_parser == "minecraft:game_profile") { /*8.0*/
         }
-        else if (parser == "minecraft:block_pos") { /*8.0*/
+        else if (V_parser == "minecraft:block_pos") { /*8.0*/
         }
-        else if (parser == "minecraft:column_pos") { /*8.0*/
+        else if (V_parser == "minecraft:column_pos") { /*8.0*/
         }
-        else if (parser == "minecraft:vec3") { /*8.0*/
+        else if (V_parser == "minecraft:vec3") { /*8.0*/
         }
-        else if (parser == "minecraft:vec2") { /*8.0*/
+        else if (V_parser == "minecraft:vec2") { /*8.0*/
         }
-        else if (parser == "minecraft:block_state") { /*8.0*/
+        else if (V_parser == "minecraft:block_state") { /*8.0*/
         }
-        else if (parser == "minecraft:block_predicate") { /*8.0*/
+        else if (V_parser == "minecraft:block_predicate") { /*8.0*/
         }
-        else if (parser == "minecraft:item_stack") { /*8.0*/
+        else if (V_parser == "minecraft:item_stack") { /*8.0*/
         }
-        else if (parser == "minecraft:item_predicate") { /*8.0*/
+        else if (V_parser == "minecraft:item_predicate") { /*8.0*/
         }
-        else if (parser == "minecraft:color") { /*8.0*/
+        else if (V_parser == "minecraft:color") { /*8.0*/
         }
-        else if (parser == "minecraft:component") { /*8.0*/
+        else if (V_parser == "minecraft:component") { /*8.0*/
         }
-        else if (parser == "minecraft:message") { /*8.0*/
+        else if (V_parser == "minecraft:message") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt") { /*8.0*/
+        else if (V_parser == "minecraft:nbt") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt_path") { /*8.0*/
+        else if (V_parser == "minecraft:nbt_path") { /*8.0*/
         }
-        else if (parser == "minecraft:objective") { /*8.0*/
+        else if (V_parser == "minecraft:objective") { /*8.0*/
         }
-        else if (parser == "minecraft:objective_criteria") { /*8.0*/
+        else if (V_parser == "minecraft:objective_criteria") { /*8.0*/
         }
-        else if (parser == "minecraft:operation") { /*8.0*/
+        else if (V_parser == "minecraft:operation") { /*8.0*/
         }
-        else if (parser == "minecraft:particle") { /*8.0*/
+        else if (V_parser == "minecraft:particle") { /*8.0*/
         }
-        else if (parser == "minecraft:angle") { /*8.0*/
+        else if (V_parser == "minecraft:angle") { /*8.0*/
         }
-        else if (parser == "minecraft:rotation") { /*8.0*/
+        else if (V_parser == "minecraft:rotation") { /*8.0*/
         }
-        else if (parser == "minecraft:scoreboard_slot") { /*8.0*/
+        else if (V_parser == "minecraft:scoreboard_slot") { /*8.0*/
         }
-        else if (parser == "minecraft:score_holder") { /*8.0*/
+        else if (V_parser == "minecraft:score_holder") { /*8.0*/
           len += 1; /*properties: bitfield*/ /*4.1*/
         }
-        else if (parser == "minecraft:swizzle") { /*8.0*/
+        else if (V_parser == "minecraft:swizzle") { /*8.0*/
         }
-        else if (parser == "minecraft:team") { /*8.0*/
+        else if (V_parser == "minecraft:team") { /*8.0*/
         }
-        else if (parser == "minecraft:item_slot") { /*8.0*/
+        else if (V_parser == "minecraft:item_slot") { /*8.0*/
         }
-        else if (parser == "minecraft:resource_location") { /*8.0*/
+        else if (V_parser == "minecraft:resource_location") { /*8.0*/
         }
-        else if (parser == "minecraft:mob_effect") { /*8.0*/
+        else if (V_parser == "minecraft:mob_effect") { /*8.0*/
         }
-        else if (parser == "minecraft:function") { /*8.0*/
+        else if (V_parser == "minecraft:function") { /*8.0*/
         }
-        else if (parser == "minecraft:entity_anchor") { /*8.0*/
+        else if (V_parser == "minecraft:entity_anchor") { /*8.0*/
         }
-        else if (parser == "minecraft:range") { /*8.0*/
+        else if (V_parser == "minecraft:range") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_minecraft_range); const pdef::pc1_18_play_toServer::command_node::ExtraNodeData2::PropertiesMinecraftRange &v4 = *v2.properties_minecraft_range; /*8.6*/
             len += 1; /*0.2*/
         }
-        else if (parser == "minecraft:int_range") { /*8.0*/
+        else if (V_parser == "minecraft:int_range") { /*8.0*/
         }
-        else if (parser == "minecraft:float_range") { /*8.0*/
+        else if (V_parser == "minecraft:float_range") { /*8.0*/
         }
-        else if (parser == "minecraft:item_enchantment") { /*8.0*/
+        else if (V_parser == "minecraft:item_enchantment") { /*8.0*/
         }
-        else if (parser == "minecraft:entity_summon") { /*8.0*/
+        else if (V_parser == "minecraft:entity_summon") { /*8.0*/
         }
-        else if (parser == "minecraft:dimension") { /*8.0*/
+        else if (V_parser == "minecraft:dimension") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt_compound_tag") { /*8.0*/
+        else if (V_parser == "minecraft:nbt_compound_tag") { /*8.0*/
         }
-        else if (parser == "minecraft:time") { /*8.0*/
+        else if (V_parser == "minecraft:time") { /*8.0*/
         }
-        else if (parser == "minecraft:resource_or_tag") { /*8.0*/
+        else if (V_parser == "minecraft:resource_or_tag") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_minecraft_resource_or_tag_or_minecraft_resource); const pdef::pc1_18_play_toServer::command_node::ExtraNodeData2::PropertiesMinecraftResourceOrTagOrMinecraftResource &v4 = *v2.properties_minecraft_resource_or_tag_or_minecraft_resource; /*8.6*/
             len += stream.sizeOfVarInt(v4.registry.length());
             len += v4.registry.length(); /*registry: pstring*/ /*4.1*/
         }
-        else if (parser == "minecraft:resource") { /*8.0*/
+        else if (V_parser == "minecraft:resource") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_minecraft_resource_or_tag_or_minecraft_resource); const pdef::pc1_18_play_toServer::command_node::ExtraNodeData2::PropertiesMinecraftResourceOrTagOrMinecraftResource &v4 = *v2.properties_minecraft_resource_or_tag_or_minecraft_resource; /*8.6*/
             len += stream.sizeOfVarInt(v4.registry.length());
             len += v4.registry.length(); /*registry: pstring*/ /*4.1*/
         }
-        else if (parser == "minecraft:uuid") { /*8.0*/
+        else if (V_parser == "minecraft:uuid") { /*8.0*/
         }
-        if (flags.has_custom_suggestions == 1) { /*8.2*/
+        if (V_flags.has_custom_suggestions == 1) { /*8.2*/
           len += stream.sizeOfVarInt(v2.suggestionType.length());
           len += v2.suggestionType.length(); /*suggestionType: pstring*/ /*4.1*/
         }
@@ -985,7 +985,7 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_play_toServer::tags &obj) {
     size_t len = 0;
     len += stream.sizeOfVarInt(obj.hand); /*0.2*/
     len += stream.sizeOfVarInt(obj.pages.size()); /*1.3*/
-    for (const auto &v2 : obj.pages) {
+    for (const auto &v2 : obj.pages) { /*3.2*/
       len += stream.sizeOfVarInt(v2.length());
       len += v2.length(); /*: pstring*/ /*4.1*/
     }
@@ -1126,20 +1126,20 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_play_toServer::tags &obj) {
   size_t packet_use_entity(pdef::Stream &stream, const pdef::pc1_18_play_toServer::packet_use_entity &obj) {
     size_t len = 0;
     len += stream.sizeOfVarInt(obj.target); /*0.2*/
-    const int &mouse = obj.mouse; /*0.1*/
-    if (mouse == 2) { /*8.2*/
+    const int &V_mouse = obj.mouse; /*0.1*/
+    if (V_mouse == 2) { /*8.2*/
       len += 4; /*0.2*/
     }
-    if (mouse == 2) { /*8.2*/
+    if (V_mouse == 2) { /*8.2*/
       len += 4; /*0.2*/
     }
-    if (mouse == 2) { /*8.2*/
+    if (V_mouse == 2) { /*8.2*/
       len += 4; /*0.2*/
     }
-    if (mouse == 0) { /*8.2*/
+    if (V_mouse == 0) { /*8.2*/
       len += stream.sizeOfVarInt(obj.hand); /*0.2*/
     }
-    else if (mouse == 2) { /*8.2*/
+    else if (V_mouse == 2) { /*8.2*/
       len += stream.sizeOfVarInt(obj.hand); /*0.2*/
     }
     len += 1; /*0.2*/
@@ -1326,12 +1326,12 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_play_toServer::tags &obj) {
   }
   size_t packet_advancement_tab(pdef::Stream &stream, const pdef::pc1_18_play_toServer::packet_advancement_tab &obj) {
     size_t len = 0;
-    const int &action = obj.action; /*0.1*/
-    if (action == 0) { /*8.2*/
+    const int &V_action = obj.action; /*0.1*/
+    if (V_action == 0) { /*8.2*/
       len += stream.sizeOfVarInt(obj.tabId.length());
       len += obj.tabId.length(); /*tabId: pstring*/ /*4.1*/
     }
-    else if (action == 1) { /*8.2*/
+    else if (V_action == 1) { /*8.2*/
     }
     PDEF_SIZE_DBG; return len;
   }
@@ -1342,9 +1342,9 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_play_toServer::tags &obj) {
   }
   size_t packet(pdef::Stream &stream, const pdef::pc1_18_play_toServer::packet &obj) {
     size_t len = 0;
-    const pdef::pc1_18_play_toServer::packet::Name &name = obj.name; /*0.3*/
+    const pdef::pc1_18_play_toServer::packet::Name &V_name = obj.name; /*0.3*/
     len += stream.sizeOfVarInt((int&)obj.name); /*name^: varint*/ /*7.0*/
-    switch (name) { /*8.0*/
+    switch (V_name) { /*8.0*/
       case pdef::pc1_18_play_toServer::packet::Name::TeleportConfirm: { /*8.5*/
         EXPECT_OR_BAIL(obj.params_packet_teleport_confirm); size_t len_0 = pdef::pc1_18_play_toServer::size::packet_teleport_confirm(stream, *obj.params_packet_teleport_confirm); EXPECT_OR_BAIL(len_0); len += len_0; /*params_packet_teleport_confirm*/ /*4.4*/
         break;
@@ -1601,11 +1601,11 @@ bool packet_pong(pdef::Stream &stream, const pdef::pc1_18_play_toServer::packet_
 bool packet(pdef::Stream &stream, const pdef::pc1_18_play_toServer::packet &obj, bool allocate);
   bool slot(pdef::Stream &stream, const pdef::pc1_18_play_toServer::slot &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::pc1_18_play_toServer::size::slot(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const bool &present = obj.present; /*0.1*/
+    const bool &V_present = obj.present; /*0.1*/
     WRITE_OR_BAIL(writeBool, (bool)obj.present); /*0.4*/
-    if (present == false) { /*8.1*/
+    if (V_present == false) { /*8.1*/
     }
-    else if (present == true) { /*8.1*/
+    else if (V_present == true) { /*8.1*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.itemId); /*0.4*/
         WRITE_OR_BAIL(writeByte, (int8_t)obj.itemCount); /*0.4*/
         WRITE_OR_BAIL(writeByte, (int8_t)obj.nbtData); /*0.4*/
@@ -1614,24 +1614,24 @@ bool packet(pdef::Stream &stream, const pdef::pc1_18_play_toServer::packet &obj,
   }
   bool particle(pdef::Stream &stream, const pdef::pc1_18_play_toServer::particle &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::pc1_18_play_toServer::size::particle(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const int &particleId = obj.particleId; /*0.1*/
+    const int &V_particleId = obj.particleId; /*0.1*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.particleId); /*0.4*/
-    if (particleId == 2) { /*8.2*/
+    if (V_particleId == 2) { /*8.2*/
         const pdef::pc1_18_play_toServer::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.5*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.blockState); /*0.4*/
     }
-    else if (particleId == 3) { /*8.2*/
+    else if (V_particleId == 3) { /*8.2*/
         const pdef::pc1_18_play_toServer::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.5*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.blockState); /*0.4*/
     }
-    else if (particleId == 14) { /*8.2*/
+    else if (V_particleId == 14) { /*8.2*/
         const pdef::pc1_18_play_toServer::particle::Data14 &v2 = *obj.data_14; /*8.5*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.red); /*0.4*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.green); /*0.4*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.blue); /*0.4*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.scale); /*0.4*/
     }
-    else if (particleId == 15) { /*8.2*/
+    else if (V_particleId == 15) { /*8.2*/
         const pdef::pc1_18_play_toServer::particle::Data15 &v2 = *obj.data_15; /*8.5*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.fromRed); /*0.4*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.fromGreen); /*0.4*/
@@ -1641,15 +1641,15 @@ bool packet(pdef::Stream &stream, const pdef::pc1_18_play_toServer::packet &obj,
         WRITE_OR_BAIL(writeFloatBE, (float)v2.toGreen); /*0.4*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.toBlue); /*0.4*/
     }
-    else if (particleId == 24) { /*8.2*/
+    else if (V_particleId == 24) { /*8.2*/
         const pdef::pc1_18_play_toServer::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.5*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.blockState); /*0.4*/
     }
-    else if (particleId == 35) { /*8.2*/
+    else if (V_particleId == 35) { /*8.2*/
         const pdef::pc1_18_play_toServer::particle::Data35 &v2 = *obj.data_35; /*8.5*/
         WRITE_OR_BAIL(writeByte, (int8_t)v2.item); /*0.4*/
     }
-    else if (particleId == 36) { /*8.2*/
+    else if (V_particleId == 36) { /*8.2*/
         const pdef::pc1_18_play_toServer::particle::Data36 &v2 = *obj.data_36; /*8.5*/
         uint64_t origin_val = 0;
         origin_val |= (uint64_t)v2.origin.x << 0;
@@ -1658,15 +1658,15 @@ bool packet(pdef::Stream &stream, const pdef::pc1_18_play_toServer::packet &obj,
         WRITE_OR_BAIL(writeULongBE, origin_val); /*origin: bitfield*/ /*4.2*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.positionType.length());
         WRITE_OR_BAIL(writeString, v2.positionType); /*positionType: pstring*/ /*4.2*/
-        const std::string &positionType = v2.positionType; /*4.7*/
-        if (positionType == "minecraft:block") { /*8.0*/
+        const std::string &V_positionType = v2.positionType; /*4.7*/
+        if (V_positionType == "minecraft:block") { /*8.0*/
           uint64_t destination_position_val = 0;
           destination_position_val |= (uint64_t)v2.destination_position.x << 0;
           destination_position_val |= (uint64_t)v2.destination_position.z << 26;
           destination_position_val |= (uint64_t)v2.destination_position.y << 52;
           WRITE_OR_BAIL(writeULongBE, destination_position_val); /*destination_position: bitfield*/ /*4.2*/
         }
-        else if (positionType == "minecraft:entity") { /*8.0*/
+        else if (V_positionType == "minecraft:entity") { /*8.0*/
           WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.destination_varint); /*0.4*/
         }
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.ticks); /*0.4*/
@@ -1716,192 +1716,192 @@ bool tags(pdef::Stream &stream, const pdef::pc1_18_play_toServer::tags &obj, boo
     flags_val |= (uint8_t)obj.flags.has_command << 5;
     flags_val |= (uint8_t)obj.flags.command_node_type << 6;
     WRITE_OR_BAIL(writeUByte, flags_val); /*flags: bitfield*/ /*4.2*/
-    const pdef::pc1_18_play_toServer::command_node::flags_t &flags = obj.flags; /*4.7*/
+    const pdef::pc1_18_play_toServer::command_node::flags_t &V_flags = obj.flags; /*4.7*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.children.size()); /*1.4*/
     for (const auto &v2 : obj.children) { /*3.1*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2); /*0.4*/
     }
-    if (flags.has_redirect_node == 1) { /*8.2*/
+    if (V_flags.has_redirect_node == 1) { /*8.2*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.redirectNode); /*0.4*/
     }
-    if (flags.command_node_type == 0) { /*8.2*/
+    if (V_flags.command_node_type == 0) { /*8.2*/
     }
-    else if (flags.command_node_type == 1) { /*8.2*/
+    else if (V_flags.command_node_type == 1) { /*8.2*/
         const pdef::pc1_18_play_toServer::command_node::ExtraNodeData1 &v2 = *obj.extraNodeData_1; /*8.5*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.name.length());
         WRITE_OR_BAIL(writeString, v2.name); /*name: pstring*/ /*4.2*/
     }
-    else if (flags.command_node_type == 2) { /*8.2*/
+    else if (V_flags.command_node_type == 2) { /*8.2*/
         const pdef::pc1_18_play_toServer::command_node::ExtraNodeData2 &v2 = *obj.extraNodeData_2; /*8.5*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.name.length());
         WRITE_OR_BAIL(writeString, v2.name); /*name: pstring*/ /*4.2*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.parser.length());
         WRITE_OR_BAIL(writeString, v2.parser); /*parser: pstring*/ /*4.2*/
-        const std::string &parser = v2.parser; /*4.7*/
-        if (parser == "brigadier:bool") { /*8.0*/
+        const std::string &V_parser = v2.parser; /*4.7*/
+        if (V_parser == "brigadier:bool") { /*8.0*/
         }
-        else if (parser == "brigadier:float") { /*8.0*/
+        else if (V_parser == "brigadier:float") { /*8.0*/
             const pdef::pc1_18_play_toServer::command_node::ExtraNodeData2::PropertiesBrigadierFloat &v4 = *v2.properties_brigadier_float; /*8.5*/
             uint8_t flags_val = 0;
             flags_val |= (uint8_t)v4.flags.unused << 0;
             flags_val |= (uint8_t)v4.flags.max_present << 6;
             flags_val |= (uint8_t)v4.flags.min_present << 7;
             WRITE_OR_BAIL(writeUByte, flags_val); /*flags: bitfield*/ /*4.2*/
-            const pdef::pc1_18_play_toServer::command_node::ExtraNodeData2::PropertiesBrigadierFloat::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_play_toServer::command_node::ExtraNodeData2::PropertiesBrigadierFloat::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeFloatBE, (float)v4.min); /*0.4*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeFloatBE, (float)v4.max); /*0.4*/
             }
         }
-        else if (parser == "brigadier:double") { /*8.0*/
+        else if (V_parser == "brigadier:double") { /*8.0*/
             const pdef::pc1_18_play_toServer::command_node::ExtraNodeData2::PropertiesBrigadierDouble &v4 = *v2.properties_brigadier_double; /*8.5*/
             uint8_t flags_val = 0;
             flags_val |= (uint8_t)v4.flags.unused << 0;
             flags_val |= (uint8_t)v4.flags.max_present << 6;
             flags_val |= (uint8_t)v4.flags.min_present << 7;
             WRITE_OR_BAIL(writeUByte, flags_val); /*flags: bitfield*/ /*4.2*/
-            const pdef::pc1_18_play_toServer::command_node::ExtraNodeData2::PropertiesBrigadierDouble::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_play_toServer::command_node::ExtraNodeData2::PropertiesBrigadierDouble::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeDoubleBE, (double)v4.min); /*0.4*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeDoubleBE, (double)v4.max); /*0.4*/
             }
         }
-        else if (parser == "brigadier:integer") { /*8.0*/
+        else if (V_parser == "brigadier:integer") { /*8.0*/
             const pdef::pc1_18_play_toServer::command_node::ExtraNodeData2::PropertiesBrigadierInteger &v4 = *v2.properties_brigadier_integer; /*8.5*/
             uint8_t flags_val = 0;
             flags_val |= (uint8_t)v4.flags.unused << 0;
             flags_val |= (uint8_t)v4.flags.max_present << 6;
             flags_val |= (uint8_t)v4.flags.min_present << 7;
             WRITE_OR_BAIL(writeUByte, flags_val); /*flags: bitfield*/ /*4.2*/
-            const pdef::pc1_18_play_toServer::command_node::ExtraNodeData2::PropertiesBrigadierInteger::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_play_toServer::command_node::ExtraNodeData2::PropertiesBrigadierInteger::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeIntBE, (int32_t)v4.min); /*0.4*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeIntBE, (int32_t)v4.max); /*0.4*/
             }
         }
-        else if (parser == "brigadier:long") { /*8.0*/
+        else if (V_parser == "brigadier:long") { /*8.0*/
             const pdef::pc1_18_play_toServer::command_node::ExtraNodeData2::PropertiesBrigadierLong &v4 = *v2.properties_brigadier_long; /*8.5*/
             uint8_t flags_val = 0;
             flags_val |= (uint8_t)v4.flags.unused << 0;
             flags_val |= (uint8_t)v4.flags.max_present << 6;
             flags_val |= (uint8_t)v4.flags.min_present << 7;
             WRITE_OR_BAIL(writeUByte, flags_val); /*flags: bitfield*/ /*4.2*/
-            const pdef::pc1_18_play_toServer::command_node::ExtraNodeData2::PropertiesBrigadierLong::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_play_toServer::command_node::ExtraNodeData2::PropertiesBrigadierLong::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeLongBE, (int64_t)v4.min); /*0.4*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeLongBE, (int64_t)v4.max); /*0.4*/
             }
         }
-        else if (parser == "brigadier:string") { /*8.0*/
+        else if (V_parser == "brigadier:string") { /*8.0*/
         }
-        else if (parser == "minecraft:entity") { /*8.0*/
+        else if (V_parser == "minecraft:entity") { /*8.0*/
           uint8_t properties_minecraft_entity_val = 0;
           properties_minecraft_entity_val |= (uint8_t)v2.properties_minecraft_entity.unused << 0;
           properties_minecraft_entity_val |= (uint8_t)v2.properties_minecraft_entity.onlyAllowPlayers << 6;
           properties_minecraft_entity_val |= (uint8_t)v2.properties_minecraft_entity.onlyAllowEntities << 7;
           WRITE_OR_BAIL(writeUByte, properties_minecraft_entity_val); /*properties_minecraft_entity: bitfield*/ /*4.2*/
         }
-        else if (parser == "minecraft:game_profile") { /*8.0*/
+        else if (V_parser == "minecraft:game_profile") { /*8.0*/
         }
-        else if (parser == "minecraft:block_pos") { /*8.0*/
+        else if (V_parser == "minecraft:block_pos") { /*8.0*/
         }
-        else if (parser == "minecraft:column_pos") { /*8.0*/
+        else if (V_parser == "minecraft:column_pos") { /*8.0*/
         }
-        else if (parser == "minecraft:vec3") { /*8.0*/
+        else if (V_parser == "minecraft:vec3") { /*8.0*/
         }
-        else if (parser == "minecraft:vec2") { /*8.0*/
+        else if (V_parser == "minecraft:vec2") { /*8.0*/
         }
-        else if (parser == "minecraft:block_state") { /*8.0*/
+        else if (V_parser == "minecraft:block_state") { /*8.0*/
         }
-        else if (parser == "minecraft:block_predicate") { /*8.0*/
+        else if (V_parser == "minecraft:block_predicate") { /*8.0*/
         }
-        else if (parser == "minecraft:item_stack") { /*8.0*/
+        else if (V_parser == "minecraft:item_stack") { /*8.0*/
         }
-        else if (parser == "minecraft:item_predicate") { /*8.0*/
+        else if (V_parser == "minecraft:item_predicate") { /*8.0*/
         }
-        else if (parser == "minecraft:color") { /*8.0*/
+        else if (V_parser == "minecraft:color") { /*8.0*/
         }
-        else if (parser == "minecraft:component") { /*8.0*/
+        else if (V_parser == "minecraft:component") { /*8.0*/
         }
-        else if (parser == "minecraft:message") { /*8.0*/
+        else if (V_parser == "minecraft:message") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt") { /*8.0*/
+        else if (V_parser == "minecraft:nbt") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt_path") { /*8.0*/
+        else if (V_parser == "minecraft:nbt_path") { /*8.0*/
         }
-        else if (parser == "minecraft:objective") { /*8.0*/
+        else if (V_parser == "minecraft:objective") { /*8.0*/
         }
-        else if (parser == "minecraft:objective_criteria") { /*8.0*/
+        else if (V_parser == "minecraft:objective_criteria") { /*8.0*/
         }
-        else if (parser == "minecraft:operation") { /*8.0*/
+        else if (V_parser == "minecraft:operation") { /*8.0*/
         }
-        else if (parser == "minecraft:particle") { /*8.0*/
+        else if (V_parser == "minecraft:particle") { /*8.0*/
         }
-        else if (parser == "minecraft:angle") { /*8.0*/
+        else if (V_parser == "minecraft:angle") { /*8.0*/
         }
-        else if (parser == "minecraft:rotation") { /*8.0*/
+        else if (V_parser == "minecraft:rotation") { /*8.0*/
         }
-        else if (parser == "minecraft:scoreboard_slot") { /*8.0*/
+        else if (V_parser == "minecraft:scoreboard_slot") { /*8.0*/
         }
-        else if (parser == "minecraft:score_holder") { /*8.0*/
+        else if (V_parser == "minecraft:score_holder") { /*8.0*/
           uint8_t properties_minecraft_score_holder_val = 0;
           properties_minecraft_score_holder_val |= (uint8_t)v2.properties_minecraft_score_holder.unused << 0;
           properties_minecraft_score_holder_val |= (uint8_t)v2.properties_minecraft_score_holder.allowMultiple << 7;
           WRITE_OR_BAIL(writeUByte, properties_minecraft_score_holder_val); /*properties_minecraft_score_holder: bitfield*/ /*4.2*/
         }
-        else if (parser == "minecraft:swizzle") { /*8.0*/
+        else if (V_parser == "minecraft:swizzle") { /*8.0*/
         }
-        else if (parser == "minecraft:team") { /*8.0*/
+        else if (V_parser == "minecraft:team") { /*8.0*/
         }
-        else if (parser == "minecraft:item_slot") { /*8.0*/
+        else if (V_parser == "minecraft:item_slot") { /*8.0*/
         }
-        else if (parser == "minecraft:resource_location") { /*8.0*/
+        else if (V_parser == "minecraft:resource_location") { /*8.0*/
         }
-        else if (parser == "minecraft:mob_effect") { /*8.0*/
+        else if (V_parser == "minecraft:mob_effect") { /*8.0*/
         }
-        else if (parser == "minecraft:function") { /*8.0*/
+        else if (V_parser == "minecraft:function") { /*8.0*/
         }
-        else if (parser == "minecraft:entity_anchor") { /*8.0*/
+        else if (V_parser == "minecraft:entity_anchor") { /*8.0*/
         }
-        else if (parser == "minecraft:range") { /*8.0*/
+        else if (V_parser == "minecraft:range") { /*8.0*/
             const pdef::pc1_18_play_toServer::command_node::ExtraNodeData2::PropertiesMinecraftRange &v4 = *v2.properties_minecraft_range; /*8.5*/
             WRITE_OR_BAIL(writeBool, (bool)v4.allowDecimals); /*0.4*/
         }
-        else if (parser == "minecraft:int_range") { /*8.0*/
+        else if (V_parser == "minecraft:int_range") { /*8.0*/
         }
-        else if (parser == "minecraft:float_range") { /*8.0*/
+        else if (V_parser == "minecraft:float_range") { /*8.0*/
         }
-        else if (parser == "minecraft:item_enchantment") { /*8.0*/
+        else if (V_parser == "minecraft:item_enchantment") { /*8.0*/
         }
-        else if (parser == "minecraft:entity_summon") { /*8.0*/
+        else if (V_parser == "minecraft:entity_summon") { /*8.0*/
         }
-        else if (parser == "minecraft:dimension") { /*8.0*/
+        else if (V_parser == "minecraft:dimension") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt_compound_tag") { /*8.0*/
+        else if (V_parser == "minecraft:nbt_compound_tag") { /*8.0*/
         }
-        else if (parser == "minecraft:time") { /*8.0*/
+        else if (V_parser == "minecraft:time") { /*8.0*/
         }
-        else if (parser == "minecraft:resource_or_tag") { /*8.0*/
+        else if (V_parser == "minecraft:resource_or_tag") { /*8.0*/
             const pdef::pc1_18_play_toServer::command_node::ExtraNodeData2::PropertiesMinecraftResourceOrTagOrMinecraftResource &v4 = *v2.properties_minecraft_resource_or_tag_or_minecraft_resource; /*8.5*/
             WRITE_OR_BAIL(writeUnsignedVarInt, (int)v4.registry.length());
             WRITE_OR_BAIL(writeString, v4.registry); /*registry: pstring*/ /*4.2*/
         }
-        else if (parser == "minecraft:resource") { /*8.0*/
+        else if (V_parser == "minecraft:resource") { /*8.0*/
             const pdef::pc1_18_play_toServer::command_node::ExtraNodeData2::PropertiesMinecraftResourceOrTagOrMinecraftResource &v4 = *v2.properties_minecraft_resource_or_tag_or_minecraft_resource; /*8.5*/
             WRITE_OR_BAIL(writeUnsignedVarInt, (int)v4.registry.length());
             WRITE_OR_BAIL(writeString, v4.registry); /*registry: pstring*/ /*4.2*/
         }
-        else if (parser == "minecraft:uuid") { /*8.0*/
+        else if (V_parser == "minecraft:uuid") { /*8.0*/
         }
-        if (flags.has_custom_suggestions == 1) { /*8.2*/
+        if (V_flags.has_custom_suggestions == 1) { /*8.2*/
           WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.suggestionType.length());
           WRITE_OR_BAIL(writeString, v2.suggestionType); /*suggestionType: pstring*/ /*4.2*/
         }
@@ -2081,21 +2081,21 @@ bool tags(pdef::Stream &stream, const pdef::pc1_18_play_toServer::tags &obj, boo
   bool packet_use_entity(pdef::Stream &stream, const pdef::pc1_18_play_toServer::packet_use_entity &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::pc1_18_play_toServer::size::packet_use_entity(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.target); /*0.4*/
-    const int &mouse = obj.mouse; /*0.1*/
+    const int &V_mouse = obj.mouse; /*0.1*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.mouse); /*0.4*/
-    if (mouse == 2) { /*8.2*/
+    if (V_mouse == 2) { /*8.2*/
       WRITE_OR_BAIL(writeFloatBE, (float)obj.x); /*0.4*/
     }
-    if (mouse == 2) { /*8.2*/
+    if (V_mouse == 2) { /*8.2*/
       WRITE_OR_BAIL(writeFloatBE, (float)obj.y); /*0.4*/
     }
-    if (mouse == 2) { /*8.2*/
+    if (V_mouse == 2) { /*8.2*/
       WRITE_OR_BAIL(writeFloatBE, (float)obj.z); /*0.4*/
     }
-    if (mouse == 0) { /*8.2*/
+    if (V_mouse == 0) { /*8.2*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.hand); /*0.4*/
     }
-    else if (mouse == 2) { /*8.2*/
+    else if (V_mouse == 2) { /*8.2*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.hand); /*0.4*/
     }
     WRITE_OR_BAIL(writeBool, (bool)obj.sneaking); /*0.4*/
@@ -2302,13 +2302,13 @@ bool tags(pdef::Stream &stream, const pdef::pc1_18_play_toServer::tags &obj, boo
   }
   bool packet_advancement_tab(pdef::Stream &stream, const pdef::pc1_18_play_toServer::packet_advancement_tab &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::pc1_18_play_toServer::size::packet_advancement_tab(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const int &action = obj.action; /*0.1*/
+    const int &V_action = obj.action; /*0.1*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.action); /*0.4*/
-    if (action == 0) { /*8.2*/
+    if (V_action == 0) { /*8.2*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.tabId.length());
       WRITE_OR_BAIL(writeString, obj.tabId); /*tabId: pstring*/ /*4.2*/
     }
-    else if (action == 1) { /*8.2*/
+    else if (V_action == 1) { /*8.2*/
     }
     return true;
   }
@@ -2319,9 +2319,9 @@ bool tags(pdef::Stream &stream, const pdef::pc1_18_play_toServer::tags &obj, boo
   }
   bool packet(pdef::Stream &stream, const pdef::pc1_18_play_toServer::packet &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::pc1_18_play_toServer::size::packet(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const pdef::pc1_18_play_toServer::packet::Name &name = obj.name; /*0.3*/
+    const pdef::pc1_18_play_toServer::packet::Name &V_name = obj.name; /*0.3*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)(int&)obj.name); /*7.1*/
-    switch (name) { /*8.0*/
+    switch (V_name) { /*8.0*/
       case pdef::pc1_18_play_toServer::packet::Name::TeleportConfirm: { /*8.5*/
         pdef::pc1_18_play_toServer::encode::packet_teleport_confirm(stream, *obj.params_packet_teleport_confirm); /*packet_teleport_confirm*/ /*4.5*/
         break;
@@ -2578,10 +2578,10 @@ bool packet_pong(pdef::Stream &stream, pdef::pc1_18_play_toServer::packet_pong &
 bool packet(pdef::Stream &stream, pdef::pc1_18_play_toServer::packet &obj);
   bool slot(pdef::Stream &stream, pdef::pc1_18_play_toServer::slot &obj) {
     READ_OR_BAIL(readBool, (bool&)obj.present); /*0.5*/
-    bool &present = obj.present; /*0.6*/
-    if (present == false) { /*8.1*/
+    bool &V_present = obj.present; /*0.6*/
+    if (V_present == false) { /*8.1*/
     }
-    else if (present == true) { /*8.1*/
+    else if (V_present == true) { /*8.1*/
         READ_OR_BAIL(readUnsignedVarInt, obj.itemId); /*0.5*/
         READ_OR_BAIL(readByte, obj.itemCount); /*0.5*/
         READ_OR_BAIL(readByte, obj.nbtData); /*0.5*/
@@ -2590,23 +2590,23 @@ bool packet(pdef::Stream &stream, pdef::pc1_18_play_toServer::packet &obj);
   }
   bool particle(pdef::Stream &stream, pdef::pc1_18_play_toServer::particle &obj) {
     READ_OR_BAIL(readUnsignedVarInt, obj.particleId); /*0.5*/
-    int &particleId = obj.particleId; /*0.6*/
-    if (particleId == 2) { /*8.2*/
+    int &V_particleId = obj.particleId; /*0.6*/
+    if (V_particleId == 2) { /*8.2*/
          obj.data_2_or_3_or_24 = {}; pdef::pc1_18_play_toServer::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.4*/
         READ_OR_BAIL(readUnsignedVarInt, v2.blockState); /*0.5*/
     }
-    else if (particleId == 3) { /*8.2*/
+    else if (V_particleId == 3) { /*8.2*/
          obj.data_2_or_3_or_24 = {}; pdef::pc1_18_play_toServer::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.4*/
         READ_OR_BAIL(readUnsignedVarInt, v2.blockState); /*0.5*/
     }
-    else if (particleId == 14) { /*8.2*/
+    else if (V_particleId == 14) { /*8.2*/
          obj.data_14 = {}; pdef::pc1_18_play_toServer::particle::Data14 &v2 = *obj.data_14; /*8.4*/
         READ_OR_BAIL(readFloatBE, v2.red); /*0.5*/
         READ_OR_BAIL(readFloatBE, v2.green); /*0.5*/
         READ_OR_BAIL(readFloatBE, v2.blue); /*0.5*/
         READ_OR_BAIL(readFloatBE, v2.scale); /*0.5*/
     }
-    else if (particleId == 15) { /*8.2*/
+    else if (V_particleId == 15) { /*8.2*/
          obj.data_15 = {}; pdef::pc1_18_play_toServer::particle::Data15 &v2 = *obj.data_15; /*8.4*/
         READ_OR_BAIL(readFloatBE, v2.fromRed); /*0.5*/
         READ_OR_BAIL(readFloatBE, v2.fromGreen); /*0.5*/
@@ -2616,15 +2616,15 @@ bool packet(pdef::Stream &stream, pdef::pc1_18_play_toServer::packet &obj);
         READ_OR_BAIL(readFloatBE, v2.toGreen); /*0.5*/
         READ_OR_BAIL(readFloatBE, v2.toBlue); /*0.5*/
     }
-    else if (particleId == 24) { /*8.2*/
+    else if (V_particleId == 24) { /*8.2*/
          obj.data_2_or_3_or_24 = {}; pdef::pc1_18_play_toServer::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.4*/
         READ_OR_BAIL(readUnsignedVarInt, v2.blockState); /*0.5*/
     }
-    else if (particleId == 35) { /*8.2*/
+    else if (V_particleId == 35) { /*8.2*/
          obj.data_35 = {}; pdef::pc1_18_play_toServer::particle::Data35 &v2 = *obj.data_35; /*8.4*/
         READ_OR_BAIL(readByte, v2.item); /*0.5*/
     }
-    else if (particleId == 36) { /*8.2*/
+    else if (V_particleId == 36) { /*8.2*/
          obj.data_36 = {}; pdef::pc1_18_play_toServer::particle::Data36 &v2 = *obj.data_36; /*8.4*/
         uint64_t origin_val;
         READ_OR_BAIL(readULongBE, origin_val);
@@ -2633,15 +2633,15 @@ bool packet(pdef::Stream &stream, pdef::pc1_18_play_toServer::packet &obj);
         v2.origin.y = origin_val >> 52 & 12; /*origin: bitfield*/ /*4.3*/
         int positionType_strlen; READ_OR_BAIL(readUnsignedVarInt, positionType_strlen);
         if (!stream.readString(v2.positionType, positionType_strlen)) return false; /*positionType: pstring*/ /*4.3*/
-        std::string &positionType = v2.positionType; /*4.8*/
-        if (positionType == "minecraft:block") { /*8.0*/
+        std::string &V_positionType = v2.positionType; /*4.8*/
+        if (V_positionType == "minecraft:block") { /*8.0*/
           uint64_t destination_position_val;
           READ_OR_BAIL(readULongBE, destination_position_val);
           v2.destination_position.x = destination_position_val >> 0 & 26;
           v2.destination_position.z = destination_position_val >> 26 & 26;
           v2.destination_position.y = destination_position_val >> 52 & 12; /*destination_position: bitfield*/ /*4.3*/
         }
-        else if (positionType == "minecraft:entity") { /*8.0*/
+        else if (V_positionType == "minecraft:entity") { /*8.0*/
           READ_OR_BAIL(readUnsignedVarInt, v2.destination_varint); /*0.5*/
         }
         READ_OR_BAIL(readUnsignedVarInt, v2.ticks); /*0.5*/
@@ -2653,7 +2653,7 @@ bool packet(pdef::Stream &stream, pdef::pc1_18_play_toServer::packet &obj);
     if (!stream.readString(obj.group, group_strlen)) return false; /*group: pstring*/ /*4.3*/
     int ingredient_len; READ_OR_BAIL(readUnsignedVarInt, ingredient_len); /*1.5*/
     obj.ingredient.resize(ingredient_len); /*1.6*/
-    for (int i = 0; i < ingredient_len; i++) {
+    for (int i = 0; i < ingredient_len; i++) { /*3.3*/
       auto &v2 = obj.ingredient[i]; /*3.4*/
       READ_OR_BAIL(readByte, v2); /*0.5*/
     }
@@ -2667,7 +2667,7 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_play_toServer::tags &obj) {
     if (!stream.readString(obj.tagName, tagName_strlen)) return false; /*tagName: pstring*/ /*4.3*/
     int entries_len; READ_OR_BAIL(readUnsignedVarInt, entries_len); /*1.5*/
     obj.entries.resize(entries_len); /*1.6*/
-    for (int i = 0; i < entries_len; i++) {
+    for (int i = 0; i < entries_len; i++) { /*3.3*/
       auto &v2 = obj.entries[i]; /*3.4*/
       READ_OR_BAIL(readUnsignedVarInt, v2); /*0.5*/
     }
@@ -2691,194 +2691,194 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_play_toServer::tags &obj) {
     obj.flags.has_redirect_node = flags_val >> 4 & 1;
     obj.flags.has_command = flags_val >> 5 & 1;
     obj.flags.command_node_type = flags_val >> 6 & 2; /*flags: bitfield*/ /*4.3*/
-    pdef::pc1_18_play_toServer::command_node::flags_t &flags = obj.flags; /*4.8*/
+    pdef::pc1_18_play_toServer::command_node::flags_t &V_flags = obj.flags; /*4.8*/
     int children_len; READ_OR_BAIL(readUnsignedVarInt, children_len); /*1.5*/
     obj.children.resize(children_len); /*1.6*/
-    for (int i = 0; i < children_len; i++) {
+    for (int i = 0; i < children_len; i++) { /*3.3*/
       auto &v2 = obj.children[i]; /*3.4*/
       READ_OR_BAIL(readUnsignedVarInt, v2); /*0.5*/
     }
-    if (flags.has_redirect_node == 1) { /*8.2*/
+    if (V_flags.has_redirect_node == 1) { /*8.2*/
       READ_OR_BAIL(readUnsignedVarInt, obj.redirectNode); /*0.5*/
     }
-    if (flags.command_node_type == 0) { /*8.2*/
+    if (V_flags.command_node_type == 0) { /*8.2*/
     }
-    else if (flags.command_node_type == 1) { /*8.2*/
+    else if (V_flags.command_node_type == 1) { /*8.2*/
          obj.extraNodeData_1 = {}; pdef::pc1_18_play_toServer::command_node::ExtraNodeData1 &v2 = *obj.extraNodeData_1; /*8.4*/
         int name_strlen; READ_OR_BAIL(readUnsignedVarInt, name_strlen);
         if (!stream.readString(v2.name, name_strlen)) return false; /*name: pstring*/ /*4.3*/
     }
-    else if (flags.command_node_type == 2) { /*8.2*/
+    else if (V_flags.command_node_type == 2) { /*8.2*/
          obj.extraNodeData_2 = {}; pdef::pc1_18_play_toServer::command_node::ExtraNodeData2 &v2 = *obj.extraNodeData_2; /*8.4*/
         int name_strlen; READ_OR_BAIL(readUnsignedVarInt, name_strlen);
         if (!stream.readString(v2.name, name_strlen)) return false; /*name: pstring*/ /*4.3*/
         int parser_strlen; READ_OR_BAIL(readUnsignedVarInt, parser_strlen);
         if (!stream.readString(v2.parser, parser_strlen)) return false; /*parser: pstring*/ /*4.3*/
-        std::string &parser = v2.parser; /*4.8*/
-        if (parser == "brigadier:bool") { /*8.0*/
+        std::string &V_parser = v2.parser; /*4.8*/
+        if (V_parser == "brigadier:bool") { /*8.0*/
         }
-        else if (parser == "brigadier:float") { /*8.0*/
+        else if (V_parser == "brigadier:float") { /*8.0*/
              v2.properties_brigadier_float = {}; pdef::pc1_18_play_toServer::command_node::ExtraNodeData2::PropertiesBrigadierFloat &v4 = *v2.properties_brigadier_float; /*8.4*/
             uint8_t flags_val;
             READ_OR_BAIL(readUByte, flags_val);
             v4.flags.unused = flags_val >> 0 & 6;
             v4.flags.max_present = flags_val >> 6 & 1;
             v4.flags.min_present = flags_val >> 7 & 1; /*flags: bitfield*/ /*4.3*/
-            pdef::pc1_18_play_toServer::command_node::ExtraNodeData2::PropertiesBrigadierFloat::flags_t &flags = v4.flags; /*4.8*/
-            if (flags.min_present == 1) { /*8.2*/
+            pdef::pc1_18_play_toServer::command_node::ExtraNodeData2::PropertiesBrigadierFloat::flags_t &V_flags = v4.flags; /*4.8*/
+            if (V_flags.min_present == 1) { /*8.2*/
               READ_OR_BAIL(readFloatBE, v4.min); /*0.5*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               READ_OR_BAIL(readFloatBE, v4.max); /*0.5*/
             }
         }
-        else if (parser == "brigadier:double") { /*8.0*/
+        else if (V_parser == "brigadier:double") { /*8.0*/
              v2.properties_brigadier_double = {}; pdef::pc1_18_play_toServer::command_node::ExtraNodeData2::PropertiesBrigadierDouble &v4 = *v2.properties_brigadier_double; /*8.4*/
             uint8_t flags_val;
             READ_OR_BAIL(readUByte, flags_val);
             v4.flags.unused = flags_val >> 0 & 6;
             v4.flags.max_present = flags_val >> 6 & 1;
             v4.flags.min_present = flags_val >> 7 & 1; /*flags: bitfield*/ /*4.3*/
-            pdef::pc1_18_play_toServer::command_node::ExtraNodeData2::PropertiesBrigadierDouble::flags_t &flags = v4.flags; /*4.8*/
-            if (flags.min_present == 1) { /*8.2*/
+            pdef::pc1_18_play_toServer::command_node::ExtraNodeData2::PropertiesBrigadierDouble::flags_t &V_flags = v4.flags; /*4.8*/
+            if (V_flags.min_present == 1) { /*8.2*/
               READ_OR_BAIL(readDoubleBE, v4.min); /*0.5*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               READ_OR_BAIL(readDoubleBE, v4.max); /*0.5*/
             }
         }
-        else if (parser == "brigadier:integer") { /*8.0*/
+        else if (V_parser == "brigadier:integer") { /*8.0*/
              v2.properties_brigadier_integer = {}; pdef::pc1_18_play_toServer::command_node::ExtraNodeData2::PropertiesBrigadierInteger &v4 = *v2.properties_brigadier_integer; /*8.4*/
             uint8_t flags_val;
             READ_OR_BAIL(readUByte, flags_val);
             v4.flags.unused = flags_val >> 0 & 6;
             v4.flags.max_present = flags_val >> 6 & 1;
             v4.flags.min_present = flags_val >> 7 & 1; /*flags: bitfield*/ /*4.3*/
-            pdef::pc1_18_play_toServer::command_node::ExtraNodeData2::PropertiesBrigadierInteger::flags_t &flags = v4.flags; /*4.8*/
-            if (flags.min_present == 1) { /*8.2*/
+            pdef::pc1_18_play_toServer::command_node::ExtraNodeData2::PropertiesBrigadierInteger::flags_t &V_flags = v4.flags; /*4.8*/
+            if (V_flags.min_present == 1) { /*8.2*/
               READ_OR_BAIL(readIntBE, v4.min); /*0.5*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               READ_OR_BAIL(readIntBE, v4.max); /*0.5*/
             }
         }
-        else if (parser == "brigadier:long") { /*8.0*/
+        else if (V_parser == "brigadier:long") { /*8.0*/
              v2.properties_brigadier_long = {}; pdef::pc1_18_play_toServer::command_node::ExtraNodeData2::PropertiesBrigadierLong &v4 = *v2.properties_brigadier_long; /*8.4*/
             uint8_t flags_val;
             READ_OR_BAIL(readUByte, flags_val);
             v4.flags.unused = flags_val >> 0 & 6;
             v4.flags.max_present = flags_val >> 6 & 1;
             v4.flags.min_present = flags_val >> 7 & 1; /*flags: bitfield*/ /*4.3*/
-            pdef::pc1_18_play_toServer::command_node::ExtraNodeData2::PropertiesBrigadierLong::flags_t &flags = v4.flags; /*4.8*/
-            if (flags.min_present == 1) { /*8.2*/
+            pdef::pc1_18_play_toServer::command_node::ExtraNodeData2::PropertiesBrigadierLong::flags_t &V_flags = v4.flags; /*4.8*/
+            if (V_flags.min_present == 1) { /*8.2*/
               READ_OR_BAIL(readLongBE, v4.min); /*0.5*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               READ_OR_BAIL(readLongBE, v4.max); /*0.5*/
             }
         }
-        else if (parser == "brigadier:string") { /*8.0*/
+        else if (V_parser == "brigadier:string") { /*8.0*/
         }
-        else if (parser == "minecraft:entity") { /*8.0*/
+        else if (V_parser == "minecraft:entity") { /*8.0*/
           uint8_t properties_minecraft_entity_val;
           READ_OR_BAIL(readUByte, properties_minecraft_entity_val);
           v2.properties_minecraft_entity.unused = properties_minecraft_entity_val >> 0 & 6;
           v2.properties_minecraft_entity.onlyAllowPlayers = properties_minecraft_entity_val >> 6 & 1;
           v2.properties_minecraft_entity.onlyAllowEntities = properties_minecraft_entity_val >> 7 & 1; /*properties_minecraft_entity: bitfield*/ /*4.3*/
         }
-        else if (parser == "minecraft:game_profile") { /*8.0*/
+        else if (V_parser == "minecraft:game_profile") { /*8.0*/
         }
-        else if (parser == "minecraft:block_pos") { /*8.0*/
+        else if (V_parser == "minecraft:block_pos") { /*8.0*/
         }
-        else if (parser == "minecraft:column_pos") { /*8.0*/
+        else if (V_parser == "minecraft:column_pos") { /*8.0*/
         }
-        else if (parser == "minecraft:vec3") { /*8.0*/
+        else if (V_parser == "minecraft:vec3") { /*8.0*/
         }
-        else if (parser == "minecraft:vec2") { /*8.0*/
+        else if (V_parser == "minecraft:vec2") { /*8.0*/
         }
-        else if (parser == "minecraft:block_state") { /*8.0*/
+        else if (V_parser == "minecraft:block_state") { /*8.0*/
         }
-        else if (parser == "minecraft:block_predicate") { /*8.0*/
+        else if (V_parser == "minecraft:block_predicate") { /*8.0*/
         }
-        else if (parser == "minecraft:item_stack") { /*8.0*/
+        else if (V_parser == "minecraft:item_stack") { /*8.0*/
         }
-        else if (parser == "minecraft:item_predicate") { /*8.0*/
+        else if (V_parser == "minecraft:item_predicate") { /*8.0*/
         }
-        else if (parser == "minecraft:color") { /*8.0*/
+        else if (V_parser == "minecraft:color") { /*8.0*/
         }
-        else if (parser == "minecraft:component") { /*8.0*/
+        else if (V_parser == "minecraft:component") { /*8.0*/
         }
-        else if (parser == "minecraft:message") { /*8.0*/
+        else if (V_parser == "minecraft:message") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt") { /*8.0*/
+        else if (V_parser == "minecraft:nbt") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt_path") { /*8.0*/
+        else if (V_parser == "minecraft:nbt_path") { /*8.0*/
         }
-        else if (parser == "minecraft:objective") { /*8.0*/
+        else if (V_parser == "minecraft:objective") { /*8.0*/
         }
-        else if (parser == "minecraft:objective_criteria") { /*8.0*/
+        else if (V_parser == "minecraft:objective_criteria") { /*8.0*/
         }
-        else if (parser == "minecraft:operation") { /*8.0*/
+        else if (V_parser == "minecraft:operation") { /*8.0*/
         }
-        else if (parser == "minecraft:particle") { /*8.0*/
+        else if (V_parser == "minecraft:particle") { /*8.0*/
         }
-        else if (parser == "minecraft:angle") { /*8.0*/
+        else if (V_parser == "minecraft:angle") { /*8.0*/
         }
-        else if (parser == "minecraft:rotation") { /*8.0*/
+        else if (V_parser == "minecraft:rotation") { /*8.0*/
         }
-        else if (parser == "minecraft:scoreboard_slot") { /*8.0*/
+        else if (V_parser == "minecraft:scoreboard_slot") { /*8.0*/
         }
-        else if (parser == "minecraft:score_holder") { /*8.0*/
+        else if (V_parser == "minecraft:score_holder") { /*8.0*/
           uint8_t properties_minecraft_score_holder_val;
           READ_OR_BAIL(readUByte, properties_minecraft_score_holder_val);
           v2.properties_minecraft_score_holder.unused = properties_minecraft_score_holder_val >> 0 & 7;
           v2.properties_minecraft_score_holder.allowMultiple = properties_minecraft_score_holder_val >> 7 & 1; /*properties_minecraft_score_holder: bitfield*/ /*4.3*/
         }
-        else if (parser == "minecraft:swizzle") { /*8.0*/
+        else if (V_parser == "minecraft:swizzle") { /*8.0*/
         }
-        else if (parser == "minecraft:team") { /*8.0*/
+        else if (V_parser == "minecraft:team") { /*8.0*/
         }
-        else if (parser == "minecraft:item_slot") { /*8.0*/
+        else if (V_parser == "minecraft:item_slot") { /*8.0*/
         }
-        else if (parser == "minecraft:resource_location") { /*8.0*/
+        else if (V_parser == "minecraft:resource_location") { /*8.0*/
         }
-        else if (parser == "minecraft:mob_effect") { /*8.0*/
+        else if (V_parser == "minecraft:mob_effect") { /*8.0*/
         }
-        else if (parser == "minecraft:function") { /*8.0*/
+        else if (V_parser == "minecraft:function") { /*8.0*/
         }
-        else if (parser == "minecraft:entity_anchor") { /*8.0*/
+        else if (V_parser == "minecraft:entity_anchor") { /*8.0*/
         }
-        else if (parser == "minecraft:range") { /*8.0*/
+        else if (V_parser == "minecraft:range") { /*8.0*/
              v2.properties_minecraft_range = {}; pdef::pc1_18_play_toServer::command_node::ExtraNodeData2::PropertiesMinecraftRange &v4 = *v2.properties_minecraft_range; /*8.4*/
             READ_OR_BAIL(readBool, (bool&)v4.allowDecimals); /*0.5*/
         }
-        else if (parser == "minecraft:int_range") { /*8.0*/
+        else if (V_parser == "minecraft:int_range") { /*8.0*/
         }
-        else if (parser == "minecraft:float_range") { /*8.0*/
+        else if (V_parser == "minecraft:float_range") { /*8.0*/
         }
-        else if (parser == "minecraft:item_enchantment") { /*8.0*/
+        else if (V_parser == "minecraft:item_enchantment") { /*8.0*/
         }
-        else if (parser == "minecraft:entity_summon") { /*8.0*/
+        else if (V_parser == "minecraft:entity_summon") { /*8.0*/
         }
-        else if (parser == "minecraft:dimension") { /*8.0*/
+        else if (V_parser == "minecraft:dimension") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt_compound_tag") { /*8.0*/
+        else if (V_parser == "minecraft:nbt_compound_tag") { /*8.0*/
         }
-        else if (parser == "minecraft:time") { /*8.0*/
+        else if (V_parser == "minecraft:time") { /*8.0*/
         }
-        else if (parser == "minecraft:resource_or_tag") { /*8.0*/
+        else if (V_parser == "minecraft:resource_or_tag") { /*8.0*/
              v2.properties_minecraft_resource_or_tag_or_minecraft_resource = {}; pdef::pc1_18_play_toServer::command_node::ExtraNodeData2::PropertiesMinecraftResourceOrTagOrMinecraftResource &v4 = *v2.properties_minecraft_resource_or_tag_or_minecraft_resource; /*8.4*/
             int registry_strlen; READ_OR_BAIL(readUnsignedVarInt, registry_strlen);
             if (!stream.readString(v4.registry, registry_strlen)) return false; /*registry: pstring*/ /*4.3*/
         }
-        else if (parser == "minecraft:resource") { /*8.0*/
+        else if (V_parser == "minecraft:resource") { /*8.0*/
              v2.properties_minecraft_resource_or_tag_or_minecraft_resource = {}; pdef::pc1_18_play_toServer::command_node::ExtraNodeData2::PropertiesMinecraftResourceOrTagOrMinecraftResource &v4 = *v2.properties_minecraft_resource_or_tag_or_minecraft_resource; /*8.4*/
             int registry_strlen; READ_OR_BAIL(readUnsignedVarInt, registry_strlen);
             if (!stream.readString(v4.registry, registry_strlen)) return false; /*registry: pstring*/ /*4.3*/
         }
-        else if (parser == "minecraft:uuid") { /*8.0*/
+        else if (V_parser == "minecraft:uuid") { /*8.0*/
         }
-        if (flags.has_custom_suggestions == 1) { /*8.2*/
+        if (V_flags.has_custom_suggestions == 1) { /*8.2*/
           int suggestionType_strlen; READ_OR_BAIL(readUnsignedVarInt, suggestionType_strlen);
           if (!stream.readString(v2.suggestionType, suggestionType_strlen)) return false; /*suggestionType: pstring*/ /*4.3*/
         }
@@ -2906,7 +2906,7 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_play_toServer::tags &obj) {
     READ_OR_BAIL(readUnsignedVarInt, obj.hand); /*0.5*/
     int pages_len; READ_OR_BAIL(readUnsignedVarInt, pages_len); /*1.5*/
     obj.pages.resize(pages_len); /*1.6*/
-    for (int i = 0; i < pages_len; i++) {
+    for (int i = 0; i < pages_len; i++) { /*3.3*/
       auto &v2 = obj.pages[i]; /*3.4*/
       int _strlen; READ_OR_BAIL(readUnsignedVarInt, _strlen);
       if (!stream.readString(v2, _strlen)) return false; /*: pstring*/ /*4.3*/
@@ -3042,20 +3042,20 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_play_toServer::tags &obj) {
   bool packet_use_entity(pdef::Stream &stream, pdef::pc1_18_play_toServer::packet_use_entity &obj) {
     READ_OR_BAIL(readUnsignedVarInt, obj.target); /*0.5*/
     READ_OR_BAIL(readUnsignedVarInt, obj.mouse); /*0.5*/
-    int &mouse = obj.mouse; /*0.6*/
-    if (mouse == 2) { /*8.2*/
+    int &V_mouse = obj.mouse; /*0.6*/
+    if (V_mouse == 2) { /*8.2*/
       READ_OR_BAIL(readFloatBE, obj.x); /*0.5*/
     }
-    if (mouse == 2) { /*8.2*/
+    if (V_mouse == 2) { /*8.2*/
       READ_OR_BAIL(readFloatBE, obj.y); /*0.5*/
     }
-    if (mouse == 2) { /*8.2*/
+    if (V_mouse == 2) { /*8.2*/
       READ_OR_BAIL(readFloatBE, obj.z); /*0.5*/
     }
-    if (mouse == 0) { /*8.2*/
+    if (V_mouse == 0) { /*8.2*/
       READ_OR_BAIL(readUnsignedVarInt, obj.hand); /*0.5*/
     }
-    else if (mouse == 2) { /*8.2*/
+    else if (V_mouse == 2) { /*8.2*/
       READ_OR_BAIL(readUnsignedVarInt, obj.hand); /*0.5*/
     }
     READ_OR_BAIL(readBool, (bool&)obj.sneaking); /*0.5*/
@@ -3237,12 +3237,12 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_play_toServer::tags &obj) {
   }
   bool packet_advancement_tab(pdef::Stream &stream, pdef::pc1_18_play_toServer::packet_advancement_tab &obj) {
     READ_OR_BAIL(readUnsignedVarInt, obj.action); /*0.5*/
-    int &action = obj.action; /*0.6*/
-    if (action == 0) { /*8.2*/
+    int &V_action = obj.action; /*0.6*/
+    if (V_action == 0) { /*8.2*/
       int tabId_strlen; READ_OR_BAIL(readUnsignedVarInt, tabId_strlen);
       if (!stream.readString(obj.tabId, tabId_strlen)) return false; /*tabId: pstring*/ /*4.3*/
     }
-    else if (action == 1) { /*8.2*/
+    else if (V_action == 1) { /*8.2*/
     }
     return true;
   }
@@ -3252,8 +3252,8 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_play_toServer::tags &obj) {
   }
   bool packet(pdef::Stream &stream, pdef::pc1_18_play_toServer::packet &obj) {
     READ_OR_BAIL(readUnsignedVarInt, (int&)obj.name); /*7.2*/
-    const pdef::pc1_18_play_toServer::packet::Name &name = obj.name; /*0.7*/
-    switch (name) { /*8.0*/
+    const pdef::pc1_18_play_toServer::packet::Name &V_name = obj.name; /*0.7*/
+    switch (V_name) { /*8.0*/
       case pdef::pc1_18_play_toServer::packet::Name::TeleportConfirm: { /*8.5*/
         obj.params_packet_teleport_confirm = {}; pdef::pc1_18_play_toServer::decode::packet_teleport_confirm(stream, *obj.params_packet_teleport_confirm); /*obj*/ /*4.6*/
         break;

--- a/examples/mcpc-protocol/build/pc1_18_status_toClient.h
+++ b/examples/mcpc-protocol/build/pc1_18_status_toClient.h
@@ -245,10 +245,10 @@ size_t packet_ping(pdef::Stream &stream, const pdef::pc1_18_status_toClient::pac
 size_t packet(pdef::Stream &stream, const pdef::pc1_18_status_toClient::packet &obj);
   size_t slot(pdef::Stream &stream, const pdef::pc1_18_status_toClient::slot &obj) {
     size_t len = 0;
-    const bool &present = obj.present; /*0.1*/
-    if (present == false) { /*8.1*/
+    const bool &V_present = obj.present; /*0.1*/
+    if (V_present == false) { /*8.1*/
     }
-    else if (present == true) { /*8.1*/
+    else if (V_present == true) { /*8.1*/
         len += stream.sizeOfVarInt(obj.itemId); /*0.2*/
         len += 1; /*0.2*/
         len += 1; /*0.2*/
@@ -257,23 +257,23 @@ size_t packet(pdef::Stream &stream, const pdef::pc1_18_status_toClient::packet &
   }
   size_t particle(pdef::Stream &stream, const pdef::pc1_18_status_toClient::particle &obj) {
     size_t len = 0;
-    const int &particleId = obj.particleId; /*0.1*/
-    if (particleId == 2) { /*8.2*/
+    const int &V_particleId = obj.particleId; /*0.1*/
+    if (V_particleId == 2) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_2_or_3_or_24); const pdef::pc1_18_status_toClient::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.6*/
         len += stream.sizeOfVarInt(v2.blockState); /*0.2*/
     }
-    else if (particleId == 3) { /*8.2*/
+    else if (V_particleId == 3) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_2_or_3_or_24); const pdef::pc1_18_status_toClient::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.6*/
         len += stream.sizeOfVarInt(v2.blockState); /*0.2*/
     }
-    else if (particleId == 14) { /*8.2*/
+    else if (V_particleId == 14) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_14); const pdef::pc1_18_status_toClient::particle::Data14 &v2 = *obj.data_14; /*8.6*/
         len += 4; /*0.2*/
         len += 4; /*0.2*/
         len += 4; /*0.2*/
         len += 4; /*0.2*/
     }
-    else if (particleId == 15) { /*8.2*/
+    else if (V_particleId == 15) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_15); const pdef::pc1_18_status_toClient::particle::Data15 &v2 = *obj.data_15; /*8.6*/
         len += 4; /*0.2*/
         len += 4; /*0.2*/
@@ -283,24 +283,24 @@ size_t packet(pdef::Stream &stream, const pdef::pc1_18_status_toClient::packet &
         len += 4; /*0.2*/
         len += 4; /*0.2*/
     }
-    else if (particleId == 24) { /*8.2*/
+    else if (V_particleId == 24) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_2_or_3_or_24); const pdef::pc1_18_status_toClient::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.6*/
         len += stream.sizeOfVarInt(v2.blockState); /*0.2*/
     }
-    else if (particleId == 35) { /*8.2*/
+    else if (V_particleId == 35) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_35); const pdef::pc1_18_status_toClient::particle::Data35 &v2 = *obj.data_35; /*8.6*/
         len += 1; /*0.2*/
     }
-    else if (particleId == 36) { /*8.2*/
+    else if (V_particleId == 36) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_36); const pdef::pc1_18_status_toClient::particle::Data36 &v2 = *obj.data_36; /*8.6*/
         len += 1; /*origin: bitfield*/ /*4.1*/
         len += stream.sizeOfVarInt(v2.positionType.length());
         len += v2.positionType.length(); /*positionType^: pstring*/ /*4.1*/
-        const std::string &positionType = v2.positionType; /*4.7*/
-        if (positionType == "minecraft:block") { /*8.0*/
+        const std::string &V_positionType = v2.positionType; /*4.7*/
+        if (V_positionType == "minecraft:block") { /*8.0*/
           len += 1; /*destination: bitfield*/ /*4.1*/
         }
-        else if (positionType == "minecraft:entity") { /*8.0*/
+        else if (V_positionType == "minecraft:entity") { /*8.0*/
           len += stream.sizeOfVarInt(v2.destination_varint); /*0.2*/
         }
         len += stream.sizeOfVarInt(v2.ticks); /*0.2*/
@@ -312,7 +312,7 @@ size_t packet(pdef::Stream &stream, const pdef::pc1_18_status_toClient::packet &
     len += stream.sizeOfVarInt(obj.group.length());
     len += obj.group.length(); /*group: pstring*/ /*4.1*/
     len += stream.sizeOfVarInt(obj.ingredient.size()); /*1.3*/
-    for (const auto &v2 : obj.ingredient) {
+    for (const auto &v2 : obj.ingredient) { /*3.2*/
       len += 1; /*0.2*/
     }
     len += 1; /*0.2*/
@@ -325,7 +325,7 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_status_toClient::tags &obj)
     len += stream.sizeOfVarInt(obj.tagName.length());
     len += obj.tagName.length(); /*tagName: pstring*/ /*4.1*/
     len += stream.sizeOfVarInt(obj.entries.size()); /*1.3*/
-    for (const auto &v2 : obj.entries) {
+    for (const auto &v2 : obj.entries) { /*3.2*/
       len += stream.sizeOfVarInt(v2); /*0.2*/
     }
   PDEF_SIZE_DBG; return len;
@@ -341,169 +341,169 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_status_toClient::tags &obj)
   size_t command_node(pdef::Stream &stream, const pdef::pc1_18_status_toClient::command_node &obj) {
     size_t len = 0;
     len += 1; /*flags^: bitfield*/ /*4.1*/
-    const pdef::pc1_18_status_toClient::command_node::flags_t &flags = obj.flags; /*4.7*/
+    const pdef::pc1_18_status_toClient::command_node::flags_t &V_flags = obj.flags; /*4.7*/
     len += stream.sizeOfVarInt(obj.children.size()); /*1.3*/
-    for (const auto &v2 : obj.children) {
+    for (const auto &v2 : obj.children) { /*3.2*/
       len += stream.sizeOfVarInt(v2); /*0.2*/
     }
-    if (flags.has_redirect_node == 1) { /*8.2*/
+    if (V_flags.has_redirect_node == 1) { /*8.2*/
       len += stream.sizeOfVarInt(obj.redirectNode); /*0.2*/
     }
-    if (flags.command_node_type == 0) { /*8.2*/
+    if (V_flags.command_node_type == 0) { /*8.2*/
     }
-    else if (flags.command_node_type == 1) { /*8.2*/
+    else if (V_flags.command_node_type == 1) { /*8.2*/
         EXPECT_OR_BAIL(obj.extraNodeData_1); const pdef::pc1_18_status_toClient::command_node::ExtraNodeData1 &v2 = *obj.extraNodeData_1; /*8.6*/
         len += stream.sizeOfVarInt(v2.name.length());
         len += v2.name.length(); /*name: pstring*/ /*4.1*/
     }
-    else if (flags.command_node_type == 2) { /*8.2*/
+    else if (V_flags.command_node_type == 2) { /*8.2*/
         EXPECT_OR_BAIL(obj.extraNodeData_2); const pdef::pc1_18_status_toClient::command_node::ExtraNodeData2 &v2 = *obj.extraNodeData_2; /*8.6*/
         len += stream.sizeOfVarInt(v2.name.length());
         len += v2.name.length(); /*name: pstring*/ /*4.1*/
         len += stream.sizeOfVarInt(v2.parser.length());
         len += v2.parser.length(); /*parser^: pstring*/ /*4.1*/
-        const std::string &parser = v2.parser; /*4.7*/
-        if (parser == "brigadier:bool") { /*8.0*/
+        const std::string &V_parser = v2.parser; /*4.7*/
+        if (V_parser == "brigadier:bool") { /*8.0*/
         }
-        else if (parser == "brigadier:float") { /*8.0*/
+        else if (V_parser == "brigadier:float") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_brigadier_float); const pdef::pc1_18_status_toClient::command_node::ExtraNodeData2::PropertiesBrigadierFloat &v4 = *v2.properties_brigadier_float; /*8.6*/
             len += 1; /*flags^: bitfield*/ /*4.1*/
-            const pdef::pc1_18_status_toClient::command_node::ExtraNodeData2::PropertiesBrigadierFloat::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_status_toClient::command_node::ExtraNodeData2::PropertiesBrigadierFloat::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               len += 4; /*0.2*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               len += 4; /*0.2*/
             }
         }
-        else if (parser == "brigadier:double") { /*8.0*/
+        else if (V_parser == "brigadier:double") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_brigadier_double); const pdef::pc1_18_status_toClient::command_node::ExtraNodeData2::PropertiesBrigadierDouble &v4 = *v2.properties_brigadier_double; /*8.6*/
             len += 1; /*flags^: bitfield*/ /*4.1*/
-            const pdef::pc1_18_status_toClient::command_node::ExtraNodeData2::PropertiesBrigadierDouble::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_status_toClient::command_node::ExtraNodeData2::PropertiesBrigadierDouble::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               len += 8; /*0.2*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               len += 8; /*0.2*/
             }
         }
-        else if (parser == "brigadier:integer") { /*8.0*/
+        else if (V_parser == "brigadier:integer") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_brigadier_integer); const pdef::pc1_18_status_toClient::command_node::ExtraNodeData2::PropertiesBrigadierInteger &v4 = *v2.properties_brigadier_integer; /*8.6*/
             len += 1; /*flags^: bitfield*/ /*4.1*/
-            const pdef::pc1_18_status_toClient::command_node::ExtraNodeData2::PropertiesBrigadierInteger::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_status_toClient::command_node::ExtraNodeData2::PropertiesBrigadierInteger::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               len += 4; /*0.2*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               len += 4; /*0.2*/
             }
         }
-        else if (parser == "brigadier:long") { /*8.0*/
+        else if (V_parser == "brigadier:long") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_brigadier_long); const pdef::pc1_18_status_toClient::command_node::ExtraNodeData2::PropertiesBrigadierLong &v4 = *v2.properties_brigadier_long; /*8.6*/
             len += 1; /*flags^: bitfield*/ /*4.1*/
-            const pdef::pc1_18_status_toClient::command_node::ExtraNodeData2::PropertiesBrigadierLong::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_status_toClient::command_node::ExtraNodeData2::PropertiesBrigadierLong::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               len += 8; /*0.2*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               len += 8; /*0.2*/
             }
         }
-        else if (parser == "brigadier:string") { /*8.0*/
+        else if (V_parser == "brigadier:string") { /*8.0*/
         }
-        else if (parser == "minecraft:entity") { /*8.0*/
+        else if (V_parser == "minecraft:entity") { /*8.0*/
           len += 1; /*properties: bitfield*/ /*4.1*/
         }
-        else if (parser == "minecraft:game_profile") { /*8.0*/
+        else if (V_parser == "minecraft:game_profile") { /*8.0*/
         }
-        else if (parser == "minecraft:block_pos") { /*8.0*/
+        else if (V_parser == "minecraft:block_pos") { /*8.0*/
         }
-        else if (parser == "minecraft:column_pos") { /*8.0*/
+        else if (V_parser == "minecraft:column_pos") { /*8.0*/
         }
-        else if (parser == "minecraft:vec3") { /*8.0*/
+        else if (V_parser == "minecraft:vec3") { /*8.0*/
         }
-        else if (parser == "minecraft:vec2") { /*8.0*/
+        else if (V_parser == "minecraft:vec2") { /*8.0*/
         }
-        else if (parser == "minecraft:block_state") { /*8.0*/
+        else if (V_parser == "minecraft:block_state") { /*8.0*/
         }
-        else if (parser == "minecraft:block_predicate") { /*8.0*/
+        else if (V_parser == "minecraft:block_predicate") { /*8.0*/
         }
-        else if (parser == "minecraft:item_stack") { /*8.0*/
+        else if (V_parser == "minecraft:item_stack") { /*8.0*/
         }
-        else if (parser == "minecraft:item_predicate") { /*8.0*/
+        else if (V_parser == "minecraft:item_predicate") { /*8.0*/
         }
-        else if (parser == "minecraft:color") { /*8.0*/
+        else if (V_parser == "minecraft:color") { /*8.0*/
         }
-        else if (parser == "minecraft:component") { /*8.0*/
+        else if (V_parser == "minecraft:component") { /*8.0*/
         }
-        else if (parser == "minecraft:message") { /*8.0*/
+        else if (V_parser == "minecraft:message") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt") { /*8.0*/
+        else if (V_parser == "minecraft:nbt") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt_path") { /*8.0*/
+        else if (V_parser == "minecraft:nbt_path") { /*8.0*/
         }
-        else if (parser == "minecraft:objective") { /*8.0*/
+        else if (V_parser == "minecraft:objective") { /*8.0*/
         }
-        else if (parser == "minecraft:objective_criteria") { /*8.0*/
+        else if (V_parser == "minecraft:objective_criteria") { /*8.0*/
         }
-        else if (parser == "minecraft:operation") { /*8.0*/
+        else if (V_parser == "minecraft:operation") { /*8.0*/
         }
-        else if (parser == "minecraft:particle") { /*8.0*/
+        else if (V_parser == "minecraft:particle") { /*8.0*/
         }
-        else if (parser == "minecraft:angle") { /*8.0*/
+        else if (V_parser == "minecraft:angle") { /*8.0*/
         }
-        else if (parser == "minecraft:rotation") { /*8.0*/
+        else if (V_parser == "minecraft:rotation") { /*8.0*/
         }
-        else if (parser == "minecraft:scoreboard_slot") { /*8.0*/
+        else if (V_parser == "minecraft:scoreboard_slot") { /*8.0*/
         }
-        else if (parser == "minecraft:score_holder") { /*8.0*/
+        else if (V_parser == "minecraft:score_holder") { /*8.0*/
           len += 1; /*properties: bitfield*/ /*4.1*/
         }
-        else if (parser == "minecraft:swizzle") { /*8.0*/
+        else if (V_parser == "minecraft:swizzle") { /*8.0*/
         }
-        else if (parser == "minecraft:team") { /*8.0*/
+        else if (V_parser == "minecraft:team") { /*8.0*/
         }
-        else if (parser == "minecraft:item_slot") { /*8.0*/
+        else if (V_parser == "minecraft:item_slot") { /*8.0*/
         }
-        else if (parser == "minecraft:resource_location") { /*8.0*/
+        else if (V_parser == "minecraft:resource_location") { /*8.0*/
         }
-        else if (parser == "minecraft:mob_effect") { /*8.0*/
+        else if (V_parser == "minecraft:mob_effect") { /*8.0*/
         }
-        else if (parser == "minecraft:function") { /*8.0*/
+        else if (V_parser == "minecraft:function") { /*8.0*/
         }
-        else if (parser == "minecraft:entity_anchor") { /*8.0*/
+        else if (V_parser == "minecraft:entity_anchor") { /*8.0*/
         }
-        else if (parser == "minecraft:range") { /*8.0*/
+        else if (V_parser == "minecraft:range") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_minecraft_range); const pdef::pc1_18_status_toClient::command_node::ExtraNodeData2::PropertiesMinecraftRange &v4 = *v2.properties_minecraft_range; /*8.6*/
             len += 1; /*0.2*/
         }
-        else if (parser == "minecraft:int_range") { /*8.0*/
+        else if (V_parser == "minecraft:int_range") { /*8.0*/
         }
-        else if (parser == "minecraft:float_range") { /*8.0*/
+        else if (V_parser == "minecraft:float_range") { /*8.0*/
         }
-        else if (parser == "minecraft:item_enchantment") { /*8.0*/
+        else if (V_parser == "minecraft:item_enchantment") { /*8.0*/
         }
-        else if (parser == "minecraft:entity_summon") { /*8.0*/
+        else if (V_parser == "minecraft:entity_summon") { /*8.0*/
         }
-        else if (parser == "minecraft:dimension") { /*8.0*/
+        else if (V_parser == "minecraft:dimension") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt_compound_tag") { /*8.0*/
+        else if (V_parser == "minecraft:nbt_compound_tag") { /*8.0*/
         }
-        else if (parser == "minecraft:time") { /*8.0*/
+        else if (V_parser == "minecraft:time") { /*8.0*/
         }
-        else if (parser == "minecraft:resource_or_tag") { /*8.0*/
+        else if (V_parser == "minecraft:resource_or_tag") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_minecraft_resource_or_tag_or_minecraft_resource); const pdef::pc1_18_status_toClient::command_node::ExtraNodeData2::PropertiesMinecraftResourceOrTagOrMinecraftResource &v4 = *v2.properties_minecraft_resource_or_tag_or_minecraft_resource; /*8.6*/
             len += stream.sizeOfVarInt(v4.registry.length());
             len += v4.registry.length(); /*registry: pstring*/ /*4.1*/
         }
-        else if (parser == "minecraft:resource") { /*8.0*/
+        else if (V_parser == "minecraft:resource") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_minecraft_resource_or_tag_or_minecraft_resource); const pdef::pc1_18_status_toClient::command_node::ExtraNodeData2::PropertiesMinecraftResourceOrTagOrMinecraftResource &v4 = *v2.properties_minecraft_resource_or_tag_or_minecraft_resource; /*8.6*/
             len += stream.sizeOfVarInt(v4.registry.length());
             len += v4.registry.length(); /*registry: pstring*/ /*4.1*/
         }
-        else if (parser == "minecraft:uuid") { /*8.0*/
+        else if (V_parser == "minecraft:uuid") { /*8.0*/
         }
-        if (flags.has_custom_suggestions == 1) { /*8.2*/
+        if (V_flags.has_custom_suggestions == 1) { /*8.2*/
           len += stream.sizeOfVarInt(v2.suggestionType.length());
           len += v2.suggestionType.length(); /*suggestionType: pstring*/ /*4.1*/
         }
@@ -523,9 +523,9 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_status_toClient::tags &obj)
   }
   size_t packet(pdef::Stream &stream, const pdef::pc1_18_status_toClient::packet &obj) {
     size_t len = 0;
-    const pdef::pc1_18_status_toClient::packet::Name &name = obj.name; /*0.3*/
+    const pdef::pc1_18_status_toClient::packet::Name &V_name = obj.name; /*0.3*/
     len += stream.sizeOfVarInt((int&)obj.name); /*name^: varint*/ /*7.0*/
-    switch (name) { /*8.0*/
+    switch (V_name) { /*8.0*/
       case pdef::pc1_18_status_toClient::packet::Name::ServerInfo: { /*8.5*/
         EXPECT_OR_BAIL(obj.params_packet_server_info); size_t len_0 = pdef::pc1_18_status_toClient::size::packet_server_info(stream, *obj.params_packet_server_info); EXPECT_OR_BAIL(len_0); len += len_0; /*params_packet_server_info*/ /*4.4*/
         break;
@@ -552,11 +552,11 @@ bool packet_ping(pdef::Stream &stream, const pdef::pc1_18_status_toClient::packe
 bool packet(pdef::Stream &stream, const pdef::pc1_18_status_toClient::packet &obj, bool allocate);
   bool slot(pdef::Stream &stream, const pdef::pc1_18_status_toClient::slot &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::pc1_18_status_toClient::size::slot(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const bool &present = obj.present; /*0.1*/
+    const bool &V_present = obj.present; /*0.1*/
     WRITE_OR_BAIL(writeBool, (bool)obj.present); /*0.4*/
-    if (present == false) { /*8.1*/
+    if (V_present == false) { /*8.1*/
     }
-    else if (present == true) { /*8.1*/
+    else if (V_present == true) { /*8.1*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.itemId); /*0.4*/
         WRITE_OR_BAIL(writeByte, (int8_t)obj.itemCount); /*0.4*/
         WRITE_OR_BAIL(writeByte, (int8_t)obj.nbtData); /*0.4*/
@@ -565,24 +565,24 @@ bool packet(pdef::Stream &stream, const pdef::pc1_18_status_toClient::packet &ob
   }
   bool particle(pdef::Stream &stream, const pdef::pc1_18_status_toClient::particle &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::pc1_18_status_toClient::size::particle(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const int &particleId = obj.particleId; /*0.1*/
+    const int &V_particleId = obj.particleId; /*0.1*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.particleId); /*0.4*/
-    if (particleId == 2) { /*8.2*/
+    if (V_particleId == 2) { /*8.2*/
         const pdef::pc1_18_status_toClient::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.5*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.blockState); /*0.4*/
     }
-    else if (particleId == 3) { /*8.2*/
+    else if (V_particleId == 3) { /*8.2*/
         const pdef::pc1_18_status_toClient::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.5*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.blockState); /*0.4*/
     }
-    else if (particleId == 14) { /*8.2*/
+    else if (V_particleId == 14) { /*8.2*/
         const pdef::pc1_18_status_toClient::particle::Data14 &v2 = *obj.data_14; /*8.5*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.red); /*0.4*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.green); /*0.4*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.blue); /*0.4*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.scale); /*0.4*/
     }
-    else if (particleId == 15) { /*8.2*/
+    else if (V_particleId == 15) { /*8.2*/
         const pdef::pc1_18_status_toClient::particle::Data15 &v2 = *obj.data_15; /*8.5*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.fromRed); /*0.4*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.fromGreen); /*0.4*/
@@ -592,15 +592,15 @@ bool packet(pdef::Stream &stream, const pdef::pc1_18_status_toClient::packet &ob
         WRITE_OR_BAIL(writeFloatBE, (float)v2.toGreen); /*0.4*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.toBlue); /*0.4*/
     }
-    else if (particleId == 24) { /*8.2*/
+    else if (V_particleId == 24) { /*8.2*/
         const pdef::pc1_18_status_toClient::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.5*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.blockState); /*0.4*/
     }
-    else if (particleId == 35) { /*8.2*/
+    else if (V_particleId == 35) { /*8.2*/
         const pdef::pc1_18_status_toClient::particle::Data35 &v2 = *obj.data_35; /*8.5*/
         WRITE_OR_BAIL(writeByte, (int8_t)v2.item); /*0.4*/
     }
-    else if (particleId == 36) { /*8.2*/
+    else if (V_particleId == 36) { /*8.2*/
         const pdef::pc1_18_status_toClient::particle::Data36 &v2 = *obj.data_36; /*8.5*/
         uint64_t origin_val = 0;
         origin_val |= (uint64_t)v2.origin.x << 0;
@@ -609,15 +609,15 @@ bool packet(pdef::Stream &stream, const pdef::pc1_18_status_toClient::packet &ob
         WRITE_OR_BAIL(writeULongBE, origin_val); /*origin: bitfield*/ /*4.2*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.positionType.length());
         WRITE_OR_BAIL(writeString, v2.positionType); /*positionType: pstring*/ /*4.2*/
-        const std::string &positionType = v2.positionType; /*4.7*/
-        if (positionType == "minecraft:block") { /*8.0*/
+        const std::string &V_positionType = v2.positionType; /*4.7*/
+        if (V_positionType == "minecraft:block") { /*8.0*/
           uint64_t destination_position_val = 0;
           destination_position_val |= (uint64_t)v2.destination_position.x << 0;
           destination_position_val |= (uint64_t)v2.destination_position.z << 26;
           destination_position_val |= (uint64_t)v2.destination_position.y << 52;
           WRITE_OR_BAIL(writeULongBE, destination_position_val); /*destination_position: bitfield*/ /*4.2*/
         }
-        else if (positionType == "minecraft:entity") { /*8.0*/
+        else if (V_positionType == "minecraft:entity") { /*8.0*/
           WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.destination_varint); /*0.4*/
         }
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.ticks); /*0.4*/
@@ -667,192 +667,192 @@ bool tags(pdef::Stream &stream, const pdef::pc1_18_status_toClient::tags &obj, b
     flags_val |= (uint8_t)obj.flags.has_command << 5;
     flags_val |= (uint8_t)obj.flags.command_node_type << 6;
     WRITE_OR_BAIL(writeUByte, flags_val); /*flags: bitfield*/ /*4.2*/
-    const pdef::pc1_18_status_toClient::command_node::flags_t &flags = obj.flags; /*4.7*/
+    const pdef::pc1_18_status_toClient::command_node::flags_t &V_flags = obj.flags; /*4.7*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.children.size()); /*1.4*/
     for (const auto &v2 : obj.children) { /*3.1*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2); /*0.4*/
     }
-    if (flags.has_redirect_node == 1) { /*8.2*/
+    if (V_flags.has_redirect_node == 1) { /*8.2*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.redirectNode); /*0.4*/
     }
-    if (flags.command_node_type == 0) { /*8.2*/
+    if (V_flags.command_node_type == 0) { /*8.2*/
     }
-    else if (flags.command_node_type == 1) { /*8.2*/
+    else if (V_flags.command_node_type == 1) { /*8.2*/
         const pdef::pc1_18_status_toClient::command_node::ExtraNodeData1 &v2 = *obj.extraNodeData_1; /*8.5*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.name.length());
         WRITE_OR_BAIL(writeString, v2.name); /*name: pstring*/ /*4.2*/
     }
-    else if (flags.command_node_type == 2) { /*8.2*/
+    else if (V_flags.command_node_type == 2) { /*8.2*/
         const pdef::pc1_18_status_toClient::command_node::ExtraNodeData2 &v2 = *obj.extraNodeData_2; /*8.5*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.name.length());
         WRITE_OR_BAIL(writeString, v2.name); /*name: pstring*/ /*4.2*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.parser.length());
         WRITE_OR_BAIL(writeString, v2.parser); /*parser: pstring*/ /*4.2*/
-        const std::string &parser = v2.parser; /*4.7*/
-        if (parser == "brigadier:bool") { /*8.0*/
+        const std::string &V_parser = v2.parser; /*4.7*/
+        if (V_parser == "brigadier:bool") { /*8.0*/
         }
-        else if (parser == "brigadier:float") { /*8.0*/
+        else if (V_parser == "brigadier:float") { /*8.0*/
             const pdef::pc1_18_status_toClient::command_node::ExtraNodeData2::PropertiesBrigadierFloat &v4 = *v2.properties_brigadier_float; /*8.5*/
             uint8_t flags_val = 0;
             flags_val |= (uint8_t)v4.flags.unused << 0;
             flags_val |= (uint8_t)v4.flags.max_present << 6;
             flags_val |= (uint8_t)v4.flags.min_present << 7;
             WRITE_OR_BAIL(writeUByte, flags_val); /*flags: bitfield*/ /*4.2*/
-            const pdef::pc1_18_status_toClient::command_node::ExtraNodeData2::PropertiesBrigadierFloat::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_status_toClient::command_node::ExtraNodeData2::PropertiesBrigadierFloat::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeFloatBE, (float)v4.min); /*0.4*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeFloatBE, (float)v4.max); /*0.4*/
             }
         }
-        else if (parser == "brigadier:double") { /*8.0*/
+        else if (V_parser == "brigadier:double") { /*8.0*/
             const pdef::pc1_18_status_toClient::command_node::ExtraNodeData2::PropertiesBrigadierDouble &v4 = *v2.properties_brigadier_double; /*8.5*/
             uint8_t flags_val = 0;
             flags_val |= (uint8_t)v4.flags.unused << 0;
             flags_val |= (uint8_t)v4.flags.max_present << 6;
             flags_val |= (uint8_t)v4.flags.min_present << 7;
             WRITE_OR_BAIL(writeUByte, flags_val); /*flags: bitfield*/ /*4.2*/
-            const pdef::pc1_18_status_toClient::command_node::ExtraNodeData2::PropertiesBrigadierDouble::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_status_toClient::command_node::ExtraNodeData2::PropertiesBrigadierDouble::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeDoubleBE, (double)v4.min); /*0.4*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeDoubleBE, (double)v4.max); /*0.4*/
             }
         }
-        else if (parser == "brigadier:integer") { /*8.0*/
+        else if (V_parser == "brigadier:integer") { /*8.0*/
             const pdef::pc1_18_status_toClient::command_node::ExtraNodeData2::PropertiesBrigadierInteger &v4 = *v2.properties_brigadier_integer; /*8.5*/
             uint8_t flags_val = 0;
             flags_val |= (uint8_t)v4.flags.unused << 0;
             flags_val |= (uint8_t)v4.flags.max_present << 6;
             flags_val |= (uint8_t)v4.flags.min_present << 7;
             WRITE_OR_BAIL(writeUByte, flags_val); /*flags: bitfield*/ /*4.2*/
-            const pdef::pc1_18_status_toClient::command_node::ExtraNodeData2::PropertiesBrigadierInteger::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_status_toClient::command_node::ExtraNodeData2::PropertiesBrigadierInteger::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeIntBE, (int32_t)v4.min); /*0.4*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeIntBE, (int32_t)v4.max); /*0.4*/
             }
         }
-        else if (parser == "brigadier:long") { /*8.0*/
+        else if (V_parser == "brigadier:long") { /*8.0*/
             const pdef::pc1_18_status_toClient::command_node::ExtraNodeData2::PropertiesBrigadierLong &v4 = *v2.properties_brigadier_long; /*8.5*/
             uint8_t flags_val = 0;
             flags_val |= (uint8_t)v4.flags.unused << 0;
             flags_val |= (uint8_t)v4.flags.max_present << 6;
             flags_val |= (uint8_t)v4.flags.min_present << 7;
             WRITE_OR_BAIL(writeUByte, flags_val); /*flags: bitfield*/ /*4.2*/
-            const pdef::pc1_18_status_toClient::command_node::ExtraNodeData2::PropertiesBrigadierLong::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_status_toClient::command_node::ExtraNodeData2::PropertiesBrigadierLong::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeLongBE, (int64_t)v4.min); /*0.4*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeLongBE, (int64_t)v4.max); /*0.4*/
             }
         }
-        else if (parser == "brigadier:string") { /*8.0*/
+        else if (V_parser == "brigadier:string") { /*8.0*/
         }
-        else if (parser == "minecraft:entity") { /*8.0*/
+        else if (V_parser == "minecraft:entity") { /*8.0*/
           uint8_t properties_minecraft_entity_val = 0;
           properties_minecraft_entity_val |= (uint8_t)v2.properties_minecraft_entity.unused << 0;
           properties_minecraft_entity_val |= (uint8_t)v2.properties_minecraft_entity.onlyAllowPlayers << 6;
           properties_minecraft_entity_val |= (uint8_t)v2.properties_minecraft_entity.onlyAllowEntities << 7;
           WRITE_OR_BAIL(writeUByte, properties_minecraft_entity_val); /*properties_minecraft_entity: bitfield*/ /*4.2*/
         }
-        else if (parser == "minecraft:game_profile") { /*8.0*/
+        else if (V_parser == "minecraft:game_profile") { /*8.0*/
         }
-        else if (parser == "minecraft:block_pos") { /*8.0*/
+        else if (V_parser == "minecraft:block_pos") { /*8.0*/
         }
-        else if (parser == "minecraft:column_pos") { /*8.0*/
+        else if (V_parser == "minecraft:column_pos") { /*8.0*/
         }
-        else if (parser == "minecraft:vec3") { /*8.0*/
+        else if (V_parser == "minecraft:vec3") { /*8.0*/
         }
-        else if (parser == "minecraft:vec2") { /*8.0*/
+        else if (V_parser == "minecraft:vec2") { /*8.0*/
         }
-        else if (parser == "minecraft:block_state") { /*8.0*/
+        else if (V_parser == "minecraft:block_state") { /*8.0*/
         }
-        else if (parser == "minecraft:block_predicate") { /*8.0*/
+        else if (V_parser == "minecraft:block_predicate") { /*8.0*/
         }
-        else if (parser == "minecraft:item_stack") { /*8.0*/
+        else if (V_parser == "minecraft:item_stack") { /*8.0*/
         }
-        else if (parser == "minecraft:item_predicate") { /*8.0*/
+        else if (V_parser == "minecraft:item_predicate") { /*8.0*/
         }
-        else if (parser == "minecraft:color") { /*8.0*/
+        else if (V_parser == "minecraft:color") { /*8.0*/
         }
-        else if (parser == "minecraft:component") { /*8.0*/
+        else if (V_parser == "minecraft:component") { /*8.0*/
         }
-        else if (parser == "minecraft:message") { /*8.0*/
+        else if (V_parser == "minecraft:message") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt") { /*8.0*/
+        else if (V_parser == "minecraft:nbt") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt_path") { /*8.0*/
+        else if (V_parser == "minecraft:nbt_path") { /*8.0*/
         }
-        else if (parser == "minecraft:objective") { /*8.0*/
+        else if (V_parser == "minecraft:objective") { /*8.0*/
         }
-        else if (parser == "minecraft:objective_criteria") { /*8.0*/
+        else if (V_parser == "minecraft:objective_criteria") { /*8.0*/
         }
-        else if (parser == "minecraft:operation") { /*8.0*/
+        else if (V_parser == "minecraft:operation") { /*8.0*/
         }
-        else if (parser == "minecraft:particle") { /*8.0*/
+        else if (V_parser == "minecraft:particle") { /*8.0*/
         }
-        else if (parser == "minecraft:angle") { /*8.0*/
+        else if (V_parser == "minecraft:angle") { /*8.0*/
         }
-        else if (parser == "minecraft:rotation") { /*8.0*/
+        else if (V_parser == "minecraft:rotation") { /*8.0*/
         }
-        else if (parser == "minecraft:scoreboard_slot") { /*8.0*/
+        else if (V_parser == "minecraft:scoreboard_slot") { /*8.0*/
         }
-        else if (parser == "minecraft:score_holder") { /*8.0*/
+        else if (V_parser == "minecraft:score_holder") { /*8.0*/
           uint8_t properties_minecraft_score_holder_val = 0;
           properties_minecraft_score_holder_val |= (uint8_t)v2.properties_minecraft_score_holder.unused << 0;
           properties_minecraft_score_holder_val |= (uint8_t)v2.properties_minecraft_score_holder.allowMultiple << 7;
           WRITE_OR_BAIL(writeUByte, properties_minecraft_score_holder_val); /*properties_minecraft_score_holder: bitfield*/ /*4.2*/
         }
-        else if (parser == "minecraft:swizzle") { /*8.0*/
+        else if (V_parser == "minecraft:swizzle") { /*8.0*/
         }
-        else if (parser == "minecraft:team") { /*8.0*/
+        else if (V_parser == "minecraft:team") { /*8.0*/
         }
-        else if (parser == "minecraft:item_slot") { /*8.0*/
+        else if (V_parser == "minecraft:item_slot") { /*8.0*/
         }
-        else if (parser == "minecraft:resource_location") { /*8.0*/
+        else if (V_parser == "minecraft:resource_location") { /*8.0*/
         }
-        else if (parser == "minecraft:mob_effect") { /*8.0*/
+        else if (V_parser == "minecraft:mob_effect") { /*8.0*/
         }
-        else if (parser == "minecraft:function") { /*8.0*/
+        else if (V_parser == "minecraft:function") { /*8.0*/
         }
-        else if (parser == "minecraft:entity_anchor") { /*8.0*/
+        else if (V_parser == "minecraft:entity_anchor") { /*8.0*/
         }
-        else if (parser == "minecraft:range") { /*8.0*/
+        else if (V_parser == "minecraft:range") { /*8.0*/
             const pdef::pc1_18_status_toClient::command_node::ExtraNodeData2::PropertiesMinecraftRange &v4 = *v2.properties_minecraft_range; /*8.5*/
             WRITE_OR_BAIL(writeBool, (bool)v4.allowDecimals); /*0.4*/
         }
-        else if (parser == "minecraft:int_range") { /*8.0*/
+        else if (V_parser == "minecraft:int_range") { /*8.0*/
         }
-        else if (parser == "minecraft:float_range") { /*8.0*/
+        else if (V_parser == "minecraft:float_range") { /*8.0*/
         }
-        else if (parser == "minecraft:item_enchantment") { /*8.0*/
+        else if (V_parser == "minecraft:item_enchantment") { /*8.0*/
         }
-        else if (parser == "minecraft:entity_summon") { /*8.0*/
+        else if (V_parser == "minecraft:entity_summon") { /*8.0*/
         }
-        else if (parser == "minecraft:dimension") { /*8.0*/
+        else if (V_parser == "minecraft:dimension") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt_compound_tag") { /*8.0*/
+        else if (V_parser == "minecraft:nbt_compound_tag") { /*8.0*/
         }
-        else if (parser == "minecraft:time") { /*8.0*/
+        else if (V_parser == "minecraft:time") { /*8.0*/
         }
-        else if (parser == "minecraft:resource_or_tag") { /*8.0*/
+        else if (V_parser == "minecraft:resource_or_tag") { /*8.0*/
             const pdef::pc1_18_status_toClient::command_node::ExtraNodeData2::PropertiesMinecraftResourceOrTagOrMinecraftResource &v4 = *v2.properties_minecraft_resource_or_tag_or_minecraft_resource; /*8.5*/
             WRITE_OR_BAIL(writeUnsignedVarInt, (int)v4.registry.length());
             WRITE_OR_BAIL(writeString, v4.registry); /*registry: pstring*/ /*4.2*/
         }
-        else if (parser == "minecraft:resource") { /*8.0*/
+        else if (V_parser == "minecraft:resource") { /*8.0*/
             const pdef::pc1_18_status_toClient::command_node::ExtraNodeData2::PropertiesMinecraftResourceOrTagOrMinecraftResource &v4 = *v2.properties_minecraft_resource_or_tag_or_minecraft_resource; /*8.5*/
             WRITE_OR_BAIL(writeUnsignedVarInt, (int)v4.registry.length());
             WRITE_OR_BAIL(writeString, v4.registry); /*registry: pstring*/ /*4.2*/
         }
-        else if (parser == "minecraft:uuid") { /*8.0*/
+        else if (V_parser == "minecraft:uuid") { /*8.0*/
         }
-        if (flags.has_custom_suggestions == 1) { /*8.2*/
+        if (V_flags.has_custom_suggestions == 1) { /*8.2*/
           WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.suggestionType.length());
           WRITE_OR_BAIL(writeString, v2.suggestionType); /*suggestionType: pstring*/ /*4.2*/
         }
@@ -872,9 +872,9 @@ bool tags(pdef::Stream &stream, const pdef::pc1_18_status_toClient::tags &obj, b
   }
   bool packet(pdef::Stream &stream, const pdef::pc1_18_status_toClient::packet &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::pc1_18_status_toClient::size::packet(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const pdef::pc1_18_status_toClient::packet::Name &name = obj.name; /*0.3*/
+    const pdef::pc1_18_status_toClient::packet::Name &V_name = obj.name; /*0.3*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)(int&)obj.name); /*7.1*/
-    switch (name) { /*8.0*/
+    switch (V_name) { /*8.0*/
       case pdef::pc1_18_status_toClient::packet::Name::ServerInfo: { /*8.5*/
         pdef::pc1_18_status_toClient::encode::packet_server_info(stream, *obj.params_packet_server_info); /*packet_server_info*/ /*4.5*/
         break;
@@ -901,10 +901,10 @@ bool packet_ping(pdef::Stream &stream, pdef::pc1_18_status_toClient::packet_ping
 bool packet(pdef::Stream &stream, pdef::pc1_18_status_toClient::packet &obj);
   bool slot(pdef::Stream &stream, pdef::pc1_18_status_toClient::slot &obj) {
     READ_OR_BAIL(readBool, (bool&)obj.present); /*0.5*/
-    bool &present = obj.present; /*0.6*/
-    if (present == false) { /*8.1*/
+    bool &V_present = obj.present; /*0.6*/
+    if (V_present == false) { /*8.1*/
     }
-    else if (present == true) { /*8.1*/
+    else if (V_present == true) { /*8.1*/
         READ_OR_BAIL(readUnsignedVarInt, obj.itemId); /*0.5*/
         READ_OR_BAIL(readByte, obj.itemCount); /*0.5*/
         READ_OR_BAIL(readByte, obj.nbtData); /*0.5*/
@@ -913,23 +913,23 @@ bool packet(pdef::Stream &stream, pdef::pc1_18_status_toClient::packet &obj);
   }
   bool particle(pdef::Stream &stream, pdef::pc1_18_status_toClient::particle &obj) {
     READ_OR_BAIL(readUnsignedVarInt, obj.particleId); /*0.5*/
-    int &particleId = obj.particleId; /*0.6*/
-    if (particleId == 2) { /*8.2*/
+    int &V_particleId = obj.particleId; /*0.6*/
+    if (V_particleId == 2) { /*8.2*/
          obj.data_2_or_3_or_24 = {}; pdef::pc1_18_status_toClient::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.4*/
         READ_OR_BAIL(readUnsignedVarInt, v2.blockState); /*0.5*/
     }
-    else if (particleId == 3) { /*8.2*/
+    else if (V_particleId == 3) { /*8.2*/
          obj.data_2_or_3_or_24 = {}; pdef::pc1_18_status_toClient::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.4*/
         READ_OR_BAIL(readUnsignedVarInt, v2.blockState); /*0.5*/
     }
-    else if (particleId == 14) { /*8.2*/
+    else if (V_particleId == 14) { /*8.2*/
          obj.data_14 = {}; pdef::pc1_18_status_toClient::particle::Data14 &v2 = *obj.data_14; /*8.4*/
         READ_OR_BAIL(readFloatBE, v2.red); /*0.5*/
         READ_OR_BAIL(readFloatBE, v2.green); /*0.5*/
         READ_OR_BAIL(readFloatBE, v2.blue); /*0.5*/
         READ_OR_BAIL(readFloatBE, v2.scale); /*0.5*/
     }
-    else if (particleId == 15) { /*8.2*/
+    else if (V_particleId == 15) { /*8.2*/
          obj.data_15 = {}; pdef::pc1_18_status_toClient::particle::Data15 &v2 = *obj.data_15; /*8.4*/
         READ_OR_BAIL(readFloatBE, v2.fromRed); /*0.5*/
         READ_OR_BAIL(readFloatBE, v2.fromGreen); /*0.5*/
@@ -939,15 +939,15 @@ bool packet(pdef::Stream &stream, pdef::pc1_18_status_toClient::packet &obj);
         READ_OR_BAIL(readFloatBE, v2.toGreen); /*0.5*/
         READ_OR_BAIL(readFloatBE, v2.toBlue); /*0.5*/
     }
-    else if (particleId == 24) { /*8.2*/
+    else if (V_particleId == 24) { /*8.2*/
          obj.data_2_or_3_or_24 = {}; pdef::pc1_18_status_toClient::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.4*/
         READ_OR_BAIL(readUnsignedVarInt, v2.blockState); /*0.5*/
     }
-    else if (particleId == 35) { /*8.2*/
+    else if (V_particleId == 35) { /*8.2*/
          obj.data_35 = {}; pdef::pc1_18_status_toClient::particle::Data35 &v2 = *obj.data_35; /*8.4*/
         READ_OR_BAIL(readByte, v2.item); /*0.5*/
     }
-    else if (particleId == 36) { /*8.2*/
+    else if (V_particleId == 36) { /*8.2*/
          obj.data_36 = {}; pdef::pc1_18_status_toClient::particle::Data36 &v2 = *obj.data_36; /*8.4*/
         uint64_t origin_val;
         READ_OR_BAIL(readULongBE, origin_val);
@@ -956,15 +956,15 @@ bool packet(pdef::Stream &stream, pdef::pc1_18_status_toClient::packet &obj);
         v2.origin.y = origin_val >> 52 & 12; /*origin: bitfield*/ /*4.3*/
         int positionType_strlen; READ_OR_BAIL(readUnsignedVarInt, positionType_strlen);
         if (!stream.readString(v2.positionType, positionType_strlen)) return false; /*positionType: pstring*/ /*4.3*/
-        std::string &positionType = v2.positionType; /*4.8*/
-        if (positionType == "minecraft:block") { /*8.0*/
+        std::string &V_positionType = v2.positionType; /*4.8*/
+        if (V_positionType == "minecraft:block") { /*8.0*/
           uint64_t destination_position_val;
           READ_OR_BAIL(readULongBE, destination_position_val);
           v2.destination_position.x = destination_position_val >> 0 & 26;
           v2.destination_position.z = destination_position_val >> 26 & 26;
           v2.destination_position.y = destination_position_val >> 52 & 12; /*destination_position: bitfield*/ /*4.3*/
         }
-        else if (positionType == "minecraft:entity") { /*8.0*/
+        else if (V_positionType == "minecraft:entity") { /*8.0*/
           READ_OR_BAIL(readUnsignedVarInt, v2.destination_varint); /*0.5*/
         }
         READ_OR_BAIL(readUnsignedVarInt, v2.ticks); /*0.5*/
@@ -976,7 +976,7 @@ bool packet(pdef::Stream &stream, pdef::pc1_18_status_toClient::packet &obj);
     if (!stream.readString(obj.group, group_strlen)) return false; /*group: pstring*/ /*4.3*/
     int ingredient_len; READ_OR_BAIL(readUnsignedVarInt, ingredient_len); /*1.5*/
     obj.ingredient.resize(ingredient_len); /*1.6*/
-    for (int i = 0; i < ingredient_len; i++) {
+    for (int i = 0; i < ingredient_len; i++) { /*3.3*/
       auto &v2 = obj.ingredient[i]; /*3.4*/
       READ_OR_BAIL(readByte, v2); /*0.5*/
     }
@@ -990,7 +990,7 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_status_toClient::tags &obj) {
     if (!stream.readString(obj.tagName, tagName_strlen)) return false; /*tagName: pstring*/ /*4.3*/
     int entries_len; READ_OR_BAIL(readUnsignedVarInt, entries_len); /*1.5*/
     obj.entries.resize(entries_len); /*1.6*/
-    for (int i = 0; i < entries_len; i++) {
+    for (int i = 0; i < entries_len; i++) { /*3.3*/
       auto &v2 = obj.entries[i]; /*3.4*/
       READ_OR_BAIL(readUnsignedVarInt, v2); /*0.5*/
     }
@@ -1014,194 +1014,194 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_status_toClient::tags &obj) {
     obj.flags.has_redirect_node = flags_val >> 4 & 1;
     obj.flags.has_command = flags_val >> 5 & 1;
     obj.flags.command_node_type = flags_val >> 6 & 2; /*flags: bitfield*/ /*4.3*/
-    pdef::pc1_18_status_toClient::command_node::flags_t &flags = obj.flags; /*4.8*/
+    pdef::pc1_18_status_toClient::command_node::flags_t &V_flags = obj.flags; /*4.8*/
     int children_len; READ_OR_BAIL(readUnsignedVarInt, children_len); /*1.5*/
     obj.children.resize(children_len); /*1.6*/
-    for (int i = 0; i < children_len; i++) {
+    for (int i = 0; i < children_len; i++) { /*3.3*/
       auto &v2 = obj.children[i]; /*3.4*/
       READ_OR_BAIL(readUnsignedVarInt, v2); /*0.5*/
     }
-    if (flags.has_redirect_node == 1) { /*8.2*/
+    if (V_flags.has_redirect_node == 1) { /*8.2*/
       READ_OR_BAIL(readUnsignedVarInt, obj.redirectNode); /*0.5*/
     }
-    if (flags.command_node_type == 0) { /*8.2*/
+    if (V_flags.command_node_type == 0) { /*8.2*/
     }
-    else if (flags.command_node_type == 1) { /*8.2*/
+    else if (V_flags.command_node_type == 1) { /*8.2*/
          obj.extraNodeData_1 = {}; pdef::pc1_18_status_toClient::command_node::ExtraNodeData1 &v2 = *obj.extraNodeData_1; /*8.4*/
         int name_strlen; READ_OR_BAIL(readUnsignedVarInt, name_strlen);
         if (!stream.readString(v2.name, name_strlen)) return false; /*name: pstring*/ /*4.3*/
     }
-    else if (flags.command_node_type == 2) { /*8.2*/
+    else if (V_flags.command_node_type == 2) { /*8.2*/
          obj.extraNodeData_2 = {}; pdef::pc1_18_status_toClient::command_node::ExtraNodeData2 &v2 = *obj.extraNodeData_2; /*8.4*/
         int name_strlen; READ_OR_BAIL(readUnsignedVarInt, name_strlen);
         if (!stream.readString(v2.name, name_strlen)) return false; /*name: pstring*/ /*4.3*/
         int parser_strlen; READ_OR_BAIL(readUnsignedVarInt, parser_strlen);
         if (!stream.readString(v2.parser, parser_strlen)) return false; /*parser: pstring*/ /*4.3*/
-        std::string &parser = v2.parser; /*4.8*/
-        if (parser == "brigadier:bool") { /*8.0*/
+        std::string &V_parser = v2.parser; /*4.8*/
+        if (V_parser == "brigadier:bool") { /*8.0*/
         }
-        else if (parser == "brigadier:float") { /*8.0*/
+        else if (V_parser == "brigadier:float") { /*8.0*/
              v2.properties_brigadier_float = {}; pdef::pc1_18_status_toClient::command_node::ExtraNodeData2::PropertiesBrigadierFloat &v4 = *v2.properties_brigadier_float; /*8.4*/
             uint8_t flags_val;
             READ_OR_BAIL(readUByte, flags_val);
             v4.flags.unused = flags_val >> 0 & 6;
             v4.flags.max_present = flags_val >> 6 & 1;
             v4.flags.min_present = flags_val >> 7 & 1; /*flags: bitfield*/ /*4.3*/
-            pdef::pc1_18_status_toClient::command_node::ExtraNodeData2::PropertiesBrigadierFloat::flags_t &flags = v4.flags; /*4.8*/
-            if (flags.min_present == 1) { /*8.2*/
+            pdef::pc1_18_status_toClient::command_node::ExtraNodeData2::PropertiesBrigadierFloat::flags_t &V_flags = v4.flags; /*4.8*/
+            if (V_flags.min_present == 1) { /*8.2*/
               READ_OR_BAIL(readFloatBE, v4.min); /*0.5*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               READ_OR_BAIL(readFloatBE, v4.max); /*0.5*/
             }
         }
-        else if (parser == "brigadier:double") { /*8.0*/
+        else if (V_parser == "brigadier:double") { /*8.0*/
              v2.properties_brigadier_double = {}; pdef::pc1_18_status_toClient::command_node::ExtraNodeData2::PropertiesBrigadierDouble &v4 = *v2.properties_brigadier_double; /*8.4*/
             uint8_t flags_val;
             READ_OR_BAIL(readUByte, flags_val);
             v4.flags.unused = flags_val >> 0 & 6;
             v4.flags.max_present = flags_val >> 6 & 1;
             v4.flags.min_present = flags_val >> 7 & 1; /*flags: bitfield*/ /*4.3*/
-            pdef::pc1_18_status_toClient::command_node::ExtraNodeData2::PropertiesBrigadierDouble::flags_t &flags = v4.flags; /*4.8*/
-            if (flags.min_present == 1) { /*8.2*/
+            pdef::pc1_18_status_toClient::command_node::ExtraNodeData2::PropertiesBrigadierDouble::flags_t &V_flags = v4.flags; /*4.8*/
+            if (V_flags.min_present == 1) { /*8.2*/
               READ_OR_BAIL(readDoubleBE, v4.min); /*0.5*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               READ_OR_BAIL(readDoubleBE, v4.max); /*0.5*/
             }
         }
-        else if (parser == "brigadier:integer") { /*8.0*/
+        else if (V_parser == "brigadier:integer") { /*8.0*/
              v2.properties_brigadier_integer = {}; pdef::pc1_18_status_toClient::command_node::ExtraNodeData2::PropertiesBrigadierInteger &v4 = *v2.properties_brigadier_integer; /*8.4*/
             uint8_t flags_val;
             READ_OR_BAIL(readUByte, flags_val);
             v4.flags.unused = flags_val >> 0 & 6;
             v4.flags.max_present = flags_val >> 6 & 1;
             v4.flags.min_present = flags_val >> 7 & 1; /*flags: bitfield*/ /*4.3*/
-            pdef::pc1_18_status_toClient::command_node::ExtraNodeData2::PropertiesBrigadierInteger::flags_t &flags = v4.flags; /*4.8*/
-            if (flags.min_present == 1) { /*8.2*/
+            pdef::pc1_18_status_toClient::command_node::ExtraNodeData2::PropertiesBrigadierInteger::flags_t &V_flags = v4.flags; /*4.8*/
+            if (V_flags.min_present == 1) { /*8.2*/
               READ_OR_BAIL(readIntBE, v4.min); /*0.5*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               READ_OR_BAIL(readIntBE, v4.max); /*0.5*/
             }
         }
-        else if (parser == "brigadier:long") { /*8.0*/
+        else if (V_parser == "brigadier:long") { /*8.0*/
              v2.properties_brigadier_long = {}; pdef::pc1_18_status_toClient::command_node::ExtraNodeData2::PropertiesBrigadierLong &v4 = *v2.properties_brigadier_long; /*8.4*/
             uint8_t flags_val;
             READ_OR_BAIL(readUByte, flags_val);
             v4.flags.unused = flags_val >> 0 & 6;
             v4.flags.max_present = flags_val >> 6 & 1;
             v4.flags.min_present = flags_val >> 7 & 1; /*flags: bitfield*/ /*4.3*/
-            pdef::pc1_18_status_toClient::command_node::ExtraNodeData2::PropertiesBrigadierLong::flags_t &flags = v4.flags; /*4.8*/
-            if (flags.min_present == 1) { /*8.2*/
+            pdef::pc1_18_status_toClient::command_node::ExtraNodeData2::PropertiesBrigadierLong::flags_t &V_flags = v4.flags; /*4.8*/
+            if (V_flags.min_present == 1) { /*8.2*/
               READ_OR_BAIL(readLongBE, v4.min); /*0.5*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               READ_OR_BAIL(readLongBE, v4.max); /*0.5*/
             }
         }
-        else if (parser == "brigadier:string") { /*8.0*/
+        else if (V_parser == "brigadier:string") { /*8.0*/
         }
-        else if (parser == "minecraft:entity") { /*8.0*/
+        else if (V_parser == "minecraft:entity") { /*8.0*/
           uint8_t properties_minecraft_entity_val;
           READ_OR_BAIL(readUByte, properties_minecraft_entity_val);
           v2.properties_minecraft_entity.unused = properties_minecraft_entity_val >> 0 & 6;
           v2.properties_minecraft_entity.onlyAllowPlayers = properties_minecraft_entity_val >> 6 & 1;
           v2.properties_minecraft_entity.onlyAllowEntities = properties_minecraft_entity_val >> 7 & 1; /*properties_minecraft_entity: bitfield*/ /*4.3*/
         }
-        else if (parser == "minecraft:game_profile") { /*8.0*/
+        else if (V_parser == "minecraft:game_profile") { /*8.0*/
         }
-        else if (parser == "minecraft:block_pos") { /*8.0*/
+        else if (V_parser == "minecraft:block_pos") { /*8.0*/
         }
-        else if (parser == "minecraft:column_pos") { /*8.0*/
+        else if (V_parser == "minecraft:column_pos") { /*8.0*/
         }
-        else if (parser == "minecraft:vec3") { /*8.0*/
+        else if (V_parser == "minecraft:vec3") { /*8.0*/
         }
-        else if (parser == "minecraft:vec2") { /*8.0*/
+        else if (V_parser == "minecraft:vec2") { /*8.0*/
         }
-        else if (parser == "minecraft:block_state") { /*8.0*/
+        else if (V_parser == "minecraft:block_state") { /*8.0*/
         }
-        else if (parser == "minecraft:block_predicate") { /*8.0*/
+        else if (V_parser == "minecraft:block_predicate") { /*8.0*/
         }
-        else if (parser == "minecraft:item_stack") { /*8.0*/
+        else if (V_parser == "minecraft:item_stack") { /*8.0*/
         }
-        else if (parser == "minecraft:item_predicate") { /*8.0*/
+        else if (V_parser == "minecraft:item_predicate") { /*8.0*/
         }
-        else if (parser == "minecraft:color") { /*8.0*/
+        else if (V_parser == "minecraft:color") { /*8.0*/
         }
-        else if (parser == "minecraft:component") { /*8.0*/
+        else if (V_parser == "minecraft:component") { /*8.0*/
         }
-        else if (parser == "minecraft:message") { /*8.0*/
+        else if (V_parser == "minecraft:message") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt") { /*8.0*/
+        else if (V_parser == "minecraft:nbt") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt_path") { /*8.0*/
+        else if (V_parser == "minecraft:nbt_path") { /*8.0*/
         }
-        else if (parser == "minecraft:objective") { /*8.0*/
+        else if (V_parser == "minecraft:objective") { /*8.0*/
         }
-        else if (parser == "minecraft:objective_criteria") { /*8.0*/
+        else if (V_parser == "minecraft:objective_criteria") { /*8.0*/
         }
-        else if (parser == "minecraft:operation") { /*8.0*/
+        else if (V_parser == "minecraft:operation") { /*8.0*/
         }
-        else if (parser == "minecraft:particle") { /*8.0*/
+        else if (V_parser == "minecraft:particle") { /*8.0*/
         }
-        else if (parser == "minecraft:angle") { /*8.0*/
+        else if (V_parser == "minecraft:angle") { /*8.0*/
         }
-        else if (parser == "minecraft:rotation") { /*8.0*/
+        else if (V_parser == "minecraft:rotation") { /*8.0*/
         }
-        else if (parser == "minecraft:scoreboard_slot") { /*8.0*/
+        else if (V_parser == "minecraft:scoreboard_slot") { /*8.0*/
         }
-        else if (parser == "minecraft:score_holder") { /*8.0*/
+        else if (V_parser == "minecraft:score_holder") { /*8.0*/
           uint8_t properties_minecraft_score_holder_val;
           READ_OR_BAIL(readUByte, properties_minecraft_score_holder_val);
           v2.properties_minecraft_score_holder.unused = properties_minecraft_score_holder_val >> 0 & 7;
           v2.properties_minecraft_score_holder.allowMultiple = properties_minecraft_score_holder_val >> 7 & 1; /*properties_minecraft_score_holder: bitfield*/ /*4.3*/
         }
-        else if (parser == "minecraft:swizzle") { /*8.0*/
+        else if (V_parser == "minecraft:swizzle") { /*8.0*/
         }
-        else if (parser == "minecraft:team") { /*8.0*/
+        else if (V_parser == "minecraft:team") { /*8.0*/
         }
-        else if (parser == "minecraft:item_slot") { /*8.0*/
+        else if (V_parser == "minecraft:item_slot") { /*8.0*/
         }
-        else if (parser == "minecraft:resource_location") { /*8.0*/
+        else if (V_parser == "minecraft:resource_location") { /*8.0*/
         }
-        else if (parser == "minecraft:mob_effect") { /*8.0*/
+        else if (V_parser == "minecraft:mob_effect") { /*8.0*/
         }
-        else if (parser == "minecraft:function") { /*8.0*/
+        else if (V_parser == "minecraft:function") { /*8.0*/
         }
-        else if (parser == "minecraft:entity_anchor") { /*8.0*/
+        else if (V_parser == "minecraft:entity_anchor") { /*8.0*/
         }
-        else if (parser == "minecraft:range") { /*8.0*/
+        else if (V_parser == "minecraft:range") { /*8.0*/
              v2.properties_minecraft_range = {}; pdef::pc1_18_status_toClient::command_node::ExtraNodeData2::PropertiesMinecraftRange &v4 = *v2.properties_minecraft_range; /*8.4*/
             READ_OR_BAIL(readBool, (bool&)v4.allowDecimals); /*0.5*/
         }
-        else if (parser == "minecraft:int_range") { /*8.0*/
+        else if (V_parser == "minecraft:int_range") { /*8.0*/
         }
-        else if (parser == "minecraft:float_range") { /*8.0*/
+        else if (V_parser == "minecraft:float_range") { /*8.0*/
         }
-        else if (parser == "minecraft:item_enchantment") { /*8.0*/
+        else if (V_parser == "minecraft:item_enchantment") { /*8.0*/
         }
-        else if (parser == "minecraft:entity_summon") { /*8.0*/
+        else if (V_parser == "minecraft:entity_summon") { /*8.0*/
         }
-        else if (parser == "minecraft:dimension") { /*8.0*/
+        else if (V_parser == "minecraft:dimension") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt_compound_tag") { /*8.0*/
+        else if (V_parser == "minecraft:nbt_compound_tag") { /*8.0*/
         }
-        else if (parser == "minecraft:time") { /*8.0*/
+        else if (V_parser == "minecraft:time") { /*8.0*/
         }
-        else if (parser == "minecraft:resource_or_tag") { /*8.0*/
+        else if (V_parser == "minecraft:resource_or_tag") { /*8.0*/
              v2.properties_minecraft_resource_or_tag_or_minecraft_resource = {}; pdef::pc1_18_status_toClient::command_node::ExtraNodeData2::PropertiesMinecraftResourceOrTagOrMinecraftResource &v4 = *v2.properties_minecraft_resource_or_tag_or_minecraft_resource; /*8.4*/
             int registry_strlen; READ_OR_BAIL(readUnsignedVarInt, registry_strlen);
             if (!stream.readString(v4.registry, registry_strlen)) return false; /*registry: pstring*/ /*4.3*/
         }
-        else if (parser == "minecraft:resource") { /*8.0*/
+        else if (V_parser == "minecraft:resource") { /*8.0*/
              v2.properties_minecraft_resource_or_tag_or_minecraft_resource = {}; pdef::pc1_18_status_toClient::command_node::ExtraNodeData2::PropertiesMinecraftResourceOrTagOrMinecraftResource &v4 = *v2.properties_minecraft_resource_or_tag_or_minecraft_resource; /*8.4*/
             int registry_strlen; READ_OR_BAIL(readUnsignedVarInt, registry_strlen);
             if (!stream.readString(v4.registry, registry_strlen)) return false; /*registry: pstring*/ /*4.3*/
         }
-        else if (parser == "minecraft:uuid") { /*8.0*/
+        else if (V_parser == "minecraft:uuid") { /*8.0*/
         }
-        if (flags.has_custom_suggestions == 1) { /*8.2*/
+        if (V_flags.has_custom_suggestions == 1) { /*8.2*/
           int suggestionType_strlen; READ_OR_BAIL(readUnsignedVarInt, suggestionType_strlen);
           if (!stream.readString(v2.suggestionType, suggestionType_strlen)) return false; /*suggestionType: pstring*/ /*4.3*/
         }
@@ -1219,8 +1219,8 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_status_toClient::tags &obj) {
   }
   bool packet(pdef::Stream &stream, pdef::pc1_18_status_toClient::packet &obj) {
     READ_OR_BAIL(readUnsignedVarInt, (int&)obj.name); /*7.2*/
-    const pdef::pc1_18_status_toClient::packet::Name &name = obj.name; /*0.7*/
-    switch (name) { /*8.0*/
+    const pdef::pc1_18_status_toClient::packet::Name &V_name = obj.name; /*0.7*/
+    switch (V_name) { /*8.0*/
       case pdef::pc1_18_status_toClient::packet::Name::ServerInfo: { /*8.5*/
         obj.params_packet_server_info = {}; pdef::pc1_18_status_toClient::decode::packet_server_info(stream, *obj.params_packet_server_info); /*obj*/ /*4.6*/
         break;

--- a/examples/mcpc-protocol/build/pc1_18_status_toServer.h
+++ b/examples/mcpc-protocol/build/pc1_18_status_toServer.h
@@ -244,10 +244,10 @@ size_t packet_ping(pdef::Stream &stream, const pdef::pc1_18_status_toServer::pac
 size_t packet(pdef::Stream &stream, const pdef::pc1_18_status_toServer::packet &obj);
   size_t slot(pdef::Stream &stream, const pdef::pc1_18_status_toServer::slot &obj) {
     size_t len = 0;
-    const bool &present = obj.present; /*0.1*/
-    if (present == false) { /*8.1*/
+    const bool &V_present = obj.present; /*0.1*/
+    if (V_present == false) { /*8.1*/
     }
-    else if (present == true) { /*8.1*/
+    else if (V_present == true) { /*8.1*/
         len += stream.sizeOfVarInt(obj.itemId); /*0.2*/
         len += 1; /*0.2*/
         len += 1; /*0.2*/
@@ -256,23 +256,23 @@ size_t packet(pdef::Stream &stream, const pdef::pc1_18_status_toServer::packet &
   }
   size_t particle(pdef::Stream &stream, const pdef::pc1_18_status_toServer::particle &obj) {
     size_t len = 0;
-    const int &particleId = obj.particleId; /*0.1*/
-    if (particleId == 2) { /*8.2*/
+    const int &V_particleId = obj.particleId; /*0.1*/
+    if (V_particleId == 2) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_2_or_3_or_24); const pdef::pc1_18_status_toServer::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.6*/
         len += stream.sizeOfVarInt(v2.blockState); /*0.2*/
     }
-    else if (particleId == 3) { /*8.2*/
+    else if (V_particleId == 3) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_2_or_3_or_24); const pdef::pc1_18_status_toServer::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.6*/
         len += stream.sizeOfVarInt(v2.blockState); /*0.2*/
     }
-    else if (particleId == 14) { /*8.2*/
+    else if (V_particleId == 14) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_14); const pdef::pc1_18_status_toServer::particle::Data14 &v2 = *obj.data_14; /*8.6*/
         len += 4; /*0.2*/
         len += 4; /*0.2*/
         len += 4; /*0.2*/
         len += 4; /*0.2*/
     }
-    else if (particleId == 15) { /*8.2*/
+    else if (V_particleId == 15) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_15); const pdef::pc1_18_status_toServer::particle::Data15 &v2 = *obj.data_15; /*8.6*/
         len += 4; /*0.2*/
         len += 4; /*0.2*/
@@ -282,24 +282,24 @@ size_t packet(pdef::Stream &stream, const pdef::pc1_18_status_toServer::packet &
         len += 4; /*0.2*/
         len += 4; /*0.2*/
     }
-    else if (particleId == 24) { /*8.2*/
+    else if (V_particleId == 24) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_2_or_3_or_24); const pdef::pc1_18_status_toServer::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.6*/
         len += stream.sizeOfVarInt(v2.blockState); /*0.2*/
     }
-    else if (particleId == 35) { /*8.2*/
+    else if (V_particleId == 35) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_35); const pdef::pc1_18_status_toServer::particle::Data35 &v2 = *obj.data_35; /*8.6*/
         len += 1; /*0.2*/
     }
-    else if (particleId == 36) { /*8.2*/
+    else if (V_particleId == 36) { /*8.2*/
         EXPECT_OR_BAIL(obj.data_36); const pdef::pc1_18_status_toServer::particle::Data36 &v2 = *obj.data_36; /*8.6*/
         len += 1; /*origin: bitfield*/ /*4.1*/
         len += stream.sizeOfVarInt(v2.positionType.length());
         len += v2.positionType.length(); /*positionType^: pstring*/ /*4.1*/
-        const std::string &positionType = v2.positionType; /*4.7*/
-        if (positionType == "minecraft:block") { /*8.0*/
+        const std::string &V_positionType = v2.positionType; /*4.7*/
+        if (V_positionType == "minecraft:block") { /*8.0*/
           len += 1; /*destination: bitfield*/ /*4.1*/
         }
-        else if (positionType == "minecraft:entity") { /*8.0*/
+        else if (V_positionType == "minecraft:entity") { /*8.0*/
           len += stream.sizeOfVarInt(v2.destination_varint); /*0.2*/
         }
         len += stream.sizeOfVarInt(v2.ticks); /*0.2*/
@@ -311,7 +311,7 @@ size_t packet(pdef::Stream &stream, const pdef::pc1_18_status_toServer::packet &
     len += stream.sizeOfVarInt(obj.group.length());
     len += obj.group.length(); /*group: pstring*/ /*4.1*/
     len += stream.sizeOfVarInt(obj.ingredient.size()); /*1.3*/
-    for (const auto &v2 : obj.ingredient) {
+    for (const auto &v2 : obj.ingredient) { /*3.2*/
       len += 1; /*0.2*/
     }
     len += 1; /*0.2*/
@@ -324,7 +324,7 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_status_toServer::tags &obj)
     len += stream.sizeOfVarInt(obj.tagName.length());
     len += obj.tagName.length(); /*tagName: pstring*/ /*4.1*/
     len += stream.sizeOfVarInt(obj.entries.size()); /*1.3*/
-    for (const auto &v2 : obj.entries) {
+    for (const auto &v2 : obj.entries) { /*3.2*/
       len += stream.sizeOfVarInt(v2); /*0.2*/
     }
   PDEF_SIZE_DBG; return len;
@@ -340,169 +340,169 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_status_toServer::tags &obj)
   size_t command_node(pdef::Stream &stream, const pdef::pc1_18_status_toServer::command_node &obj) {
     size_t len = 0;
     len += 1; /*flags^: bitfield*/ /*4.1*/
-    const pdef::pc1_18_status_toServer::command_node::flags_t &flags = obj.flags; /*4.7*/
+    const pdef::pc1_18_status_toServer::command_node::flags_t &V_flags = obj.flags; /*4.7*/
     len += stream.sizeOfVarInt(obj.children.size()); /*1.3*/
-    for (const auto &v2 : obj.children) {
+    for (const auto &v2 : obj.children) { /*3.2*/
       len += stream.sizeOfVarInt(v2); /*0.2*/
     }
-    if (flags.has_redirect_node == 1) { /*8.2*/
+    if (V_flags.has_redirect_node == 1) { /*8.2*/
       len += stream.sizeOfVarInt(obj.redirectNode); /*0.2*/
     }
-    if (flags.command_node_type == 0) { /*8.2*/
+    if (V_flags.command_node_type == 0) { /*8.2*/
     }
-    else if (flags.command_node_type == 1) { /*8.2*/
+    else if (V_flags.command_node_type == 1) { /*8.2*/
         EXPECT_OR_BAIL(obj.extraNodeData_1); const pdef::pc1_18_status_toServer::command_node::ExtraNodeData1 &v2 = *obj.extraNodeData_1; /*8.6*/
         len += stream.sizeOfVarInt(v2.name.length());
         len += v2.name.length(); /*name: pstring*/ /*4.1*/
     }
-    else if (flags.command_node_type == 2) { /*8.2*/
+    else if (V_flags.command_node_type == 2) { /*8.2*/
         EXPECT_OR_BAIL(obj.extraNodeData_2); const pdef::pc1_18_status_toServer::command_node::ExtraNodeData2 &v2 = *obj.extraNodeData_2; /*8.6*/
         len += stream.sizeOfVarInt(v2.name.length());
         len += v2.name.length(); /*name: pstring*/ /*4.1*/
         len += stream.sizeOfVarInt(v2.parser.length());
         len += v2.parser.length(); /*parser^: pstring*/ /*4.1*/
-        const std::string &parser = v2.parser; /*4.7*/
-        if (parser == "brigadier:bool") { /*8.0*/
+        const std::string &V_parser = v2.parser; /*4.7*/
+        if (V_parser == "brigadier:bool") { /*8.0*/
         }
-        else if (parser == "brigadier:float") { /*8.0*/
+        else if (V_parser == "brigadier:float") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_brigadier_float); const pdef::pc1_18_status_toServer::command_node::ExtraNodeData2::PropertiesBrigadierFloat &v4 = *v2.properties_brigadier_float; /*8.6*/
             len += 1; /*flags^: bitfield*/ /*4.1*/
-            const pdef::pc1_18_status_toServer::command_node::ExtraNodeData2::PropertiesBrigadierFloat::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_status_toServer::command_node::ExtraNodeData2::PropertiesBrigadierFloat::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               len += 4; /*0.2*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               len += 4; /*0.2*/
             }
         }
-        else if (parser == "brigadier:double") { /*8.0*/
+        else if (V_parser == "brigadier:double") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_brigadier_double); const pdef::pc1_18_status_toServer::command_node::ExtraNodeData2::PropertiesBrigadierDouble &v4 = *v2.properties_brigadier_double; /*8.6*/
             len += 1; /*flags^: bitfield*/ /*4.1*/
-            const pdef::pc1_18_status_toServer::command_node::ExtraNodeData2::PropertiesBrigadierDouble::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_status_toServer::command_node::ExtraNodeData2::PropertiesBrigadierDouble::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               len += 8; /*0.2*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               len += 8; /*0.2*/
             }
         }
-        else if (parser == "brigadier:integer") { /*8.0*/
+        else if (V_parser == "brigadier:integer") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_brigadier_integer); const pdef::pc1_18_status_toServer::command_node::ExtraNodeData2::PropertiesBrigadierInteger &v4 = *v2.properties_brigadier_integer; /*8.6*/
             len += 1; /*flags^: bitfield*/ /*4.1*/
-            const pdef::pc1_18_status_toServer::command_node::ExtraNodeData2::PropertiesBrigadierInteger::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_status_toServer::command_node::ExtraNodeData2::PropertiesBrigadierInteger::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               len += 4; /*0.2*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               len += 4; /*0.2*/
             }
         }
-        else if (parser == "brigadier:long") { /*8.0*/
+        else if (V_parser == "brigadier:long") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_brigadier_long); const pdef::pc1_18_status_toServer::command_node::ExtraNodeData2::PropertiesBrigadierLong &v4 = *v2.properties_brigadier_long; /*8.6*/
             len += 1; /*flags^: bitfield*/ /*4.1*/
-            const pdef::pc1_18_status_toServer::command_node::ExtraNodeData2::PropertiesBrigadierLong::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_status_toServer::command_node::ExtraNodeData2::PropertiesBrigadierLong::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               len += 8; /*0.2*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               len += 8; /*0.2*/
             }
         }
-        else if (parser == "brigadier:string") { /*8.0*/
+        else if (V_parser == "brigadier:string") { /*8.0*/
         }
-        else if (parser == "minecraft:entity") { /*8.0*/
+        else if (V_parser == "minecraft:entity") { /*8.0*/
           len += 1; /*properties: bitfield*/ /*4.1*/
         }
-        else if (parser == "minecraft:game_profile") { /*8.0*/
+        else if (V_parser == "minecraft:game_profile") { /*8.0*/
         }
-        else if (parser == "minecraft:block_pos") { /*8.0*/
+        else if (V_parser == "minecraft:block_pos") { /*8.0*/
         }
-        else if (parser == "minecraft:column_pos") { /*8.0*/
+        else if (V_parser == "minecraft:column_pos") { /*8.0*/
         }
-        else if (parser == "minecraft:vec3") { /*8.0*/
+        else if (V_parser == "minecraft:vec3") { /*8.0*/
         }
-        else if (parser == "minecraft:vec2") { /*8.0*/
+        else if (V_parser == "minecraft:vec2") { /*8.0*/
         }
-        else if (parser == "minecraft:block_state") { /*8.0*/
+        else if (V_parser == "minecraft:block_state") { /*8.0*/
         }
-        else if (parser == "minecraft:block_predicate") { /*8.0*/
+        else if (V_parser == "minecraft:block_predicate") { /*8.0*/
         }
-        else if (parser == "minecraft:item_stack") { /*8.0*/
+        else if (V_parser == "minecraft:item_stack") { /*8.0*/
         }
-        else if (parser == "minecraft:item_predicate") { /*8.0*/
+        else if (V_parser == "minecraft:item_predicate") { /*8.0*/
         }
-        else if (parser == "minecraft:color") { /*8.0*/
+        else if (V_parser == "minecraft:color") { /*8.0*/
         }
-        else if (parser == "minecraft:component") { /*8.0*/
+        else if (V_parser == "minecraft:component") { /*8.0*/
         }
-        else if (parser == "minecraft:message") { /*8.0*/
+        else if (V_parser == "minecraft:message") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt") { /*8.0*/
+        else if (V_parser == "minecraft:nbt") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt_path") { /*8.0*/
+        else if (V_parser == "minecraft:nbt_path") { /*8.0*/
         }
-        else if (parser == "minecraft:objective") { /*8.0*/
+        else if (V_parser == "minecraft:objective") { /*8.0*/
         }
-        else if (parser == "minecraft:objective_criteria") { /*8.0*/
+        else if (V_parser == "minecraft:objective_criteria") { /*8.0*/
         }
-        else if (parser == "minecraft:operation") { /*8.0*/
+        else if (V_parser == "minecraft:operation") { /*8.0*/
         }
-        else if (parser == "minecraft:particle") { /*8.0*/
+        else if (V_parser == "minecraft:particle") { /*8.0*/
         }
-        else if (parser == "minecraft:angle") { /*8.0*/
+        else if (V_parser == "minecraft:angle") { /*8.0*/
         }
-        else if (parser == "minecraft:rotation") { /*8.0*/
+        else if (V_parser == "minecraft:rotation") { /*8.0*/
         }
-        else if (parser == "minecraft:scoreboard_slot") { /*8.0*/
+        else if (V_parser == "minecraft:scoreboard_slot") { /*8.0*/
         }
-        else if (parser == "minecraft:score_holder") { /*8.0*/
+        else if (V_parser == "minecraft:score_holder") { /*8.0*/
           len += 1; /*properties: bitfield*/ /*4.1*/
         }
-        else if (parser == "minecraft:swizzle") { /*8.0*/
+        else if (V_parser == "minecraft:swizzle") { /*8.0*/
         }
-        else if (parser == "minecraft:team") { /*8.0*/
+        else if (V_parser == "minecraft:team") { /*8.0*/
         }
-        else if (parser == "minecraft:item_slot") { /*8.0*/
+        else if (V_parser == "minecraft:item_slot") { /*8.0*/
         }
-        else if (parser == "minecraft:resource_location") { /*8.0*/
+        else if (V_parser == "minecraft:resource_location") { /*8.0*/
         }
-        else if (parser == "minecraft:mob_effect") { /*8.0*/
+        else if (V_parser == "minecraft:mob_effect") { /*8.0*/
         }
-        else if (parser == "minecraft:function") { /*8.0*/
+        else if (V_parser == "minecraft:function") { /*8.0*/
         }
-        else if (parser == "minecraft:entity_anchor") { /*8.0*/
+        else if (V_parser == "minecraft:entity_anchor") { /*8.0*/
         }
-        else if (parser == "minecraft:range") { /*8.0*/
+        else if (V_parser == "minecraft:range") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_minecraft_range); const pdef::pc1_18_status_toServer::command_node::ExtraNodeData2::PropertiesMinecraftRange &v4 = *v2.properties_minecraft_range; /*8.6*/
             len += 1; /*0.2*/
         }
-        else if (parser == "minecraft:int_range") { /*8.0*/
+        else if (V_parser == "minecraft:int_range") { /*8.0*/
         }
-        else if (parser == "minecraft:float_range") { /*8.0*/
+        else if (V_parser == "minecraft:float_range") { /*8.0*/
         }
-        else if (parser == "minecraft:item_enchantment") { /*8.0*/
+        else if (V_parser == "minecraft:item_enchantment") { /*8.0*/
         }
-        else if (parser == "minecraft:entity_summon") { /*8.0*/
+        else if (V_parser == "minecraft:entity_summon") { /*8.0*/
         }
-        else if (parser == "minecraft:dimension") { /*8.0*/
+        else if (V_parser == "minecraft:dimension") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt_compound_tag") { /*8.0*/
+        else if (V_parser == "minecraft:nbt_compound_tag") { /*8.0*/
         }
-        else if (parser == "minecraft:time") { /*8.0*/
+        else if (V_parser == "minecraft:time") { /*8.0*/
         }
-        else if (parser == "minecraft:resource_or_tag") { /*8.0*/
+        else if (V_parser == "minecraft:resource_or_tag") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_minecraft_resource_or_tag_or_minecraft_resource); const pdef::pc1_18_status_toServer::command_node::ExtraNodeData2::PropertiesMinecraftResourceOrTagOrMinecraftResource &v4 = *v2.properties_minecraft_resource_or_tag_or_minecraft_resource; /*8.6*/
             len += stream.sizeOfVarInt(v4.registry.length());
             len += v4.registry.length(); /*registry: pstring*/ /*4.1*/
         }
-        else if (parser == "minecraft:resource") { /*8.0*/
+        else if (V_parser == "minecraft:resource") { /*8.0*/
             EXPECT_OR_BAIL(v2.properties_minecraft_resource_or_tag_or_minecraft_resource); const pdef::pc1_18_status_toServer::command_node::ExtraNodeData2::PropertiesMinecraftResourceOrTagOrMinecraftResource &v4 = *v2.properties_minecraft_resource_or_tag_or_minecraft_resource; /*8.6*/
             len += stream.sizeOfVarInt(v4.registry.length());
             len += v4.registry.length(); /*registry: pstring*/ /*4.1*/
         }
-        else if (parser == "minecraft:uuid") { /*8.0*/
+        else if (V_parser == "minecraft:uuid") { /*8.0*/
         }
-        if (flags.has_custom_suggestions == 1) { /*8.2*/
+        if (V_flags.has_custom_suggestions == 1) { /*8.2*/
           len += stream.sizeOfVarInt(v2.suggestionType.length());
           len += v2.suggestionType.length(); /*suggestionType: pstring*/ /*4.1*/
         }
@@ -520,9 +520,9 @@ size_t tags(pdef::Stream &stream, const pdef::pc1_18_status_toServer::tags &obj)
   }
   size_t packet(pdef::Stream &stream, const pdef::pc1_18_status_toServer::packet &obj) {
     size_t len = 0;
-    const pdef::pc1_18_status_toServer::packet::Name &name = obj.name; /*0.3*/
+    const pdef::pc1_18_status_toServer::packet::Name &V_name = obj.name; /*0.3*/
     len += stream.sizeOfVarInt((int&)obj.name); /*name^: varint*/ /*7.0*/
-    switch (name) { /*8.0*/
+    switch (V_name) { /*8.0*/
       case pdef::pc1_18_status_toServer::packet::Name::PingStart: { /*8.5*/
         EXPECT_OR_BAIL(obj.params_packet_ping_start); size_t len_0 = pdef::pc1_18_status_toServer::size::packet_ping_start(stream, *obj.params_packet_ping_start); EXPECT_OR_BAIL(len_0); len += len_0; /*params_packet_ping_start*/ /*4.4*/
         break;
@@ -549,11 +549,11 @@ bool packet_ping(pdef::Stream &stream, const pdef::pc1_18_status_toServer::packe
 bool packet(pdef::Stream &stream, const pdef::pc1_18_status_toServer::packet &obj, bool allocate);
   bool slot(pdef::Stream &stream, const pdef::pc1_18_status_toServer::slot &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::pc1_18_status_toServer::size::slot(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const bool &present = obj.present; /*0.1*/
+    const bool &V_present = obj.present; /*0.1*/
     WRITE_OR_BAIL(writeBool, (bool)obj.present); /*0.4*/
-    if (present == false) { /*8.1*/
+    if (V_present == false) { /*8.1*/
     }
-    else if (present == true) { /*8.1*/
+    else if (V_present == true) { /*8.1*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.itemId); /*0.4*/
         WRITE_OR_BAIL(writeByte, (int8_t)obj.itemCount); /*0.4*/
         WRITE_OR_BAIL(writeByte, (int8_t)obj.nbtData); /*0.4*/
@@ -562,24 +562,24 @@ bool packet(pdef::Stream &stream, const pdef::pc1_18_status_toServer::packet &ob
   }
   bool particle(pdef::Stream &stream, const pdef::pc1_18_status_toServer::particle &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::pc1_18_status_toServer::size::particle(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const int &particleId = obj.particleId; /*0.1*/
+    const int &V_particleId = obj.particleId; /*0.1*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.particleId); /*0.4*/
-    if (particleId == 2) { /*8.2*/
+    if (V_particleId == 2) { /*8.2*/
         const pdef::pc1_18_status_toServer::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.5*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.blockState); /*0.4*/
     }
-    else if (particleId == 3) { /*8.2*/
+    else if (V_particleId == 3) { /*8.2*/
         const pdef::pc1_18_status_toServer::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.5*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.blockState); /*0.4*/
     }
-    else if (particleId == 14) { /*8.2*/
+    else if (V_particleId == 14) { /*8.2*/
         const pdef::pc1_18_status_toServer::particle::Data14 &v2 = *obj.data_14; /*8.5*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.red); /*0.4*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.green); /*0.4*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.blue); /*0.4*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.scale); /*0.4*/
     }
-    else if (particleId == 15) { /*8.2*/
+    else if (V_particleId == 15) { /*8.2*/
         const pdef::pc1_18_status_toServer::particle::Data15 &v2 = *obj.data_15; /*8.5*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.fromRed); /*0.4*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.fromGreen); /*0.4*/
@@ -589,15 +589,15 @@ bool packet(pdef::Stream &stream, const pdef::pc1_18_status_toServer::packet &ob
         WRITE_OR_BAIL(writeFloatBE, (float)v2.toGreen); /*0.4*/
         WRITE_OR_BAIL(writeFloatBE, (float)v2.toBlue); /*0.4*/
     }
-    else if (particleId == 24) { /*8.2*/
+    else if (V_particleId == 24) { /*8.2*/
         const pdef::pc1_18_status_toServer::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.5*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.blockState); /*0.4*/
     }
-    else if (particleId == 35) { /*8.2*/
+    else if (V_particleId == 35) { /*8.2*/
         const pdef::pc1_18_status_toServer::particle::Data35 &v2 = *obj.data_35; /*8.5*/
         WRITE_OR_BAIL(writeByte, (int8_t)v2.item); /*0.4*/
     }
-    else if (particleId == 36) { /*8.2*/
+    else if (V_particleId == 36) { /*8.2*/
         const pdef::pc1_18_status_toServer::particle::Data36 &v2 = *obj.data_36; /*8.5*/
         uint64_t origin_val = 0;
         origin_val |= (uint64_t)v2.origin.x << 0;
@@ -606,15 +606,15 @@ bool packet(pdef::Stream &stream, const pdef::pc1_18_status_toServer::packet &ob
         WRITE_OR_BAIL(writeULongBE, origin_val); /*origin: bitfield*/ /*4.2*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.positionType.length());
         WRITE_OR_BAIL(writeString, v2.positionType); /*positionType: pstring*/ /*4.2*/
-        const std::string &positionType = v2.positionType; /*4.7*/
-        if (positionType == "minecraft:block") { /*8.0*/
+        const std::string &V_positionType = v2.positionType; /*4.7*/
+        if (V_positionType == "minecraft:block") { /*8.0*/
           uint64_t destination_position_val = 0;
           destination_position_val |= (uint64_t)v2.destination_position.x << 0;
           destination_position_val |= (uint64_t)v2.destination_position.z << 26;
           destination_position_val |= (uint64_t)v2.destination_position.y << 52;
           WRITE_OR_BAIL(writeULongBE, destination_position_val); /*destination_position: bitfield*/ /*4.2*/
         }
-        else if (positionType == "minecraft:entity") { /*8.0*/
+        else if (V_positionType == "minecraft:entity") { /*8.0*/
           WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.destination_varint); /*0.4*/
         }
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.ticks); /*0.4*/
@@ -664,192 +664,192 @@ bool tags(pdef::Stream &stream, const pdef::pc1_18_status_toServer::tags &obj, b
     flags_val |= (uint8_t)obj.flags.has_command << 5;
     flags_val |= (uint8_t)obj.flags.command_node_type << 6;
     WRITE_OR_BAIL(writeUByte, flags_val); /*flags: bitfield*/ /*4.2*/
-    const pdef::pc1_18_status_toServer::command_node::flags_t &flags = obj.flags; /*4.7*/
+    const pdef::pc1_18_status_toServer::command_node::flags_t &V_flags = obj.flags; /*4.7*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.children.size()); /*1.4*/
     for (const auto &v2 : obj.children) { /*3.1*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2); /*0.4*/
     }
-    if (flags.has_redirect_node == 1) { /*8.2*/
+    if (V_flags.has_redirect_node == 1) { /*8.2*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.redirectNode); /*0.4*/
     }
-    if (flags.command_node_type == 0) { /*8.2*/
+    if (V_flags.command_node_type == 0) { /*8.2*/
     }
-    else if (flags.command_node_type == 1) { /*8.2*/
+    else if (V_flags.command_node_type == 1) { /*8.2*/
         const pdef::pc1_18_status_toServer::command_node::ExtraNodeData1 &v2 = *obj.extraNodeData_1; /*8.5*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.name.length());
         WRITE_OR_BAIL(writeString, v2.name); /*name: pstring*/ /*4.2*/
     }
-    else if (flags.command_node_type == 2) { /*8.2*/
+    else if (V_flags.command_node_type == 2) { /*8.2*/
         const pdef::pc1_18_status_toServer::command_node::ExtraNodeData2 &v2 = *obj.extraNodeData_2; /*8.5*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.name.length());
         WRITE_OR_BAIL(writeString, v2.name); /*name: pstring*/ /*4.2*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.parser.length());
         WRITE_OR_BAIL(writeString, v2.parser); /*parser: pstring*/ /*4.2*/
-        const std::string &parser = v2.parser; /*4.7*/
-        if (parser == "brigadier:bool") { /*8.0*/
+        const std::string &V_parser = v2.parser; /*4.7*/
+        if (V_parser == "brigadier:bool") { /*8.0*/
         }
-        else if (parser == "brigadier:float") { /*8.0*/
+        else if (V_parser == "brigadier:float") { /*8.0*/
             const pdef::pc1_18_status_toServer::command_node::ExtraNodeData2::PropertiesBrigadierFloat &v4 = *v2.properties_brigadier_float; /*8.5*/
             uint8_t flags_val = 0;
             flags_val |= (uint8_t)v4.flags.unused << 0;
             flags_val |= (uint8_t)v4.flags.max_present << 6;
             flags_val |= (uint8_t)v4.flags.min_present << 7;
             WRITE_OR_BAIL(writeUByte, flags_val); /*flags: bitfield*/ /*4.2*/
-            const pdef::pc1_18_status_toServer::command_node::ExtraNodeData2::PropertiesBrigadierFloat::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_status_toServer::command_node::ExtraNodeData2::PropertiesBrigadierFloat::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeFloatBE, (float)v4.min); /*0.4*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeFloatBE, (float)v4.max); /*0.4*/
             }
         }
-        else if (parser == "brigadier:double") { /*8.0*/
+        else if (V_parser == "brigadier:double") { /*8.0*/
             const pdef::pc1_18_status_toServer::command_node::ExtraNodeData2::PropertiesBrigadierDouble &v4 = *v2.properties_brigadier_double; /*8.5*/
             uint8_t flags_val = 0;
             flags_val |= (uint8_t)v4.flags.unused << 0;
             flags_val |= (uint8_t)v4.flags.max_present << 6;
             flags_val |= (uint8_t)v4.flags.min_present << 7;
             WRITE_OR_BAIL(writeUByte, flags_val); /*flags: bitfield*/ /*4.2*/
-            const pdef::pc1_18_status_toServer::command_node::ExtraNodeData2::PropertiesBrigadierDouble::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_status_toServer::command_node::ExtraNodeData2::PropertiesBrigadierDouble::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeDoubleBE, (double)v4.min); /*0.4*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeDoubleBE, (double)v4.max); /*0.4*/
             }
         }
-        else if (parser == "brigadier:integer") { /*8.0*/
+        else if (V_parser == "brigadier:integer") { /*8.0*/
             const pdef::pc1_18_status_toServer::command_node::ExtraNodeData2::PropertiesBrigadierInteger &v4 = *v2.properties_brigadier_integer; /*8.5*/
             uint8_t flags_val = 0;
             flags_val |= (uint8_t)v4.flags.unused << 0;
             flags_val |= (uint8_t)v4.flags.max_present << 6;
             flags_val |= (uint8_t)v4.flags.min_present << 7;
             WRITE_OR_BAIL(writeUByte, flags_val); /*flags: bitfield*/ /*4.2*/
-            const pdef::pc1_18_status_toServer::command_node::ExtraNodeData2::PropertiesBrigadierInteger::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_status_toServer::command_node::ExtraNodeData2::PropertiesBrigadierInteger::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeIntBE, (int32_t)v4.min); /*0.4*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeIntBE, (int32_t)v4.max); /*0.4*/
             }
         }
-        else if (parser == "brigadier:long") { /*8.0*/
+        else if (V_parser == "brigadier:long") { /*8.0*/
             const pdef::pc1_18_status_toServer::command_node::ExtraNodeData2::PropertiesBrigadierLong &v4 = *v2.properties_brigadier_long; /*8.5*/
             uint8_t flags_val = 0;
             flags_val |= (uint8_t)v4.flags.unused << 0;
             flags_val |= (uint8_t)v4.flags.max_present << 6;
             flags_val |= (uint8_t)v4.flags.min_present << 7;
             WRITE_OR_BAIL(writeUByte, flags_val); /*flags: bitfield*/ /*4.2*/
-            const pdef::pc1_18_status_toServer::command_node::ExtraNodeData2::PropertiesBrigadierLong::flags_t &flags = v4.flags; /*4.7*/
-            if (flags.min_present == 1) { /*8.2*/
+            const pdef::pc1_18_status_toServer::command_node::ExtraNodeData2::PropertiesBrigadierLong::flags_t &V_flags = v4.flags; /*4.7*/
+            if (V_flags.min_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeLongBE, (int64_t)v4.min); /*0.4*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               WRITE_OR_BAIL(writeLongBE, (int64_t)v4.max); /*0.4*/
             }
         }
-        else if (parser == "brigadier:string") { /*8.0*/
+        else if (V_parser == "brigadier:string") { /*8.0*/
         }
-        else if (parser == "minecraft:entity") { /*8.0*/
+        else if (V_parser == "minecraft:entity") { /*8.0*/
           uint8_t properties_minecraft_entity_val = 0;
           properties_minecraft_entity_val |= (uint8_t)v2.properties_minecraft_entity.unused << 0;
           properties_minecraft_entity_val |= (uint8_t)v2.properties_minecraft_entity.onlyAllowPlayers << 6;
           properties_minecraft_entity_val |= (uint8_t)v2.properties_minecraft_entity.onlyAllowEntities << 7;
           WRITE_OR_BAIL(writeUByte, properties_minecraft_entity_val); /*properties_minecraft_entity: bitfield*/ /*4.2*/
         }
-        else if (parser == "minecraft:game_profile") { /*8.0*/
+        else if (V_parser == "minecraft:game_profile") { /*8.0*/
         }
-        else if (parser == "minecraft:block_pos") { /*8.0*/
+        else if (V_parser == "minecraft:block_pos") { /*8.0*/
         }
-        else if (parser == "minecraft:column_pos") { /*8.0*/
+        else if (V_parser == "minecraft:column_pos") { /*8.0*/
         }
-        else if (parser == "minecraft:vec3") { /*8.0*/
+        else if (V_parser == "minecraft:vec3") { /*8.0*/
         }
-        else if (parser == "minecraft:vec2") { /*8.0*/
+        else if (V_parser == "minecraft:vec2") { /*8.0*/
         }
-        else if (parser == "minecraft:block_state") { /*8.0*/
+        else if (V_parser == "minecraft:block_state") { /*8.0*/
         }
-        else if (parser == "minecraft:block_predicate") { /*8.0*/
+        else if (V_parser == "minecraft:block_predicate") { /*8.0*/
         }
-        else if (parser == "minecraft:item_stack") { /*8.0*/
+        else if (V_parser == "minecraft:item_stack") { /*8.0*/
         }
-        else if (parser == "minecraft:item_predicate") { /*8.0*/
+        else if (V_parser == "minecraft:item_predicate") { /*8.0*/
         }
-        else if (parser == "minecraft:color") { /*8.0*/
+        else if (V_parser == "minecraft:color") { /*8.0*/
         }
-        else if (parser == "minecraft:component") { /*8.0*/
+        else if (V_parser == "minecraft:component") { /*8.0*/
         }
-        else if (parser == "minecraft:message") { /*8.0*/
+        else if (V_parser == "minecraft:message") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt") { /*8.0*/
+        else if (V_parser == "minecraft:nbt") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt_path") { /*8.0*/
+        else if (V_parser == "minecraft:nbt_path") { /*8.0*/
         }
-        else if (parser == "minecraft:objective") { /*8.0*/
+        else if (V_parser == "minecraft:objective") { /*8.0*/
         }
-        else if (parser == "minecraft:objective_criteria") { /*8.0*/
+        else if (V_parser == "minecraft:objective_criteria") { /*8.0*/
         }
-        else if (parser == "minecraft:operation") { /*8.0*/
+        else if (V_parser == "minecraft:operation") { /*8.0*/
         }
-        else if (parser == "minecraft:particle") { /*8.0*/
+        else if (V_parser == "minecraft:particle") { /*8.0*/
         }
-        else if (parser == "minecraft:angle") { /*8.0*/
+        else if (V_parser == "minecraft:angle") { /*8.0*/
         }
-        else if (parser == "minecraft:rotation") { /*8.0*/
+        else if (V_parser == "minecraft:rotation") { /*8.0*/
         }
-        else if (parser == "minecraft:scoreboard_slot") { /*8.0*/
+        else if (V_parser == "minecraft:scoreboard_slot") { /*8.0*/
         }
-        else if (parser == "minecraft:score_holder") { /*8.0*/
+        else if (V_parser == "minecraft:score_holder") { /*8.0*/
           uint8_t properties_minecraft_score_holder_val = 0;
           properties_minecraft_score_holder_val |= (uint8_t)v2.properties_minecraft_score_holder.unused << 0;
           properties_minecraft_score_holder_val |= (uint8_t)v2.properties_minecraft_score_holder.allowMultiple << 7;
           WRITE_OR_BAIL(writeUByte, properties_minecraft_score_holder_val); /*properties_minecraft_score_holder: bitfield*/ /*4.2*/
         }
-        else if (parser == "minecraft:swizzle") { /*8.0*/
+        else if (V_parser == "minecraft:swizzle") { /*8.0*/
         }
-        else if (parser == "minecraft:team") { /*8.0*/
+        else if (V_parser == "minecraft:team") { /*8.0*/
         }
-        else if (parser == "minecraft:item_slot") { /*8.0*/
+        else if (V_parser == "minecraft:item_slot") { /*8.0*/
         }
-        else if (parser == "minecraft:resource_location") { /*8.0*/
+        else if (V_parser == "minecraft:resource_location") { /*8.0*/
         }
-        else if (parser == "minecraft:mob_effect") { /*8.0*/
+        else if (V_parser == "minecraft:mob_effect") { /*8.0*/
         }
-        else if (parser == "minecraft:function") { /*8.0*/
+        else if (V_parser == "minecraft:function") { /*8.0*/
         }
-        else if (parser == "minecraft:entity_anchor") { /*8.0*/
+        else if (V_parser == "minecraft:entity_anchor") { /*8.0*/
         }
-        else if (parser == "minecraft:range") { /*8.0*/
+        else if (V_parser == "minecraft:range") { /*8.0*/
             const pdef::pc1_18_status_toServer::command_node::ExtraNodeData2::PropertiesMinecraftRange &v4 = *v2.properties_minecraft_range; /*8.5*/
             WRITE_OR_BAIL(writeBool, (bool)v4.allowDecimals); /*0.4*/
         }
-        else if (parser == "minecraft:int_range") { /*8.0*/
+        else if (V_parser == "minecraft:int_range") { /*8.0*/
         }
-        else if (parser == "minecraft:float_range") { /*8.0*/
+        else if (V_parser == "minecraft:float_range") { /*8.0*/
         }
-        else if (parser == "minecraft:item_enchantment") { /*8.0*/
+        else if (V_parser == "minecraft:item_enchantment") { /*8.0*/
         }
-        else if (parser == "minecraft:entity_summon") { /*8.0*/
+        else if (V_parser == "minecraft:entity_summon") { /*8.0*/
         }
-        else if (parser == "minecraft:dimension") { /*8.0*/
+        else if (V_parser == "minecraft:dimension") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt_compound_tag") { /*8.0*/
+        else if (V_parser == "minecraft:nbt_compound_tag") { /*8.0*/
         }
-        else if (parser == "minecraft:time") { /*8.0*/
+        else if (V_parser == "minecraft:time") { /*8.0*/
         }
-        else if (parser == "minecraft:resource_or_tag") { /*8.0*/
+        else if (V_parser == "minecraft:resource_or_tag") { /*8.0*/
             const pdef::pc1_18_status_toServer::command_node::ExtraNodeData2::PropertiesMinecraftResourceOrTagOrMinecraftResource &v4 = *v2.properties_minecraft_resource_or_tag_or_minecraft_resource; /*8.5*/
             WRITE_OR_BAIL(writeUnsignedVarInt, (int)v4.registry.length());
             WRITE_OR_BAIL(writeString, v4.registry); /*registry: pstring*/ /*4.2*/
         }
-        else if (parser == "minecraft:resource") { /*8.0*/
+        else if (V_parser == "minecraft:resource") { /*8.0*/
             const pdef::pc1_18_status_toServer::command_node::ExtraNodeData2::PropertiesMinecraftResourceOrTagOrMinecraftResource &v4 = *v2.properties_minecraft_resource_or_tag_or_minecraft_resource; /*8.5*/
             WRITE_OR_BAIL(writeUnsignedVarInt, (int)v4.registry.length());
             WRITE_OR_BAIL(writeString, v4.registry); /*registry: pstring*/ /*4.2*/
         }
-        else if (parser == "minecraft:uuid") { /*8.0*/
+        else if (V_parser == "minecraft:uuid") { /*8.0*/
         }
-        if (flags.has_custom_suggestions == 1) { /*8.2*/
+        if (V_flags.has_custom_suggestions == 1) { /*8.2*/
           WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.suggestionType.length());
           WRITE_OR_BAIL(writeString, v2.suggestionType); /*suggestionType: pstring*/ /*4.2*/
         }
@@ -867,9 +867,9 @@ bool tags(pdef::Stream &stream, const pdef::pc1_18_status_toServer::tags &obj, b
   }
   bool packet(pdef::Stream &stream, const pdef::pc1_18_status_toServer::packet &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::pc1_18_status_toServer::size::packet(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const pdef::pc1_18_status_toServer::packet::Name &name = obj.name; /*0.3*/
+    const pdef::pc1_18_status_toServer::packet::Name &V_name = obj.name; /*0.3*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)(int&)obj.name); /*7.1*/
-    switch (name) { /*8.0*/
+    switch (V_name) { /*8.0*/
       case pdef::pc1_18_status_toServer::packet::Name::PingStart: { /*8.5*/
         pdef::pc1_18_status_toServer::encode::packet_ping_start(stream, *obj.params_packet_ping_start); /*packet_ping_start*/ /*4.5*/
         break;
@@ -896,10 +896,10 @@ bool packet_ping(pdef::Stream &stream, pdef::pc1_18_status_toServer::packet_ping
 bool packet(pdef::Stream &stream, pdef::pc1_18_status_toServer::packet &obj);
   bool slot(pdef::Stream &stream, pdef::pc1_18_status_toServer::slot &obj) {
     READ_OR_BAIL(readBool, (bool&)obj.present); /*0.5*/
-    bool &present = obj.present; /*0.6*/
-    if (present == false) { /*8.1*/
+    bool &V_present = obj.present; /*0.6*/
+    if (V_present == false) { /*8.1*/
     }
-    else if (present == true) { /*8.1*/
+    else if (V_present == true) { /*8.1*/
         READ_OR_BAIL(readUnsignedVarInt, obj.itemId); /*0.5*/
         READ_OR_BAIL(readByte, obj.itemCount); /*0.5*/
         READ_OR_BAIL(readByte, obj.nbtData); /*0.5*/
@@ -908,23 +908,23 @@ bool packet(pdef::Stream &stream, pdef::pc1_18_status_toServer::packet &obj);
   }
   bool particle(pdef::Stream &stream, pdef::pc1_18_status_toServer::particle &obj) {
     READ_OR_BAIL(readUnsignedVarInt, obj.particleId); /*0.5*/
-    int &particleId = obj.particleId; /*0.6*/
-    if (particleId == 2) { /*8.2*/
+    int &V_particleId = obj.particleId; /*0.6*/
+    if (V_particleId == 2) { /*8.2*/
          obj.data_2_or_3_or_24 = {}; pdef::pc1_18_status_toServer::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.4*/
         READ_OR_BAIL(readUnsignedVarInt, v2.blockState); /*0.5*/
     }
-    else if (particleId == 3) { /*8.2*/
+    else if (V_particleId == 3) { /*8.2*/
          obj.data_2_or_3_or_24 = {}; pdef::pc1_18_status_toServer::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.4*/
         READ_OR_BAIL(readUnsignedVarInt, v2.blockState); /*0.5*/
     }
-    else if (particleId == 14) { /*8.2*/
+    else if (V_particleId == 14) { /*8.2*/
          obj.data_14 = {}; pdef::pc1_18_status_toServer::particle::Data14 &v2 = *obj.data_14; /*8.4*/
         READ_OR_BAIL(readFloatBE, v2.red); /*0.5*/
         READ_OR_BAIL(readFloatBE, v2.green); /*0.5*/
         READ_OR_BAIL(readFloatBE, v2.blue); /*0.5*/
         READ_OR_BAIL(readFloatBE, v2.scale); /*0.5*/
     }
-    else if (particleId == 15) { /*8.2*/
+    else if (V_particleId == 15) { /*8.2*/
          obj.data_15 = {}; pdef::pc1_18_status_toServer::particle::Data15 &v2 = *obj.data_15; /*8.4*/
         READ_OR_BAIL(readFloatBE, v2.fromRed); /*0.5*/
         READ_OR_BAIL(readFloatBE, v2.fromGreen); /*0.5*/
@@ -934,15 +934,15 @@ bool packet(pdef::Stream &stream, pdef::pc1_18_status_toServer::packet &obj);
         READ_OR_BAIL(readFloatBE, v2.toGreen); /*0.5*/
         READ_OR_BAIL(readFloatBE, v2.toBlue); /*0.5*/
     }
-    else if (particleId == 24) { /*8.2*/
+    else if (V_particleId == 24) { /*8.2*/
          obj.data_2_or_3_or_24 = {}; pdef::pc1_18_status_toServer::particle::Data2Or3Or24 &v2 = *obj.data_2_or_3_or_24; /*8.4*/
         READ_OR_BAIL(readUnsignedVarInt, v2.blockState); /*0.5*/
     }
-    else if (particleId == 35) { /*8.2*/
+    else if (V_particleId == 35) { /*8.2*/
          obj.data_35 = {}; pdef::pc1_18_status_toServer::particle::Data35 &v2 = *obj.data_35; /*8.4*/
         READ_OR_BAIL(readByte, v2.item); /*0.5*/
     }
-    else if (particleId == 36) { /*8.2*/
+    else if (V_particleId == 36) { /*8.2*/
          obj.data_36 = {}; pdef::pc1_18_status_toServer::particle::Data36 &v2 = *obj.data_36; /*8.4*/
         uint64_t origin_val;
         READ_OR_BAIL(readULongBE, origin_val);
@@ -951,15 +951,15 @@ bool packet(pdef::Stream &stream, pdef::pc1_18_status_toServer::packet &obj);
         v2.origin.y = origin_val >> 52 & 12; /*origin: bitfield*/ /*4.3*/
         int positionType_strlen; READ_OR_BAIL(readUnsignedVarInt, positionType_strlen);
         if (!stream.readString(v2.positionType, positionType_strlen)) return false; /*positionType: pstring*/ /*4.3*/
-        std::string &positionType = v2.positionType; /*4.8*/
-        if (positionType == "minecraft:block") { /*8.0*/
+        std::string &V_positionType = v2.positionType; /*4.8*/
+        if (V_positionType == "minecraft:block") { /*8.0*/
           uint64_t destination_position_val;
           READ_OR_BAIL(readULongBE, destination_position_val);
           v2.destination_position.x = destination_position_val >> 0 & 26;
           v2.destination_position.z = destination_position_val >> 26 & 26;
           v2.destination_position.y = destination_position_val >> 52 & 12; /*destination_position: bitfield*/ /*4.3*/
         }
-        else if (positionType == "minecraft:entity") { /*8.0*/
+        else if (V_positionType == "minecraft:entity") { /*8.0*/
           READ_OR_BAIL(readUnsignedVarInt, v2.destination_varint); /*0.5*/
         }
         READ_OR_BAIL(readUnsignedVarInt, v2.ticks); /*0.5*/
@@ -971,7 +971,7 @@ bool packet(pdef::Stream &stream, pdef::pc1_18_status_toServer::packet &obj);
     if (!stream.readString(obj.group, group_strlen)) return false; /*group: pstring*/ /*4.3*/
     int ingredient_len; READ_OR_BAIL(readUnsignedVarInt, ingredient_len); /*1.5*/
     obj.ingredient.resize(ingredient_len); /*1.6*/
-    for (int i = 0; i < ingredient_len; i++) {
+    for (int i = 0; i < ingredient_len; i++) { /*3.3*/
       auto &v2 = obj.ingredient[i]; /*3.4*/
       READ_OR_BAIL(readByte, v2); /*0.5*/
     }
@@ -985,7 +985,7 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_status_toServer::tags &obj) {
     if (!stream.readString(obj.tagName, tagName_strlen)) return false; /*tagName: pstring*/ /*4.3*/
     int entries_len; READ_OR_BAIL(readUnsignedVarInt, entries_len); /*1.5*/
     obj.entries.resize(entries_len); /*1.6*/
-    for (int i = 0; i < entries_len; i++) {
+    for (int i = 0; i < entries_len; i++) { /*3.3*/
       auto &v2 = obj.entries[i]; /*3.4*/
       READ_OR_BAIL(readUnsignedVarInt, v2); /*0.5*/
     }
@@ -1009,194 +1009,194 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_status_toServer::tags &obj) {
     obj.flags.has_redirect_node = flags_val >> 4 & 1;
     obj.flags.has_command = flags_val >> 5 & 1;
     obj.flags.command_node_type = flags_val >> 6 & 2; /*flags: bitfield*/ /*4.3*/
-    pdef::pc1_18_status_toServer::command_node::flags_t &flags = obj.flags; /*4.8*/
+    pdef::pc1_18_status_toServer::command_node::flags_t &V_flags = obj.flags; /*4.8*/
     int children_len; READ_OR_BAIL(readUnsignedVarInt, children_len); /*1.5*/
     obj.children.resize(children_len); /*1.6*/
-    for (int i = 0; i < children_len; i++) {
+    for (int i = 0; i < children_len; i++) { /*3.3*/
       auto &v2 = obj.children[i]; /*3.4*/
       READ_OR_BAIL(readUnsignedVarInt, v2); /*0.5*/
     }
-    if (flags.has_redirect_node == 1) { /*8.2*/
+    if (V_flags.has_redirect_node == 1) { /*8.2*/
       READ_OR_BAIL(readUnsignedVarInt, obj.redirectNode); /*0.5*/
     }
-    if (flags.command_node_type == 0) { /*8.2*/
+    if (V_flags.command_node_type == 0) { /*8.2*/
     }
-    else if (flags.command_node_type == 1) { /*8.2*/
+    else if (V_flags.command_node_type == 1) { /*8.2*/
          obj.extraNodeData_1 = {}; pdef::pc1_18_status_toServer::command_node::ExtraNodeData1 &v2 = *obj.extraNodeData_1; /*8.4*/
         int name_strlen; READ_OR_BAIL(readUnsignedVarInt, name_strlen);
         if (!stream.readString(v2.name, name_strlen)) return false; /*name: pstring*/ /*4.3*/
     }
-    else if (flags.command_node_type == 2) { /*8.2*/
+    else if (V_flags.command_node_type == 2) { /*8.2*/
          obj.extraNodeData_2 = {}; pdef::pc1_18_status_toServer::command_node::ExtraNodeData2 &v2 = *obj.extraNodeData_2; /*8.4*/
         int name_strlen; READ_OR_BAIL(readUnsignedVarInt, name_strlen);
         if (!stream.readString(v2.name, name_strlen)) return false; /*name: pstring*/ /*4.3*/
         int parser_strlen; READ_OR_BAIL(readUnsignedVarInt, parser_strlen);
         if (!stream.readString(v2.parser, parser_strlen)) return false; /*parser: pstring*/ /*4.3*/
-        std::string &parser = v2.parser; /*4.8*/
-        if (parser == "brigadier:bool") { /*8.0*/
+        std::string &V_parser = v2.parser; /*4.8*/
+        if (V_parser == "brigadier:bool") { /*8.0*/
         }
-        else if (parser == "brigadier:float") { /*8.0*/
+        else if (V_parser == "brigadier:float") { /*8.0*/
              v2.properties_brigadier_float = {}; pdef::pc1_18_status_toServer::command_node::ExtraNodeData2::PropertiesBrigadierFloat &v4 = *v2.properties_brigadier_float; /*8.4*/
             uint8_t flags_val;
             READ_OR_BAIL(readUByte, flags_val);
             v4.flags.unused = flags_val >> 0 & 6;
             v4.flags.max_present = flags_val >> 6 & 1;
             v4.flags.min_present = flags_val >> 7 & 1; /*flags: bitfield*/ /*4.3*/
-            pdef::pc1_18_status_toServer::command_node::ExtraNodeData2::PropertiesBrigadierFloat::flags_t &flags = v4.flags; /*4.8*/
-            if (flags.min_present == 1) { /*8.2*/
+            pdef::pc1_18_status_toServer::command_node::ExtraNodeData2::PropertiesBrigadierFloat::flags_t &V_flags = v4.flags; /*4.8*/
+            if (V_flags.min_present == 1) { /*8.2*/
               READ_OR_BAIL(readFloatBE, v4.min); /*0.5*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               READ_OR_BAIL(readFloatBE, v4.max); /*0.5*/
             }
         }
-        else if (parser == "brigadier:double") { /*8.0*/
+        else if (V_parser == "brigadier:double") { /*8.0*/
              v2.properties_brigadier_double = {}; pdef::pc1_18_status_toServer::command_node::ExtraNodeData2::PropertiesBrigadierDouble &v4 = *v2.properties_brigadier_double; /*8.4*/
             uint8_t flags_val;
             READ_OR_BAIL(readUByte, flags_val);
             v4.flags.unused = flags_val >> 0 & 6;
             v4.flags.max_present = flags_val >> 6 & 1;
             v4.flags.min_present = flags_val >> 7 & 1; /*flags: bitfield*/ /*4.3*/
-            pdef::pc1_18_status_toServer::command_node::ExtraNodeData2::PropertiesBrigadierDouble::flags_t &flags = v4.flags; /*4.8*/
-            if (flags.min_present == 1) { /*8.2*/
+            pdef::pc1_18_status_toServer::command_node::ExtraNodeData2::PropertiesBrigadierDouble::flags_t &V_flags = v4.flags; /*4.8*/
+            if (V_flags.min_present == 1) { /*8.2*/
               READ_OR_BAIL(readDoubleBE, v4.min); /*0.5*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               READ_OR_BAIL(readDoubleBE, v4.max); /*0.5*/
             }
         }
-        else if (parser == "brigadier:integer") { /*8.0*/
+        else if (V_parser == "brigadier:integer") { /*8.0*/
              v2.properties_brigadier_integer = {}; pdef::pc1_18_status_toServer::command_node::ExtraNodeData2::PropertiesBrigadierInteger &v4 = *v2.properties_brigadier_integer; /*8.4*/
             uint8_t flags_val;
             READ_OR_BAIL(readUByte, flags_val);
             v4.flags.unused = flags_val >> 0 & 6;
             v4.flags.max_present = flags_val >> 6 & 1;
             v4.flags.min_present = flags_val >> 7 & 1; /*flags: bitfield*/ /*4.3*/
-            pdef::pc1_18_status_toServer::command_node::ExtraNodeData2::PropertiesBrigadierInteger::flags_t &flags = v4.flags; /*4.8*/
-            if (flags.min_present == 1) { /*8.2*/
+            pdef::pc1_18_status_toServer::command_node::ExtraNodeData2::PropertiesBrigadierInteger::flags_t &V_flags = v4.flags; /*4.8*/
+            if (V_flags.min_present == 1) { /*8.2*/
               READ_OR_BAIL(readIntBE, v4.min); /*0.5*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               READ_OR_BAIL(readIntBE, v4.max); /*0.5*/
             }
         }
-        else if (parser == "brigadier:long") { /*8.0*/
+        else if (V_parser == "brigadier:long") { /*8.0*/
              v2.properties_brigadier_long = {}; pdef::pc1_18_status_toServer::command_node::ExtraNodeData2::PropertiesBrigadierLong &v4 = *v2.properties_brigadier_long; /*8.4*/
             uint8_t flags_val;
             READ_OR_BAIL(readUByte, flags_val);
             v4.flags.unused = flags_val >> 0 & 6;
             v4.flags.max_present = flags_val >> 6 & 1;
             v4.flags.min_present = flags_val >> 7 & 1; /*flags: bitfield*/ /*4.3*/
-            pdef::pc1_18_status_toServer::command_node::ExtraNodeData2::PropertiesBrigadierLong::flags_t &flags = v4.flags; /*4.8*/
-            if (flags.min_present == 1) { /*8.2*/
+            pdef::pc1_18_status_toServer::command_node::ExtraNodeData2::PropertiesBrigadierLong::flags_t &V_flags = v4.flags; /*4.8*/
+            if (V_flags.min_present == 1) { /*8.2*/
               READ_OR_BAIL(readLongBE, v4.min); /*0.5*/
             }
-            if (flags.max_present == 1) { /*8.2*/
+            if (V_flags.max_present == 1) { /*8.2*/
               READ_OR_BAIL(readLongBE, v4.max); /*0.5*/
             }
         }
-        else if (parser == "brigadier:string") { /*8.0*/
+        else if (V_parser == "brigadier:string") { /*8.0*/
         }
-        else if (parser == "minecraft:entity") { /*8.0*/
+        else if (V_parser == "minecraft:entity") { /*8.0*/
           uint8_t properties_minecraft_entity_val;
           READ_OR_BAIL(readUByte, properties_minecraft_entity_val);
           v2.properties_minecraft_entity.unused = properties_minecraft_entity_val >> 0 & 6;
           v2.properties_minecraft_entity.onlyAllowPlayers = properties_minecraft_entity_val >> 6 & 1;
           v2.properties_minecraft_entity.onlyAllowEntities = properties_minecraft_entity_val >> 7 & 1; /*properties_minecraft_entity: bitfield*/ /*4.3*/
         }
-        else if (parser == "minecraft:game_profile") { /*8.0*/
+        else if (V_parser == "minecraft:game_profile") { /*8.0*/
         }
-        else if (parser == "minecraft:block_pos") { /*8.0*/
+        else if (V_parser == "minecraft:block_pos") { /*8.0*/
         }
-        else if (parser == "minecraft:column_pos") { /*8.0*/
+        else if (V_parser == "minecraft:column_pos") { /*8.0*/
         }
-        else if (parser == "minecraft:vec3") { /*8.0*/
+        else if (V_parser == "minecraft:vec3") { /*8.0*/
         }
-        else if (parser == "minecraft:vec2") { /*8.0*/
+        else if (V_parser == "minecraft:vec2") { /*8.0*/
         }
-        else if (parser == "minecraft:block_state") { /*8.0*/
+        else if (V_parser == "minecraft:block_state") { /*8.0*/
         }
-        else if (parser == "minecraft:block_predicate") { /*8.0*/
+        else if (V_parser == "minecraft:block_predicate") { /*8.0*/
         }
-        else if (parser == "minecraft:item_stack") { /*8.0*/
+        else if (V_parser == "minecraft:item_stack") { /*8.0*/
         }
-        else if (parser == "minecraft:item_predicate") { /*8.0*/
+        else if (V_parser == "minecraft:item_predicate") { /*8.0*/
         }
-        else if (parser == "minecraft:color") { /*8.0*/
+        else if (V_parser == "minecraft:color") { /*8.0*/
         }
-        else if (parser == "minecraft:component") { /*8.0*/
+        else if (V_parser == "minecraft:component") { /*8.0*/
         }
-        else if (parser == "minecraft:message") { /*8.0*/
+        else if (V_parser == "minecraft:message") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt") { /*8.0*/
+        else if (V_parser == "minecraft:nbt") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt_path") { /*8.0*/
+        else if (V_parser == "minecraft:nbt_path") { /*8.0*/
         }
-        else if (parser == "minecraft:objective") { /*8.0*/
+        else if (V_parser == "minecraft:objective") { /*8.0*/
         }
-        else if (parser == "minecraft:objective_criteria") { /*8.0*/
+        else if (V_parser == "minecraft:objective_criteria") { /*8.0*/
         }
-        else if (parser == "minecraft:operation") { /*8.0*/
+        else if (V_parser == "minecraft:operation") { /*8.0*/
         }
-        else if (parser == "minecraft:particle") { /*8.0*/
+        else if (V_parser == "minecraft:particle") { /*8.0*/
         }
-        else if (parser == "minecraft:angle") { /*8.0*/
+        else if (V_parser == "minecraft:angle") { /*8.0*/
         }
-        else if (parser == "minecraft:rotation") { /*8.0*/
+        else if (V_parser == "minecraft:rotation") { /*8.0*/
         }
-        else if (parser == "minecraft:scoreboard_slot") { /*8.0*/
+        else if (V_parser == "minecraft:scoreboard_slot") { /*8.0*/
         }
-        else if (parser == "minecraft:score_holder") { /*8.0*/
+        else if (V_parser == "minecraft:score_holder") { /*8.0*/
           uint8_t properties_minecraft_score_holder_val;
           READ_OR_BAIL(readUByte, properties_minecraft_score_holder_val);
           v2.properties_minecraft_score_holder.unused = properties_minecraft_score_holder_val >> 0 & 7;
           v2.properties_minecraft_score_holder.allowMultiple = properties_minecraft_score_holder_val >> 7 & 1; /*properties_minecraft_score_holder: bitfield*/ /*4.3*/
         }
-        else if (parser == "minecraft:swizzle") { /*8.0*/
+        else if (V_parser == "minecraft:swizzle") { /*8.0*/
         }
-        else if (parser == "minecraft:team") { /*8.0*/
+        else if (V_parser == "minecraft:team") { /*8.0*/
         }
-        else if (parser == "minecraft:item_slot") { /*8.0*/
+        else if (V_parser == "minecraft:item_slot") { /*8.0*/
         }
-        else if (parser == "minecraft:resource_location") { /*8.0*/
+        else if (V_parser == "minecraft:resource_location") { /*8.0*/
         }
-        else if (parser == "minecraft:mob_effect") { /*8.0*/
+        else if (V_parser == "minecraft:mob_effect") { /*8.0*/
         }
-        else if (parser == "minecraft:function") { /*8.0*/
+        else if (V_parser == "minecraft:function") { /*8.0*/
         }
-        else if (parser == "minecraft:entity_anchor") { /*8.0*/
+        else if (V_parser == "minecraft:entity_anchor") { /*8.0*/
         }
-        else if (parser == "minecraft:range") { /*8.0*/
+        else if (V_parser == "minecraft:range") { /*8.0*/
              v2.properties_minecraft_range = {}; pdef::pc1_18_status_toServer::command_node::ExtraNodeData2::PropertiesMinecraftRange &v4 = *v2.properties_minecraft_range; /*8.4*/
             READ_OR_BAIL(readBool, (bool&)v4.allowDecimals); /*0.5*/
         }
-        else if (parser == "minecraft:int_range") { /*8.0*/
+        else if (V_parser == "minecraft:int_range") { /*8.0*/
         }
-        else if (parser == "minecraft:float_range") { /*8.0*/
+        else if (V_parser == "minecraft:float_range") { /*8.0*/
         }
-        else if (parser == "minecraft:item_enchantment") { /*8.0*/
+        else if (V_parser == "minecraft:item_enchantment") { /*8.0*/
         }
-        else if (parser == "minecraft:entity_summon") { /*8.0*/
+        else if (V_parser == "minecraft:entity_summon") { /*8.0*/
         }
-        else if (parser == "minecraft:dimension") { /*8.0*/
+        else if (V_parser == "minecraft:dimension") { /*8.0*/
         }
-        else if (parser == "minecraft:nbt_compound_tag") { /*8.0*/
+        else if (V_parser == "minecraft:nbt_compound_tag") { /*8.0*/
         }
-        else if (parser == "minecraft:time") { /*8.0*/
+        else if (V_parser == "minecraft:time") { /*8.0*/
         }
-        else if (parser == "minecraft:resource_or_tag") { /*8.0*/
+        else if (V_parser == "minecraft:resource_or_tag") { /*8.0*/
              v2.properties_minecraft_resource_or_tag_or_minecraft_resource = {}; pdef::pc1_18_status_toServer::command_node::ExtraNodeData2::PropertiesMinecraftResourceOrTagOrMinecraftResource &v4 = *v2.properties_minecraft_resource_or_tag_or_minecraft_resource; /*8.4*/
             int registry_strlen; READ_OR_BAIL(readUnsignedVarInt, registry_strlen);
             if (!stream.readString(v4.registry, registry_strlen)) return false; /*registry: pstring*/ /*4.3*/
         }
-        else if (parser == "minecraft:resource") { /*8.0*/
+        else if (V_parser == "minecraft:resource") { /*8.0*/
              v2.properties_minecraft_resource_or_tag_or_minecraft_resource = {}; pdef::pc1_18_status_toServer::command_node::ExtraNodeData2::PropertiesMinecraftResourceOrTagOrMinecraftResource &v4 = *v2.properties_minecraft_resource_or_tag_or_minecraft_resource; /*8.4*/
             int registry_strlen; READ_OR_BAIL(readUnsignedVarInt, registry_strlen);
             if (!stream.readString(v4.registry, registry_strlen)) return false; /*registry: pstring*/ /*4.3*/
         }
-        else if (parser == "minecraft:uuid") { /*8.0*/
+        else if (V_parser == "minecraft:uuid") { /*8.0*/
         }
-        if (flags.has_custom_suggestions == 1) { /*8.2*/
+        if (V_flags.has_custom_suggestions == 1) { /*8.2*/
           int suggestionType_strlen; READ_OR_BAIL(readUnsignedVarInt, suggestionType_strlen);
           if (!stream.readString(v2.suggestionType, suggestionType_strlen)) return false; /*suggestionType: pstring*/ /*4.3*/
         }
@@ -1212,8 +1212,8 @@ bool tags(pdef::Stream &stream, pdef::pc1_18_status_toServer::tags &obj) {
   }
   bool packet(pdef::Stream &stream, pdef::pc1_18_status_toServer::packet &obj) {
     READ_OR_BAIL(readUnsignedVarInt, (int&)obj.name); /*7.2*/
-    const pdef::pc1_18_status_toServer::packet::Name &name = obj.name; /*0.7*/
-    switch (name) { /*8.0*/
+    const pdef::pc1_18_status_toServer::packet::Name &V_name = obj.name; /*0.7*/
+    switch (V_name) { /*8.0*/
       case pdef::pc1_18_status_toServer::packet::Name::PingStart: { /*8.5*/
         obj.params_packet_ping_start = {}; pdef::pc1_18_status_toServer::decode::packet_ping_start(stream, *obj.params_packet_ping_start); /*obj*/ /*4.6*/
         break;

--- a/examples/mcpe-protocol/build/protocol.h
+++ b/examples/mcpe-protocol/build/protocol.h
@@ -5770,9 +5770,9 @@ size_t ResourcePackIdVersions(pdef::Stream &stream, const pdef::proto::ResourceP
     len += stream.sizeOfVarInt(obj.name.length());
     len += obj.name.length(); /*name: pstring*/ /*4.1*/
     len += 1; /*0.2*/
-    const pdef::proto::GameRule::Type &type = obj.type; /*0.3*/
+    const pdef::proto::GameRule::Type &V_type = obj.type; /*0.3*/
     len += stream.sizeOfVarInt((int&)obj.type); /*type^: varint*/ /*7.0*/
-    switch (type) { /*8.0*/
+    switch (V_type) { /*8.0*/
       case pdef::proto::GameRule::Type::Bool: { /*8.5*/
         len += 1; /*0.2*/
         break;
@@ -5813,9 +5813,9 @@ size_t Itemstates(pdef::Stream &stream, const pdef::proto::Itemstates &obj) {
 }
   size_t ItemExtraDataWithBlockingTick(pdef::Stream &stream, const pdef::proto::ItemExtraDataWithBlockingTick &obj) {
     size_t len = 0;
-    const pdef::proto::ItemExtraDataWithBlockingTick::HasNbt &has_nbt = obj.has_nbt; /*0.3*/
+    const pdef::proto::ItemExtraDataWithBlockingTick::HasNbt &V_has_nbt = obj.has_nbt; /*0.3*/
     len += 2; /*has_nbt^: lu16*/ /*7.0*/
-    switch (has_nbt) { /*8.0*/
+    switch (V_has_nbt) { /*8.0*/
       case pdef::proto::ItemExtraDataWithBlockingTick::HasNbt::True: { /*8.5*/
         EXPECT_OR_BAIL(obj.nbt); const pdef::proto::ItemExtraDataWithBlockingTick::Nbt &v2 = *obj.nbt; /*8.6*/
           len += 1; /*0.2*/
@@ -5825,12 +5825,12 @@ size_t Itemstates(pdef::Stream &stream, const pdef::proto::Itemstates &obj) {
       default: break; /*avoid unhandled case warning*/
     } /*8.8*/
     len += 4; /*1.3*/
-    for (const auto &v2 : obj.can_place_on) {
+    for (const auto &v2 : obj.can_place_on) { /*3.2*/
       len += 2;
       len += v2.length(); /*: pstring*/ /*4.1*/
     }
     len += 4; /*1.3*/
-    for (const auto &v2 : obj.can_destroy) {
+    for (const auto &v2 : obj.can_destroy) { /*3.2*/
       len += 2;
       len += v2.length(); /*: pstring*/ /*4.1*/
     }
@@ -5839,9 +5839,9 @@ size_t Itemstates(pdef::Stream &stream, const pdef::proto::Itemstates &obj) {
   }
   size_t ItemExtraDataWithoutBlockingTick(pdef::Stream &stream, const pdef::proto::ItemExtraDataWithoutBlockingTick &obj) {
     size_t len = 0;
-    const pdef::proto::ItemExtraDataWithoutBlockingTick::HasNbt &has_nbt = obj.has_nbt; /*0.3*/
+    const pdef::proto::ItemExtraDataWithoutBlockingTick::HasNbt &V_has_nbt = obj.has_nbt; /*0.3*/
     len += 2; /*has_nbt^: lu16*/ /*7.0*/
-    switch (has_nbt) { /*8.0*/
+    switch (V_has_nbt) { /*8.0*/
       case pdef::proto::ItemExtraDataWithoutBlockingTick::HasNbt::True: { /*8.5*/
         EXPECT_OR_BAIL(obj.nbt); const pdef::proto::ItemExtraDataWithoutBlockingTick::Nbt &v2 = *obj.nbt; /*8.6*/
           len += 1; /*0.2*/
@@ -5851,12 +5851,12 @@ size_t Itemstates(pdef::Stream &stream, const pdef::proto::Itemstates &obj) {
       default: break; /*avoid unhandled case warning*/
     } /*8.8*/
     len += 4; /*1.3*/
-    for (const auto &v2 : obj.can_place_on) {
+    for (const auto &v2 : obj.can_place_on) { /*3.2*/
       len += 2;
       len += v2.length(); /*: pstring*/ /*4.1*/
     }
     len += 4; /*1.3*/
-    for (const auto &v2 : obj.can_destroy) {
+    for (const auto &v2 : obj.can_destroy) { /*3.2*/
       len += 2;
       len += v2.length(); /*: pstring*/ /*4.1*/
     }
@@ -5864,14 +5864,14 @@ size_t Itemstates(pdef::Stream &stream, const pdef::proto::Itemstates &obj) {
   }
   size_t ItemLegacy(pdef::Stream &stream, const pdef::proto::ItemLegacy &obj) {
     size_t len = 0;
-    const int &network_id = obj.network_id; /*0.1*/
-    if (network_id == 0) { /*8.2*/
+    const int &V_network_id = obj.network_id; /*0.1*/
+    if (V_network_id == 0) { /*8.2*/
     }
     else {
         len += 2; /*0.2*/
         len += stream.sizeOfVarInt(obj.metadata); /*0.2*/
         len += stream.sizeOfZigZagVarInt(obj.block_runtime_id); /*0.2*/
-        if (network_id == pdef::proto::ShieldItemID) { /*8.4*/
+        if (V_network_id == pdef::proto::ShieldItemID) { /*8.4*/
           len += 1; /*0.2*/
         }
         else {
@@ -5882,20 +5882,20 @@ size_t Itemstates(pdef::Stream &stream, const pdef::proto::Itemstates &obj) {
   }
   size_t Item(pdef::Stream &stream, const pdef::proto::Item &obj) {
     size_t len = 0;
-    const int &network_id = obj.network_id; /*0.1*/
-    if (network_id == 0) { /*8.2*/
+    const int &V_network_id = obj.network_id; /*0.1*/
+    if (V_network_id == 0) { /*8.2*/
     }
     else {
         len += 2; /*0.2*/
         len += stream.sizeOfVarInt(obj.metadata); /*0.2*/
-        const uint8_t &has_stack_id = obj.has_stack_id; /*0.1*/
-        if (has_stack_id == 0) { /*8.2*/
+        const uint8_t &V_has_stack_id = obj.has_stack_id; /*0.1*/
+        if (V_has_stack_id == 0) { /*8.2*/
         }
         else {
           len += stream.sizeOfZigZagVarInt(obj.stack_id); /*0.2*/
         }
         len += stream.sizeOfZigZagVarInt(obj.block_runtime_id); /*0.2*/
-        if (network_id == pdef::proto::ShieldItemID) { /*8.4*/
+        if (V_network_id == pdef::proto::ShieldItemID) { /*8.4*/
           len += 1; /*0.2*/
         }
         else {
@@ -5933,11 +5933,11 @@ size_t Itemstates(pdef::Stream &stream, const pdef::proto::Itemstates &obj) {
   }
 size_t MetadataDictionary(pdef::Stream &stream, const pdef::proto::MetadataDictionary &obj) {
   size_t len = 0;
-    const pdef::proto::MetadataDictionary::Key &key = obj.key; /*0.3*/
+    const pdef::proto::MetadataDictionary::Key &V_key = obj.key; /*0.3*/
     len += stream.sizeOfVarInt((int&)obj.key); /*key^: varint*/ /*7.0*/
-    const pdef::proto::MetadataDictionary::Type &type = obj.type; /*0.3*/
+    const pdef::proto::MetadataDictionary::Type &V_type = obj.type; /*0.3*/
     len += stream.sizeOfVarInt((int&)obj.type); /*type^: varint*/ /*7.0*/
-    switch (key) { /*8.0*/
+    switch (V_key) { /*8.0*/
       case pdef::proto::MetadataDictionary::Key::Flags: { /*8.5*/
         int64_t value_MetadataFlags1_val = 0; /*X*/
         value_MetadataFlags1_val |= (int64_t)obj.value_MetadataFlags1.onfire << 0;
@@ -6055,7 +6055,7 @@ size_t MetadataDictionary(pdef::Stream &stream, const pdef::proto::MetadataDicti
         break;
       } /*8.7*/
       default: { /*8.3*/
-        switch (type) { /*8.0*/
+        switch (V_type) { /*8.0*/
           case pdef::proto::MetadataDictionary::Type::Byte: { /*8.5*/
             len += 1; /*0.2*/
             break;
@@ -6156,9 +6156,9 @@ size_t PlayerAttributes(pdef::Stream &stream, const pdef::proto::PlayerAttribute
   }
 size_t TransactionActions(pdef::Stream &stream, const pdef::proto::TransactionActions &obj) {
   size_t len = 0;
-    const pdef::proto::TransactionActions::SourceType &source_type = obj.source_type; /*0.3*/
+    const pdef::proto::TransactionActions::SourceType &V_source_type = obj.source_type; /*0.3*/
     len += stream.sizeOfVarInt((int&)obj.source_type); /*source_type^: varint*/ /*7.0*/
-    switch (source_type) { /*8.0*/
+    switch (V_source_type) { /*8.0*/
       case pdef::proto::TransactionActions::SourceType::Container: { /*8.5*/
           len += stream.sizeOfVarInt((int&)obj.inventory_id); /*inventory_id: varint*/ /*7.0*/
         break;
@@ -6184,8 +6184,8 @@ size_t TransactionActions(pdef::Stream &stream, const pdef::proto::TransactionAc
 }
   size_t TransactionLegacy(pdef::Stream &stream, const pdef::proto::TransactionLegacy &obj) {
     size_t len = 0;
-    const int &legacy_request_id = obj.legacy_request_id; /*0.1*/
-    if (legacy_request_id == 0) { /*8.2*/
+    const int &V_legacy_request_id = obj.legacy_request_id; /*0.1*/
+    if (V_legacy_request_id == 0) { /*8.2*/
     }
     else {
       len += stream.sizeOfVarInt(obj.legacy_transactions.size()); /*1.3*/
@@ -6202,11 +6202,11 @@ size_t TransactionActions(pdef::Stream &stream, const pdef::proto::TransactionAc
   size_t Transaction(pdef::Stream &stream, const pdef::proto::Transaction &obj) {
     size_t len = 0;
     size_t len_8 = pdef::proto::size::TransactionLegacy(stream, obj.legacy); EXPECT_OR_BAIL(len_8); len += len_8; /*legacy*/ /*4.4*/
-    const pdef::proto::Transaction::TransactionType &transaction_type = obj.transaction_type; /*0.3*/
+    const pdef::proto::Transaction::TransactionType &V_transaction_type = obj.transaction_type; /*0.3*/
     len += stream.sizeOfVarInt((int&)obj.transaction_type); /*transaction_type^: varint*/ /*7.0*/
     len += stream.sizeOfVarInt(obj.actions.size()); /*2.4*/
     for (const auto &v : obj.actions) { size_t len_9 = pdef::proto::size::TransactionActions(stream, v); EXPECT_OR_BAIL(len_9); len += len_9; } /*2.5*/
-    switch (transaction_type) { /*8.0*/
+    switch (V_transaction_type) { /*8.0*/
       case pdef::proto::Transaction::TransactionType::Normal: { /*8.5*/
         break;
       } /*8.7*/
@@ -6241,8 +6241,8 @@ size_t TransactionActions(pdef::Stream &stream, const pdef::proto::TransactionAc
   }
   size_t RecipeIngredient(pdef::Stream &stream, const pdef::proto::RecipeIngredient &obj) {
     size_t len = 0;
-    const int &network_id = obj.network_id; /*0.1*/
-    if (network_id == 0) { /*8.2*/
+    const int &V_network_id = obj.network_id; /*0.1*/
+    if (V_network_id == 0) { /*8.2*/
     }
     else {
         len += stream.sizeOfZigZagVarInt(obj.network_data); /*0.2*/
@@ -6269,19 +6269,19 @@ size_t PotionContainerChangeRecipes(pdef::Stream &stream, const pdef::proto::Pot
 }
 size_t Recipes(pdef::Stream &stream, const pdef::proto::Recipes &obj) {
   size_t len = 0;
-    const pdef::proto::Recipes::Type &type = obj.type; /*0.3*/
+    const pdef::proto::Recipes::Type &V_type = obj.type; /*0.3*/
     len += stream.sizeOfZigZagVarInt((int&)obj.type); /*type^: zigzag32*/ /*7.0*/
-    switch (type) { /*8.0*/
+    switch (V_type) { /*8.0*/
       case pdef::proto::Recipes::Type::Shapeless: { /*8.5*/
         EXPECT_OR_BAIL(obj.recipe_shapeless_or_shulker_box_or_shapeless_chemistry); const pdef::proto::Recipes::RecipeShapelessOrShulkerBoxOrShapelessChemistry &v2 = *obj.recipe_shapeless_or_shulker_box_or_shapeless_chemistry; /*8.6*/
           len += stream.sizeOfVarInt(v2.recipe_id.length());
           len += v2.recipe_id.length(); /*recipe_id: pstring*/ /*4.1*/
           len += stream.sizeOfVarInt(v2.input.size()); /*1.3*/
-          for (const auto &v5 : v2.input) {
+          for (const auto &v5 : v2.input) { /*3.2*/
             size_t len_16 = pdef::proto::size::RecipeIngredient(stream, v5); EXPECT_OR_BAIL(len_16); len += len_16; /**/ /*4.4*/
           }
           len += stream.sizeOfVarInt(v2.output.size()); /*1.3*/
-          for (const auto &v5 : v2.output) {
+          for (const auto &v5 : v2.output) { /*3.2*/
             size_t len_17 = pdef::proto::size::ItemLegacy(stream, v5); EXPECT_OR_BAIL(len_17); len += len_17; /**/ /*4.4*/
           }
           len += 8; /*0.2*/
@@ -6296,11 +6296,11 @@ size_t Recipes(pdef::Stream &stream, const pdef::proto::Recipes &obj) {
           len += stream.sizeOfVarInt(v2.recipe_id.length());
           len += v2.recipe_id.length(); /*recipe_id: pstring*/ /*4.1*/
           len += stream.sizeOfVarInt(v2.input.size()); /*1.3*/
-          for (const auto &v5 : v2.input) {
+          for (const auto &v5 : v2.input) { /*3.2*/
             size_t len_18 = pdef::proto::size::RecipeIngredient(stream, v5); EXPECT_OR_BAIL(len_18); len += len_18; /**/ /*4.4*/
           }
           len += stream.sizeOfVarInt(v2.output.size()); /*1.3*/
-          for (const auto &v5 : v2.output) {
+          for (const auto &v5 : v2.output) { /*3.2*/
             size_t len_19 = pdef::proto::size::ItemLegacy(stream, v5); EXPECT_OR_BAIL(len_19); len += len_19; /**/ /*4.4*/
           }
           len += 8; /*0.2*/
@@ -6315,11 +6315,11 @@ size_t Recipes(pdef::Stream &stream, const pdef::proto::Recipes &obj) {
           len += stream.sizeOfVarInt(v2.recipe_id.length());
           len += v2.recipe_id.length(); /*recipe_id: pstring*/ /*4.1*/
           len += stream.sizeOfVarInt(v2.input.size()); /*1.3*/
-          for (const auto &v5 : v2.input) {
+          for (const auto &v5 : v2.input) { /*3.2*/
             size_t len_20 = pdef::proto::size::RecipeIngredient(stream, v5); EXPECT_OR_BAIL(len_20); len += len_20; /**/ /*4.4*/
           }
           len += stream.sizeOfVarInt(v2.output.size()); /*1.3*/
-          for (const auto &v5 : v2.output) {
+          for (const auto &v5 : v2.output) { /*3.2*/
             size_t len_21 = pdef::proto::size::ItemLegacy(stream, v5); EXPECT_OR_BAIL(len_21); len += len_21; /**/ /*4.4*/
           }
           len += 8; /*0.2*/
@@ -6333,17 +6333,17 @@ size_t Recipes(pdef::Stream &stream, const pdef::proto::Recipes &obj) {
         EXPECT_OR_BAIL(obj.recipe_shaped_or_shaped_chemistry); const pdef::proto::Recipes::RecipeShapedOrShapedChemistry &v2 = *obj.recipe_shaped_or_shaped_chemistry; /*8.6*/
           len += stream.sizeOfVarInt(v2.recipe_id.length());
           len += v2.recipe_id.length(); /*recipe_id: pstring*/ /*4.1*/
-          const int &width = v2.width; /*0.1*/
-          const int &height = v2.height; /*0.1*/
-          len += stream.sizeOfZigZagVarInt(width); /*1.1*/
+          const int &V_width = v2.width; /*0.1*/
+          const int &V_height = v2.height; /*0.1*/
+          len += stream.sizeOfZigZagVarInt(V_width); /*1.1*/
           for (const auto &v : v2.input) { /*5.1*/
-            len += stream.sizeOfZigZagVarInt(height); /*5.3*/
+            len += stream.sizeOfZigZagVarInt(V_height); /*5.3*/
             for (const auto &v : v) { /*5.10*/
               size_t len_22 = pdef::proto::size::RecipeIngredient(stream, v); EXPECT_OR_BAIL(len_22); len += len_22; /**/ /*4.4*/
             }
           }
           len += stream.sizeOfVarInt(v2.output.size()); /*1.3*/
-          for (const auto &v5 : v2.output) {
+          for (const auto &v5 : v2.output) { /*3.2*/
             size_t len_23 = pdef::proto::size::ItemLegacy(stream, v5); EXPECT_OR_BAIL(len_23); len += len_23; /**/ /*4.4*/
           }
           len += 8; /*0.2*/
@@ -6357,17 +6357,17 @@ size_t Recipes(pdef::Stream &stream, const pdef::proto::Recipes &obj) {
         EXPECT_OR_BAIL(obj.recipe_shaped_or_shaped_chemistry); const pdef::proto::Recipes::RecipeShapedOrShapedChemistry &v2 = *obj.recipe_shaped_or_shaped_chemistry; /*8.6*/
           len += stream.sizeOfVarInt(v2.recipe_id.length());
           len += v2.recipe_id.length(); /*recipe_id: pstring*/ /*4.1*/
-          const int &width = v2.width; /*0.1*/
-          const int &height = v2.height; /*0.1*/
-          len += stream.sizeOfZigZagVarInt(width); /*1.1*/
+          const int &V_width = v2.width; /*0.1*/
+          const int &V_height = v2.height; /*0.1*/
+          len += stream.sizeOfZigZagVarInt(V_width); /*1.1*/
           for (const auto &v : v2.input) { /*5.1*/
-            len += stream.sizeOfZigZagVarInt(height); /*5.3*/
+            len += stream.sizeOfZigZagVarInt(V_height); /*5.3*/
             for (const auto &v : v) { /*5.10*/
               size_t len_24 = pdef::proto::size::RecipeIngredient(stream, v); EXPECT_OR_BAIL(len_24); len += len_24; /**/ /*4.4*/
             }
           }
           len += stream.sizeOfVarInt(v2.output.size()); /*1.3*/
-          for (const auto &v5 : v2.output) {
+          for (const auto &v5 : v2.output) { /*3.2*/
             size_t len_25 = pdef::proto::size::ItemLegacy(stream, v5); EXPECT_OR_BAIL(len_25); len += len_25; /**/ /*4.4*/
           }
           len += 8; /*0.2*/
@@ -6460,7 +6460,7 @@ size_t Recipes(pdef::Stream &stream, const pdef::proto::Recipes &obj) {
       len += stream.sizeOfVarInt(v2.piece_type.length());
       len += v2.piece_type.length(); /*piece_type: pstring*/ /*4.1*/
       len += 4; /*1.3*/
-      for (const auto &v3 : v2.colors) {
+      for (const auto &v3 : v2.colors) { /*3.2*/
         len += stream.sizeOfVarInt(v3.length());
         len += v3.length(); /*: pstring*/ /*4.1*/
       }
@@ -6473,10 +6473,10 @@ size_t Recipes(pdef::Stream &stream, const pdef::proto::Recipes &obj) {
   }
   size_t PlayerRecords(pdef::Stream &stream, const pdef::proto::PlayerRecords &obj) {
     size_t len = 0;
-    const pdef::proto::PlayerRecords::Type &type = obj.type; /*0.3*/
+    const pdef::proto::PlayerRecords::Type &V_type = obj.type; /*0.3*/
     len += 1; /*type^: u8*/ /*7.0*/
-    const int &records_count = obj.records_count; /*0.1*/
-    switch (type) { /*8.0*/
+    const int &V_records_count = obj.records_count; /*0.1*/
+    switch (V_type) { /*8.0*/
       case pdef::proto::PlayerRecords::Type::Add: { /*8.5*/
         EXPECT_OR_BAIL(obj.records_add); const pdef::proto::PlayerRecords::RecordsAdd &v2 = *obj.records_add; /*8.6*/
           len += 8; /*0.2*/
@@ -6500,10 +6500,10 @@ size_t Recipes(pdef::Stream &stream, const pdef::proto::Recipes &obj) {
       } /*8.7*/
       default: break; /*avoid unhandled case warning*/
     } /*8.8*/
-    switch (type) { /*8.0*/
+    switch (V_type) { /*8.0*/
       case pdef::proto::PlayerRecords::Type::Add: { /*8.5*/
-        len += stream.sizeOfVarInt(records_count); /*1.1*/
-        for (const auto &v4 : obj.verified) {
+        len += stream.sizeOfVarInt(V_records_count); /*1.1*/
+        for (const auto &v4 : obj.verified) { /*3.2*/
           len += 1; /*0.2*/
         }
         break;
@@ -6523,15 +6523,15 @@ size_t Recipes(pdef::Stream &stream, const pdef::proto::Recipes &obj) {
     len += stream.sizeOfVarInt(obj.cost); /*0.2*/
     len += 4; /*0.2*/
     len += stream.sizeOfVarInt(obj.equip_enchants.size()); /*1.3*/
-    for (const auto &v2 : obj.equip_enchants) {
+    for (const auto &v2 : obj.equip_enchants) { /*3.2*/
       size_t len_32 = pdef::proto::size::Enchant(stream, v2); EXPECT_OR_BAIL(len_32); len += len_32; /**/ /*4.4*/
     }
     len += stream.sizeOfVarInt(obj.held_enchants.size()); /*1.3*/
-    for (const auto &v2 : obj.held_enchants) {
+    for (const auto &v2 : obj.held_enchants) { /*3.2*/
       size_t len_33 = pdef::proto::size::Enchant(stream, v2); EXPECT_OR_BAIL(len_33); len += len_33; /**/ /*4.4*/
     }
     len += stream.sizeOfVarInt(obj.self_enchants.size()); /*1.3*/
-    for (const auto &v2 : obj.self_enchants) {
+    for (const auto &v2 : obj.self_enchants) { /*3.2*/
       size_t len_34 = pdef::proto::size::Enchant(stream, v2); EXPECT_OR_BAIL(len_34); len += len_34; /**/ /*4.4*/
     }
     len += stream.sizeOfVarInt(obj.name.length());
@@ -6551,9 +6551,9 @@ size_t Recipes(pdef::Stream &stream, const pdef::proto::Recipes &obj) {
     len += stream.sizeOfZigZagVarInt(obj.request_id); /*0.2*/
     len += stream.sizeOfVarInt(obj.actions.size()); /*1.3*/
     for (const auto &v2 : obj.actions) { /*5.20*/
-      const pdef::proto::ItemStackRequest::Actions::TypeId &type_id = v2.type_id; /*0.3*/
+      const pdef::proto::ItemStackRequest::Actions::TypeId &V_type_id = v2.type_id; /*0.3*/
       len += 1; /*type_id^: u8*/ /*7.0*/
-      switch (type_id) { /*8.0*/
+      switch (V_type_id) { /*8.0*/
         case pdef::proto::ItemStackRequest::Actions::TypeId::Take: { /*8.5*/
             len += 1; /*0.2*/
             EXPECT_OR_BAIL(v2.source); size_t len_35 = pdef::proto::size::StackRequestSlotInfo(stream, *v2.source); EXPECT_OR_BAIL(len_35); len += len_35; /*source*/ /*4.4*/
@@ -6634,7 +6634,7 @@ size_t Recipes(pdef::Stream &stream, const pdef::proto::Recipes &obj) {
         } /*8.7*/
         case pdef::proto::ItemStackRequest::Actions::TypeId::ResultsDeprecated: { /*8.5*/
             len += stream.sizeOfVarInt(v2.result_items.size()); /*1.3*/
-            for (const auto &v6 : v2.result_items) {
+            for (const auto &v6 : v2.result_items) { /*3.2*/
               size_t len_44 = pdef::proto::size::ItemLegacy(stream, v6); EXPECT_OR_BAIL(len_44); len += len_44; /**/ /*4.4*/
             }
             len += 1; /*0.2*/
@@ -6644,7 +6644,7 @@ size_t Recipes(pdef::Stream &stream, const pdef::proto::Recipes &obj) {
       } /*8.8*/
     }
     len += stream.sizeOfVarInt(obj.custom_names.size()); /*1.3*/
-    for (const auto &v2 : obj.custom_names) {
+    for (const auto &v2 : obj.custom_names) { /*3.2*/
       len += stream.sizeOfVarInt(v2.length());
       len += v2.length(); /*: pstring*/ /*4.1*/
     }
@@ -6652,10 +6652,10 @@ size_t Recipes(pdef::Stream &stream, const pdef::proto::Recipes &obj) {
   }
 size_t ItemStackResponses(pdef::Stream &stream, const pdef::proto::ItemStackResponses &obj) {
   size_t len = 0;
-    const pdef::proto::ItemStackResponses::Status &status = obj.status; /*0.3*/
+    const pdef::proto::ItemStackResponses::Status &V_status = obj.status; /*0.3*/
     len += 1; /*status^: u8*/ /*7.0*/
     len += stream.sizeOfZigZagVarInt(obj.request_id); /*0.2*/
-    switch (status) { /*8.0*/
+    switch (V_status) { /*8.0*/
       case pdef::proto::ItemStackResponses::Status::Ok: { /*8.5*/
           len += stream.sizeOfVarInt(obj.containers.size()); /*1.3*/
           for (const auto &v5 : obj.containers) { /*5.20*/
@@ -6686,12 +6686,12 @@ size_t ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentL
 }
   size_t CommandOrigin(pdef::Stream &stream, const pdef::proto::CommandOrigin &obj) {
     size_t len = 0;
-    const pdef::proto::CommandOrigin::Type &type = obj.type; /*0.3*/
+    const pdef::proto::CommandOrigin::Type &V_type = obj.type; /*0.3*/
     len += stream.sizeOfVarInt((int&)obj.type); /*type^: varint*/ /*7.0*/
     len += 8; /*0.2*/
     len += stream.sizeOfVarInt(obj.request_id.length());
     len += obj.request_id.length(); /*request_id: pstring*/ /*4.1*/
-    switch (type) { /*8.0*/
+    switch (V_type) { /*8.0*/
       case pdef::proto::CommandOrigin::Type::DevConsole: { /*8.5*/
         EXPECT_OR_BAIL(obj.player_entity_id); const pdef::proto::CommandOrigin::PlayerEntityId &v2 = *obj.player_entity_id; /*8.6*/
           len += stream.sizeOfZigZagVarLong(v2.player_entity_id); /*0.2*/
@@ -6708,16 +6708,16 @@ size_t ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentL
   }
   size_t TrackedObject(pdef::Stream &stream, const pdef::proto::TrackedObject &obj) {
     size_t len = 0;
-    const pdef::proto::TrackedObject::Type &type = obj.type; /*0.3*/
+    const pdef::proto::TrackedObject::Type &V_type = obj.type; /*0.3*/
     len += 4; /*type^: li32*/ /*7.0*/
-    switch (type) { /*8.0*/
+    switch (V_type) { /*8.0*/
       case pdef::proto::TrackedObject::Type::Entity: { /*8.5*/
         len += stream.sizeOfZigZagVarLong(obj.entity_unique_id); /*0.2*/
         break;
       } /*8.7*/
       default: break; /*avoid unhandled case warning*/
     } /*8.8*/
-    switch (type) { /*8.0*/
+    switch (V_type) { /*8.0*/
       case pdef::proto::TrackedObject::Type::Block: { /*8.5*/
         EXPECT_OR_BAIL(obj.block_position); size_t len_45 = pdef::proto::size::BlockCoordinates(stream, *obj.block_position); EXPECT_OR_BAIL(len_45); len += len_45; /*block_position*/ /*4.4*/
         break;
@@ -6844,7 +6844,7 @@ size_t ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentL
     len += stream.sizeOfVarInt(obj.game_version.length());
     len += obj.game_version.length(); /*game_version: pstring*/ /*4.1*/
     len += 4; /*1.3*/
-    for (const auto &v2 : obj.experiments) {
+    for (const auto &v2 : obj.experiments) { /*3.2*/
       size_t len_54 = pdef::proto::size::Experiment(stream, v2); EXPECT_OR_BAIL(len_54); len += len_54; /**/ /*4.4*/
     }
     len += 1; /*0.2*/
@@ -6854,7 +6854,7 @@ size_t ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentL
     size_t len = 0;
     len += 1; /*response_status: u8*/ /*7.0*/
     len += 2; /*1.3*/
-    for (const auto &v2 : obj.resourcepackids) {
+    for (const auto &v2 : obj.resourcepackids) { /*3.2*/
       len += stream.sizeOfVarInt(v2.length());
       len += v2.length(); /*: pstring*/ /*4.1*/
     }
@@ -6862,10 +6862,10 @@ size_t ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentL
   }
   size_t packet_text(pdef::Stream &stream, const pdef::proto::packet_text &obj) {
     size_t len = 0;
-    const pdef::proto::packet_text::Type &type = obj.type; /*0.3*/
+    const pdef::proto::packet_text::Type &V_type = obj.type; /*0.3*/
     len += 1; /*type^: u8*/ /*7.0*/
     len += 1; /*0.2*/
-    switch (type) { /*8.0*/
+    switch (V_type) { /*8.0*/
       case pdef::proto::packet_text::Type::Chat: { /*8.5*/
           len += stream.sizeOfVarInt(obj.source_name.length());
           len += obj.source_name.length(); /*source_name: pstring*/ /*4.1*/
@@ -6916,7 +6916,7 @@ size_t ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentL
           len += stream.sizeOfVarInt(obj.message.length());
           len += obj.message.length(); /*message: pstring*/ /*4.1*/
           len += stream.sizeOfVarInt(obj.parameters.size()); /*1.3*/
-          for (const auto &v5 : obj.parameters) {
+          for (const auto &v5 : obj.parameters) { /*3.2*/
             len += stream.sizeOfVarInt(v5.length());
             len += v5.length(); /*: pstring*/ /*4.1*/
           }
@@ -6926,7 +6926,7 @@ size_t ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentL
           len += stream.sizeOfVarInt(obj.message.length());
           len += obj.message.length(); /*message: pstring*/ /*4.1*/
           len += stream.sizeOfVarInt(obj.parameters.size()); /*1.3*/
-          for (const auto &v5 : obj.parameters) {
+          for (const auto &v5 : obj.parameters) { /*3.2*/
             len += stream.sizeOfVarInt(v5.length());
             len += v5.length(); /*: pstring*/ /*4.1*/
           }
@@ -6936,7 +6936,7 @@ size_t ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentL
           len += stream.sizeOfVarInt(obj.message.length());
           len += obj.message.length(); /*message: pstring*/ /*4.1*/
           len += stream.sizeOfVarInt(obj.parameters.size()); /*1.3*/
-          for (const auto &v5 : obj.parameters) {
+          for (const auto &v5 : obj.parameters) { /*3.2*/
             len += stream.sizeOfVarInt(v5.length());
             len += v5.length(); /*: pstring*/ /*4.1*/
           }
@@ -6987,11 +6987,11 @@ size_t ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentL
     len += 1; /*0.2*/
     len += 1; /*0.2*/
     len += stream.sizeOfVarInt(obj.gamerules.size()); /*1.3*/
-    for (const auto &v2 : obj.gamerules) {
+    for (const auto &v2 : obj.gamerules) { /*3.2*/
       size_t len_58 = pdef::proto::size::GameRule(stream, v2); EXPECT_OR_BAIL(len_58); len += len_58; /**/ /*4.4*/
     }
     len += 4; /*1.3*/
-    for (const auto &v2 : obj.experiments) {
+    for (const auto &v2 : obj.experiments) { /*3.2*/
       size_t len_59 = pdef::proto::size::Experiment(stream, v2); EXPECT_OR_BAIL(len_59); len += len_59; /**/ /*4.4*/
     }
     len += 1; /*0.2*/
@@ -7064,7 +7064,7 @@ size_t ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentL
     len += stream.sizeOfVarInt(obj.custom_stored_permissions); /*0.2*/
     len += 8; /*0.2*/
     len += stream.sizeOfVarInt(obj.links.size()); /*1.3*/
-    for (const auto &v2 : obj.links) {
+    for (const auto &v2 : obj.links) { /*3.2*/
       size_t len_67 = pdef::proto::size::Link(stream, v2); EXPECT_OR_BAIL(len_67); len += len_67; /**/ /*4.4*/
     }
     len += stream.sizeOfVarInt(obj.device_id.length());
@@ -7088,7 +7088,7 @@ size_t ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentL
     len += stream.sizeOfVarInt(obj.metadata.size()); /*2.4*/
     for (const auto &v : obj.metadata) { size_t len_71 = pdef::proto::size::MetadataDictionary(stream, v); EXPECT_OR_BAIL(len_71); len += len_71; } /*2.5*/
     len += stream.sizeOfVarInt(obj.links.size()); /*1.3*/
-    for (const auto &v2 : obj.links) {
+    for (const auto &v2 : obj.links) { /*3.2*/
       size_t len_72 = pdef::proto::size::Link(stream, v2); EXPECT_OR_BAIL(len_72); len += len_72; /**/ /*4.4*/
     }
     PDEF_SIZE_DBG; return len;
@@ -7131,11 +7131,11 @@ size_t ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentL
     len += 4; /*0.2*/
     len += 4; /*0.2*/
     len += 4; /*0.2*/
-    const pdef::proto::packet_move_player::Mode &mode = obj.mode; /*0.3*/
+    const pdef::proto::packet_move_player::Mode &V_mode = obj.mode; /*0.3*/
     len += 1; /*mode^: u8*/ /*7.0*/
     len += 1; /*0.2*/
     len += stream.sizeOfVarInt(obj.ridden_runtime_id); /*0.2*/
-    switch (mode) { /*8.0*/
+    switch (V_mode) { /*8.0*/
       case pdef::proto::packet_move_player::Mode::Teleport: { /*8.5*/
         EXPECT_OR_BAIL(obj.teleport); const pdef::proto::packet_move_player::Teleport &v2 = *obj.teleport; /*8.6*/
           len += 4; /*cause: li32*/ /*7.0*/
@@ -7256,10 +7256,10 @@ size_t ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentL
   }
   size_t packet_interact(pdef::Stream &stream, const pdef::proto::packet_interact &obj) {
     size_t len = 0;
-    const pdef::proto::packet_interact::ActionId &action_id = obj.action_id; /*0.3*/
+    const pdef::proto::packet_interact::ActionId &V_action_id = obj.action_id; /*0.3*/
     len += 1; /*action_id^: u8*/ /*7.0*/
     len += stream.sizeOfVarInt64(obj.target_entity_id); /*0.2*/
-    switch (action_id) { /*8.0*/
+    switch (V_action_id) { /*8.0*/
       case pdef::proto::packet_interact::ActionId::MouseOverEntity: { /*8.5*/
         EXPECT_OR_BAIL(obj.position); size_t len_92 = pdef::proto::size::vec3f(stream, *obj.position); EXPECT_OR_BAIL(len_92); len += len_92; /*position*/ /*4.4*/
         break;
@@ -7338,10 +7338,10 @@ size_t ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentL
   }
   size_t packet_animate(pdef::Stream &stream, const pdef::proto::packet_animate &obj) {
     size_t len = 0;
-    const pdef::proto::packet_animate::ActionId &action_id = obj.action_id; /*0.3*/
+    const pdef::proto::packet_animate::ActionId &V_action_id = obj.action_id; /*0.3*/
     len += stream.sizeOfZigZagVarInt((int&)obj.action_id); /*action_id^: zigzag32*/ /*7.0*/
     len += stream.sizeOfVarInt64(obj.runtime_entity_id); /*0.2*/
-    switch (action_id) { /*8.0*/
+    switch (V_action_id) { /*8.0*/
       case pdef::proto::packet_animate::ActionId::RowRight: { /*8.5*/
           len += 4; /*0.2*/
         break;
@@ -7386,7 +7386,7 @@ size_t ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentL
     size_t len = 0;
     len += stream.sizeOfVarInt((int&)obj.window_id); /*window_id: varint*/ /*7.0*/
     len += stream.sizeOfVarInt(obj.input.size()); /*1.3*/
-    for (const auto &v2 : obj.input) {
+    for (const auto &v2 : obj.input) { /*3.2*/
       size_t len_103 = pdef::proto::size::Item(stream, v2); EXPECT_OR_BAIL(len_103); len += len_103; /**/ /*4.4*/
     }
     PDEF_SIZE_DBG; return len;
@@ -7414,7 +7414,7 @@ size_t ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentL
     len += stream.sizeOfVarInt(obj.potion_container_recipes.size()); /*2.4*/
     for (const auto &v : obj.potion_container_recipes) { size_t len_107 = pdef::proto::size::PotionContainerChangeRecipes(stream, v); EXPECT_OR_BAIL(len_107); len += len_107; } /*2.5*/
     len += stream.sizeOfVarInt(obj.material_reducers.size()); /*1.3*/
-    for (const auto &v2 : obj.material_reducers) {
+    for (const auto &v2 : obj.material_reducers) { /*3.2*/
       size_t len_108 = pdef::proto::size::MaterialReducer(stream, v2); EXPECT_OR_BAIL(len_108); len += len_108; /**/ /*4.4*/
     }
     len += 1; /*0.2*/
@@ -7426,11 +7426,11 @@ size_t ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentL
     len += stream.sizeOfZigZagVarInt((int&)obj.recipe_type); /*recipe_type: zigzag32*/ /*7.0*/
     len += 8; /*0.2*/
     len += stream.sizeOfVarInt(obj.input.size()); /*1.3*/
-    for (const auto &v2 : obj.input) {
+    for (const auto &v2 : obj.input) { /*3.2*/
       size_t len_109 = pdef::proto::size::Item(stream, v2); EXPECT_OR_BAIL(len_109); len += len_109; /**/ /*4.4*/
     }
     len += stream.sizeOfVarInt(obj.result.size()); /*1.3*/
-    for (const auto &v2 : obj.result) {
+    for (const auto &v2 : obj.result) { /*3.2*/
       size_t len_110 = pdef::proto::size::Item(stream, v2); EXPECT_OR_BAIL(len_110); len += len_110; /**/ /*4.4*/
     }
     PDEF_SIZE_DBG; return len;
@@ -7491,15 +7491,15 @@ size_t ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentL
     size_t len = 0;
     len += stream.sizeOfZigZagVarInt(obj.x); /*0.2*/
     len += stream.sizeOfZigZagVarInt(obj.z); /*0.2*/
-    const int &sub_chunk_count = obj.sub_chunk_count; /*0.1*/
-    if (sub_chunk_count == -2) { /*8.2*/
+    const int &V_sub_chunk_count = obj.sub_chunk_count; /*0.1*/
+    if (V_sub_chunk_count == -2) { /*8.2*/
       len += 2; /*0.2*/
     }
-    const bool &cache_enabled = obj.cache_enabled; /*0.1*/
-    if (cache_enabled == true) { /*8.1*/
+    const bool &V_cache_enabled = obj.cache_enabled; /*0.1*/
+    if (V_cache_enabled == true) { /*8.1*/
         EXPECT_OR_BAIL(obj.blobs); const pdef::proto::packet_level_chunk::Blobs &v2 = *obj.blobs; /*8.6*/
         len += stream.sizeOfVarInt(v2.hashes.size()); /*1.3*/
-        for (const auto &v4 : v2.hashes) {
+        for (const auto &v4 : v2.hashes) { /*3.2*/
           len += 8; /*0.2*/
         }
     }
@@ -7562,37 +7562,37 @@ size_t ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentL
     update_flags_val |= (int)obj.update_flags.decoration << 2;
     update_flags_val |= (int)obj.update_flags.initialisation << 3;
     len += stream.sizeOfVarInt(update_flags_val); /*update_flags^: bitflags*/ /*4.1*/
-    const pdef::proto::packet_clientbound_map_item_data::update_flags_t &update_flags = obj.update_flags; /*4.7*/
+    const pdef::proto::packet_clientbound_map_item_data::update_flags_t &V_update_flags = obj.update_flags; /*4.7*/
     len += 1; /*0.2*/
     len += 1; /*0.2*/
-    if (update_flags.initialisation == true) { /*8.2*/
+    if (V_update_flags.initialisation == true) { /*8.2*/
       len += stream.sizeOfVarInt(obj.included_in.size()); /*1.3*/
-      for (const auto &v3 : obj.included_in) {
+      for (const auto &v3 : obj.included_in) { /*3.2*/
         len += stream.sizeOfZigZagVarLong(v3); /*0.2*/
       }
     }
-    if ((update_flags.initialisation || update_flags.decoration || update_flags.texture) == true) { /*8.2*/
+    if ((V_update_flags.initialisation || V_update_flags.decoration || V_update_flags.texture) == true) { /*8.2*/
       len += 1; /*0.2*/
     }
-    if (update_flags.decoration == true) { /*8.2*/
+    if (V_update_flags.decoration == true) { /*8.2*/
         EXPECT_OR_BAIL(obj.tracked); const pdef::proto::packet_clientbound_map_item_data::Tracked &v2 = *obj.tracked; /*8.6*/
         len += stream.sizeOfVarInt(v2.objects.size()); /*1.3*/
-        for (const auto &v4 : v2.objects) {
+        for (const auto &v4 : v2.objects) { /*3.2*/
           size_t len_115 = pdef::proto::size::TrackedObject(stream, v4); EXPECT_OR_BAIL(len_115); len += len_115; /**/ /*4.4*/
         }
         len += stream.sizeOfVarInt(v2.decorations.size()); /*1.3*/
-        for (const auto &v4 : v2.decorations) {
+        for (const auto &v4 : v2.decorations) { /*3.2*/
           size_t len_116 = pdef::proto::size::MapDecoration(stream, v4); EXPECT_OR_BAIL(len_116); len += len_116; /**/ /*4.4*/
         }
     }
-    if (update_flags.texture == true) { /*8.2*/
+    if (V_update_flags.texture == true) { /*8.2*/
         EXPECT_OR_BAIL(obj.texture); const pdef::proto::packet_clientbound_map_item_data::Texture &v2 = *obj.texture; /*8.6*/
         len += stream.sizeOfZigZagVarInt(v2.width); /*0.2*/
         len += stream.sizeOfZigZagVarInt(v2.height); /*0.2*/
         len += stream.sizeOfZigZagVarInt(v2.x_offset); /*0.2*/
         len += stream.sizeOfZigZagVarInt(v2.y_offset); /*0.2*/
         len += stream.sizeOfVarInt(v2.pixels.size()); /*1.3*/
-        for (const auto &v4 : v2.pixels) {
+        for (const auto &v4 : v2.pixels) { /*3.2*/
           len += stream.sizeOfVarInt(v4); /*0.2*/
         }
     }
@@ -7621,7 +7621,7 @@ size_t ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentL
   size_t packet_game_rules_changed(pdef::Stream &stream, const pdef::proto::packet_game_rules_changed &obj) {
     size_t len = 0;
     len += stream.sizeOfVarInt(obj.rules.size()); /*1.3*/
-    for (const auto &v2 : obj.rules) {
+    for (const auto &v2 : obj.rules) { /*3.2*/
       size_t len_118 = pdef::proto::size::GameRule(stream, v2); EXPECT_OR_BAIL(len_118); len += len_118; /**/ /*4.4*/
     }
     PDEF_SIZE_DBG; return len;
@@ -7635,9 +7635,9 @@ size_t ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentL
   size_t packet_boss_event(pdef::Stream &stream, const pdef::proto::packet_boss_event &obj) {
     size_t len = 0;
     len += stream.sizeOfZigZagVarLong(obj.boss_entity_id); /*0.2*/
-    const pdef::proto::packet_boss_event::Type &type = obj.type; /*0.3*/
+    const pdef::proto::packet_boss_event::Type &V_type = obj.type; /*0.3*/
     len += stream.sizeOfVarInt((int&)obj.type); /*type^: varint*/ /*7.0*/
-    switch (type) { /*8.0*/
+    switch (V_type) { /*8.0*/
       case pdef::proto::packet_boss_event::Type::ShowBar: { /*8.5*/
           len += stream.sizeOfVarInt(obj.title.length());
           len += obj.title.length(); /*title: pstring*/ /*4.1*/
@@ -7691,15 +7691,15 @@ size_t ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentL
   }
   size_t packet_available_commands(pdef::Stream &stream, const pdef::proto::packet_available_commands &obj) {
     size_t len = 0;
-    const int &values_len = obj.values_len; /*0.1*/
-    pdef::proto::packet_available_commands::_EnumType _enum_type; if (values_len <= 0xff) { _enum_type = pdef::proto::packet_available_commands::_EnumType::Byte; } else if (values_len <= 0xffff) { _enum_type = pdef::proto::packet_available_commands::_EnumType::Short; } else { _enum_type = pdef::proto::packet_available_commands::_EnumType::Int; } /*_enum_type^: enum_size_based_on_values_len*/ /*4.1*/
-    len += stream.sizeOfVarInt(values_len); /*1.1*/
-    for (const auto &v2 : obj.enum_values) {
+    const int &V_values_len = obj.values_len; /*0.1*/
+    pdef::proto::packet_available_commands::_EnumType V__enum_type; if (V_values_len <= 0xff) { V__enum_type = pdef::proto::packet_available_commands::_EnumType::Byte; } else if (V_values_len <= 0xffff) { V__enum_type = pdef::proto::packet_available_commands::_EnumType::Short; } else { V__enum_type = pdef::proto::packet_available_commands::_EnumType::Int; } /*_enum_type^: enum_size_based_on_values_len*/ /*4.1*/
+    len += stream.sizeOfVarInt(V_values_len); /*1.1*/
+    for (const auto &v2 : obj.enum_values) { /*3.2*/
       len += stream.sizeOfVarInt(v2.length());
       len += v2.length(); /*: pstring*/ /*4.1*/
     }
     len += stream.sizeOfVarInt(obj.suffixes.size()); /*1.3*/
-    for (const auto &v2 : obj.suffixes) {
+    for (const auto &v2 : obj.suffixes) { /*3.2*/
       len += stream.sizeOfVarInt(v2.length());
       len += v2.length(); /*: pstring*/ /*4.1*/
     }
@@ -7707,13 +7707,13 @@ size_t ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentL
     for (const auto &v2 : obj.enums) { /*5.20*/
       len += stream.sizeOfVarInt(v2.name.length());
       len += v2.name.length(); /*name: pstring*/ /*4.1*/
-      if (_enum_type == pdef::proto::packet_available_commands::_EnumType::Byte) { /*8.5*/
+      if (V__enum_type == pdef::proto::packet_available_commands::_EnumType::Byte) { /*8.5*/
         len += 1; /*0.2*/
       }
-      else if (_enum_type == pdef::proto::packet_available_commands::_EnumType::Short) { /*8.5*/
+      else if (V__enum_type == pdef::proto::packet_available_commands::_EnumType::Short) { /*8.5*/
         len += 2; /*0.2*/
       }
-      else if (_enum_type == pdef::proto::packet_available_commands::_EnumType::Int) { /*8.5*/
+      else if (V__enum_type == pdef::proto::packet_available_commands::_EnumType::Int) { /*8.5*/
         len += 4; /*0.2*/
       }
     }
@@ -7744,7 +7744,7 @@ size_t ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentL
       len += stream.sizeOfVarInt(v2.name.length());
       len += v2.name.length(); /*name: pstring*/ /*4.1*/
       len += stream.sizeOfVarInt(v2.values.size()); /*1.3*/
-      for (const auto &v3 : v2.values) {
+      for (const auto &v3 : v2.values) { /*3.2*/
         len += stream.sizeOfVarInt(v3.length());
         len += v3.length(); /*: pstring*/ /*4.1*/
       }
@@ -7770,14 +7770,14 @@ size_t ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentL
   }
   size_t packet_command_block_update(pdef::Stream &stream, const pdef::proto::packet_command_block_update &obj) {
     size_t len = 0;
-    const bool &is_block = obj.is_block; /*0.1*/
-    if (is_block == true) { /*8.1*/
+    const bool &V_is_block = obj.is_block; /*0.1*/
+    if (V_is_block == true) { /*8.1*/
         EXPECT_OR_BAIL(obj.position); size_t len_120 = pdef::proto::size::BlockCoordinates(stream, *obj.position); EXPECT_OR_BAIL(len_120); len += len_120; /*position*/ /*4.4*/
         len += stream.sizeOfVarInt((int&)obj.mode); /*mode: varint*/ /*7.0*/
         len += 1; /*0.2*/
         len += 1; /*0.2*/
     }
-    else if (is_block == false) { /*8.1*/
+    else if (V_is_block == false) { /*8.1*/
         len += stream.sizeOfVarInt64(obj.minecart_entity_runtime_id); /*0.2*/
     }
     len += stream.sizeOfVarInt(obj.command.length());
@@ -7794,7 +7794,7 @@ size_t ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentL
   size_t packet_command_output(pdef::Stream &stream, const pdef::proto::packet_command_output &obj) {
     size_t len = 0;
     size_t len_121 = pdef::proto::size::CommandOrigin(stream, obj.origin); EXPECT_OR_BAIL(len_121); len += len_121; /*origin*/ /*4.4*/
-    const pdef::proto::packet_command_output::OutputType &output_type = obj.output_type; /*0.3*/
+    const pdef::proto::packet_command_output::OutputType &V_output_type = obj.output_type; /*0.3*/
     len += 1; /*output_type^: i8*/ /*7.0*/
     len += stream.sizeOfVarInt(obj.success_count); /*0.2*/
     len += stream.sizeOfVarInt(obj.output.size()); /*1.3*/
@@ -7803,12 +7803,12 @@ size_t ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentL
       len += stream.sizeOfVarInt(v2.message_id.length());
       len += v2.message_id.length(); /*message_id: pstring*/ /*4.1*/
       len += stream.sizeOfVarInt(v2.parameters.size()); /*1.3*/
-      for (const auto &v3 : v2.parameters) {
+      for (const auto &v3 : v2.parameters) { /*3.2*/
         len += stream.sizeOfVarInt(v3.length());
         len += v3.length(); /*: pstring*/ /*4.1*/
       }
     }
-    switch (output_type) { /*8.0*/
+    switch (V_output_type) { /*8.0*/
       case pdef::proto::packet_command_output::OutputType::DataSet: { /*8.5*/
         len += stream.sizeOfVarInt(obj.data_set.length());
         len += obj.data_set.length(); /*data_set: pstring*/ /*4.1*/
@@ -7940,7 +7940,7 @@ size_t ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentL
   size_t packet_purchase_receipt(pdef::Stream &stream, const pdef::proto::packet_purchase_receipt &obj) {
     size_t len = 0;
     len += stream.sizeOfVarInt(obj.receipts.size()); /*1.3*/
-    for (const auto &v2 : obj.receipts) {
+    for (const auto &v2 : obj.receipts) { /*3.2*/
       len += stream.sizeOfVarInt(v2.length());
       len += v2.length(); /*: pstring*/ /*4.1*/
     }
@@ -7975,10 +7975,10 @@ size_t ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentL
   }
   size_t packet_book_edit(pdef::Stream &stream, const pdef::proto::packet_book_edit &obj) {
     size_t len = 0;
-    const pdef::proto::packet_book_edit::Type &type = obj.type; /*0.3*/
+    const pdef::proto::packet_book_edit::Type &V_type = obj.type; /*0.3*/
     len += 1; /*type^: u8*/ /*7.0*/
     len += 1; /*0.2*/
-    switch (type) { /*8.0*/
+    switch (V_type) { /*8.0*/
       case pdef::proto::packet_book_edit::Type::ReplacePage: { /*8.5*/
           len += 1; /*0.2*/
           len += stream.sizeOfVarInt(obj.text.length());
@@ -8100,7 +8100,7 @@ size_t ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentL
   }
   size_t packet_set_score(pdef::Stream &stream, const pdef::proto::packet_set_score &obj) {
     size_t len = 0;
-    const pdef::proto::packet_set_score::Action &action = obj.action; /*0.3*/
+    const pdef::proto::packet_set_score::Action &V_action = obj.action; /*0.3*/
     len += 1; /*action^: u8*/ /*7.0*/
     len += stream.sizeOfVarInt(obj.entries.size()); /*1.3*/
     for (const auto &v2 : obj.entries) { /*5.20*/
@@ -8108,11 +8108,11 @@ size_t ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentL
       len += stream.sizeOfVarInt(v2.objective_name.length());
       len += v2.objective_name.length(); /*objective_name: pstring*/ /*4.1*/
       len += 4; /*0.2*/
-      switch (action) { /*8.0*/
+      switch (V_action) { /*8.0*/
         case pdef::proto::packet_set_score::Action::Change: { /*8.5*/
-            const pdef::proto::packet_set_score::Entries::EntryType &entry_type = v2.entry_type; /*0.3*/
+            const pdef::proto::packet_set_score::Entries::EntryType &V_entry_type = v2.entry_type; /*0.3*/
             len += 1; /*entry_type^: i8*/ /*7.0*/
-            switch (entry_type) { /*8.0*/
+            switch (V_entry_type) { /*8.0*/
               case pdef::proto::packet_set_score::Entries::EntryType::Player: { /*8.5*/
                 len += stream.sizeOfZigZagVarLong(v2.entity_unique_id); /*0.2*/
                 break;
@@ -8123,7 +8123,7 @@ size_t ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentL
               } /*8.7*/
               default: break; /*avoid unhandled case warning*/
             } /*8.8*/
-            switch (entry_type) { /*8.0*/
+            switch (V_entry_type) { /*8.0*/
               case pdef::proto::packet_set_score::Entries::EntryType::FakePlayer: { /*8.5*/
                 len += stream.sizeOfVarInt(v2.custom_name.length());
                 len += v2.custom_name.length(); /*custom_name: pstring*/ /*4.1*/
@@ -8175,35 +8175,35 @@ size_t ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentL
     if (obj.flags.teleport) flags_val |= 128;
     if (obj.flags.force_move) flags_val |= 256;
     len += 2; /*flags^: bitflags*/ /*4.1*/
-    const pdef::proto::packet_move_entity_delta::flags_t &flags = obj.flags; /*4.7*/
-    if (flags.has_x == true) { /*8.2*/
+    const pdef::proto::packet_move_entity_delta::flags_t &V_flags = obj.flags; /*4.7*/
+    if (V_flags.has_x == true) { /*8.2*/
       len += 4; /*0.2*/
     }
-    if (flags.has_y == true) { /*8.2*/
+    if (V_flags.has_y == true) { /*8.2*/
       len += 4; /*0.2*/
     }
-    if (flags.has_z == true) { /*8.2*/
+    if (V_flags.has_z == true) { /*8.2*/
       len += 4; /*0.2*/
     }
-    if (flags.has_rot_x == true) { /*8.2*/
+    if (V_flags.has_rot_x == true) { /*8.2*/
       len += 1; /*0.2*/
     }
-    if (flags.has_rot_y == true) { /*8.2*/
+    if (V_flags.has_rot_y == true) { /*8.2*/
       len += 1; /*0.2*/
     }
-    if (flags.has_rot_z == true) { /*8.2*/
+    if (V_flags.has_rot_z == true) { /*8.2*/
       len += 1; /*0.2*/
     }
     PDEF_SIZE_DBG; return len;
   }
   size_t packet_set_scoreboard_identity(pdef::Stream &stream, const pdef::proto::packet_set_scoreboard_identity &obj) {
     size_t len = 0;
-    const pdef::proto::packet_set_scoreboard_identity::Action &action = obj.action; /*0.3*/
+    const pdef::proto::packet_set_scoreboard_identity::Action &V_action = obj.action; /*0.3*/
     len += 1; /*action^: i8*/ /*7.0*/
     len += stream.sizeOfVarInt(obj.entries.size()); /*1.3*/
     for (const auto &v2 : obj.entries) { /*5.20*/
       len += stream.sizeOfZigZagVarLong(v2.scoreboard_id); /*0.2*/
-      switch (action) { /*8.0*/
+      switch (V_action) { /*8.0*/
         case pdef::proto::packet_set_scoreboard_identity::Action::RegisterIdentity: { /*8.5*/
           len += stream.sizeOfZigZagVarLong(v2.entity_unique_id); /*0.2*/
           break;
@@ -8223,7 +8223,7 @@ size_t ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentL
     len += stream.sizeOfVarInt(obj.enum_type.length());
     len += obj.enum_type.length(); /*enum_type: pstring*/ /*4.1*/
     len += stream.sizeOfVarInt(obj.options.size()); /*1.3*/
-    for (const auto &v2 : obj.options) {
+    for (const auto &v2 : obj.options) { /*3.2*/
       len += stream.sizeOfVarInt(v2.length());
       len += v2.length(); /*: pstring*/ /*4.1*/
     }
@@ -8356,8 +8356,8 @@ size_t ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentL
     size_t len = 0;
     len += stream.sizeOfVarInt(obj.name.length());
     len += obj.name.length(); /*name: pstring*/ /*4.1*/
-    const bool &success = obj.success; /*0.1*/
-    if (success == true) { /*8.1*/
+    const bool &V_success = obj.success; /*0.1*/
+    if (V_success == true) { /*8.1*/
       len += 1; /*0.2*/
     }
     len += 1; /*response_type: u8*/ /*7.0*/
@@ -8370,14 +8370,14 @@ size_t ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentL
   }
   size_t packet_client_cache_blob_status(pdef::Stream &stream, const pdef::proto::packet_client_cache_blob_status &obj) {
     size_t len = 0;
-    const int &misses = obj.misses; /*0.1*/
-    const int &haves = obj.haves; /*0.1*/
-    len += stream.sizeOfVarInt(misses); /*1.1*/
-    for (const auto &v2 : obj.missing) {
+    const int &V_misses = obj.misses; /*0.1*/
+    const int &V_haves = obj.haves; /*0.1*/
+    len += stream.sizeOfVarInt(V_misses); /*1.1*/
+    for (const auto &v2 : obj.missing) { /*3.2*/
       len += 8; /*0.2*/
     }
-    len += stream.sizeOfVarInt(haves); /*1.1*/
-    for (const auto &v2 : obj.have) {
+    len += stream.sizeOfVarInt(V_haves); /*1.1*/
+    for (const auto &v2 : obj.have) { /*3.2*/
       len += 8; /*0.2*/
     }
     PDEF_SIZE_DBG; return len;
@@ -8385,7 +8385,7 @@ size_t ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentL
   size_t packet_client_cache_miss_response(pdef::Stream &stream, const pdef::proto::packet_client_cache_miss_response &obj) {
     size_t len = 0;
     len += stream.sizeOfVarInt(obj.blobs.size()); /*1.3*/
-    for (const auto &v2 : obj.blobs) {
+    for (const auto &v2 : obj.blobs) { /*3.2*/
       size_t len_135 = pdef::proto::size::Blob(stream, v2); EXPECT_OR_BAIL(len_135); len += len_135; /**/ /*4.4*/
     }
     PDEF_SIZE_DBG; return len;
@@ -8402,20 +8402,20 @@ size_t ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentL
     len += obj.post_process_filter.length(); /*post_process_filter: pstring*/ /*4.1*/
     len += stream.sizeOfVarInt(obj.screenshot_border_path.length());
     len += obj.screenshot_border_path.length(); /*screenshot_border_path: pstring*/ /*4.1*/
-    const bool &has_agent_capabilities = obj.has_agent_capabilities; /*0.1*/
-    if (has_agent_capabilities == true) { /*8.1*/
+    const bool &V_has_agent_capabilities = obj.has_agent_capabilities; /*0.1*/
+    if (V_has_agent_capabilities == true) { /*8.1*/
         EXPECT_OR_BAIL(obj.agent_capabilities); const pdef::proto::packet_education_settings::AgentCapabilities &v2 = *obj.agent_capabilities; /*8.6*/
         len += 1; /*0.2*/
         len += 1; /*0.2*/
     }
-    const bool &HasOverrideURI = obj.HasOverrideURI; /*0.1*/
-    if (HasOverrideURI == true) { /*8.1*/
+    const bool &V_HasOverrideURI = obj.HasOverrideURI; /*0.1*/
+    if (V_HasOverrideURI == true) { /*8.1*/
       len += stream.sizeOfVarInt(obj.OverrideURI.length());
       len += obj.OverrideURI.length(); /*OverrideURI: pstring*/ /*4.1*/
     }
     len += 1; /*0.2*/
-    const bool &has_external_link_settings = obj.has_external_link_settings; /*0.1*/
-    if (has_external_link_settings == true) { /*8.1*/
+    const bool &V_has_external_link_settings = obj.has_external_link_settings; /*0.1*/
+    if (V_has_external_link_settings == true) { /*8.1*/
         EXPECT_OR_BAIL(obj.external_link_settings); const pdef::proto::packet_education_settings::ExternalLinkSettings &v2 = *obj.external_link_settings; /*8.6*/
         len += 1; /*0.2*/
         len += stream.sizeOfVarInt(v2.url.length());
@@ -8508,12 +8508,12 @@ size_t ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentL
     input_data_val |= (int64_t)obj.input_data.block_action << 35;
     input_data_val |= (int64_t)obj.input_data.item_stack_request << 36;
     len += stream.sizeOfVarInt64(input_data_val); /*input_data^: bitflags*/ /*4.1*/
-    const pdef::proto::packet_player_auth_input::input_data_t &input_data = obj.input_data; /*4.7*/
+    const pdef::proto::packet_player_auth_input::input_data_t &V_input_data = obj.input_data; /*4.7*/
     len += stream.sizeOfVarInt((int&)obj.input_mode); /*input_mode: varint*/ /*7.0*/
-    const pdef::proto::packet_player_auth_input::PlayMode &play_mode = obj.play_mode; /*0.3*/
+    const pdef::proto::packet_player_auth_input::PlayMode &V_play_mode = obj.play_mode; /*0.3*/
     len += stream.sizeOfVarInt((int&)obj.play_mode); /*play_mode^: varint*/ /*7.0*/
     len += stream.sizeOfZigZagVarInt((int&)obj.interaction_model); /*interaction_model: zigzag32*/ /*7.0*/
-    switch (play_mode) { /*8.0*/
+    switch (V_play_mode) { /*8.0*/
       case pdef::proto::packet_player_auth_input::PlayMode::Reality: { /*8.5*/
         EXPECT_OR_BAIL(obj.gaze_direction); size_t len_139 = pdef::proto::size::vec3f(stream, *obj.gaze_direction); EXPECT_OR_BAIL(len_139); len += len_139; /*gaze_direction*/ /*4.4*/
         break;
@@ -8522,38 +8522,38 @@ size_t ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentL
     } /*8.8*/
     len += stream.sizeOfVarInt64(obj.tick); /*0.2*/
     size_t len_140 = pdef::proto::size::vec3f(stream, obj.delta); EXPECT_OR_BAIL(len_140); len += len_140; /*delta*/ /*4.4*/
-    if (input_data.item_interact == true) { /*8.2*/
+    if (V_input_data.item_interact == true) { /*8.2*/
         EXPECT_OR_BAIL(obj.transaction); const pdef::proto::packet_player_auth_input::Transaction &v2 = *obj.transaction; /*8.6*/
         size_t len_141 = pdef::proto::size::TransactionLegacy(stream, v2.legacy); EXPECT_OR_BAIL(len_141); len += len_141; /*legacy*/ /*4.4*/
         len += stream.sizeOfVarInt(v2.actions.size()); /*2.4*/
         for (const auto &v : v2.actions) { size_t len_142 = pdef::proto::size::TransactionActions(stream, v); EXPECT_OR_BAIL(len_142); len += len_142; } /*2.5*/
         size_t len_143 = pdef::proto::size::TransactionUseItem(stream, v2.data); EXPECT_OR_BAIL(len_143); len += len_143; /*data*/ /*4.4*/
     }
-    if (input_data.item_stack_request == true) { /*8.2*/
+    if (V_input_data.item_stack_request == true) { /*8.2*/
       EXPECT_OR_BAIL(obj.item_stack_request); size_t len_144 = pdef::proto::size::ItemStackRequest(stream, *obj.item_stack_request); EXPECT_OR_BAIL(len_144); len += len_144; /*item_stack_request*/ /*4.4*/
     }
-    if (input_data.block_action == true) { /*8.2*/
+    if (V_input_data.block_action == true) { /*8.2*/
       len += stream.sizeOfZigZagVarInt(obj.block_action.size()); /*1.3*/
       for (const auto &v3 : obj.block_action) { /*5.20*/
-        const pdef::proto::packet_player_auth_input::BlockAction::Action &action = v3.action; /*0.3*/
+        const pdef::proto::packet_player_auth_input::BlockAction::Action &V_action = v3.action; /*0.3*/
         len += stream.sizeOfZigZagVarInt((int&)v3.action); /*action^: zigzag32*/ /*7.0*/
-        if (action == pdef::proto::packet_player_auth_input::BlockAction::Action::StartBreak) { /*8.5*/
+        if (V_action == pdef::proto::packet_player_auth_input::BlockAction::Action::StartBreak) { /*8.5*/
             EXPECT_OR_BAIL(v3.position); size_t len_145 = pdef::proto::size::vec3i(stream, *v3.position); EXPECT_OR_BAIL(len_145); len += len_145; /*position*/ /*4.4*/
             len += stream.sizeOfZigZagVarInt(v3.face); /*0.2*/
         }
-        else if (action == pdef::proto::packet_player_auth_input::BlockAction::Action::AbortBreak) { /*8.5*/
+        else if (V_action == pdef::proto::packet_player_auth_input::BlockAction::Action::AbortBreak) { /*8.5*/
             EXPECT_OR_BAIL(v3.position); size_t len_146 = pdef::proto::size::vec3i(stream, *v3.position); EXPECT_OR_BAIL(len_146); len += len_146; /*position*/ /*4.4*/
             len += stream.sizeOfZigZagVarInt(v3.face); /*0.2*/
         }
-        else if (action == pdef::proto::packet_player_auth_input::BlockAction::Action::CrackBreak) { /*8.5*/
+        else if (V_action == pdef::proto::packet_player_auth_input::BlockAction::Action::CrackBreak) { /*8.5*/
             EXPECT_OR_BAIL(v3.position); size_t len_147 = pdef::proto::size::vec3i(stream, *v3.position); EXPECT_OR_BAIL(len_147); len += len_147; /*position*/ /*4.4*/
             len += stream.sizeOfZigZagVarInt(v3.face); /*0.2*/
         }
-        else if (action == pdef::proto::packet_player_auth_input::BlockAction::Action::PredictBreak) { /*8.5*/
+        else if (V_action == pdef::proto::packet_player_auth_input::BlockAction::Action::PredictBreak) { /*8.5*/
             EXPECT_OR_BAIL(v3.position); size_t len_148 = pdef::proto::size::vec3i(stream, *v3.position); EXPECT_OR_BAIL(len_148); len += len_148; /*position*/ /*4.4*/
             len += stream.sizeOfZigZagVarInt(v3.face); /*0.2*/
         }
-        else if (action == pdef::proto::packet_player_auth_input::BlockAction::Action::ContinueBreak) { /*8.5*/
+        else if (V_action == pdef::proto::packet_player_auth_input::BlockAction::Action::ContinueBreak) { /*8.5*/
             EXPECT_OR_BAIL(v3.position); size_t len_149 = pdef::proto::size::vec3i(stream, *v3.position); EXPECT_OR_BAIL(len_149); len += len_149; /*position*/ /*4.4*/
             len += stream.sizeOfZigZagVarInt(v3.face); /*0.2*/
         }
@@ -8573,7 +8573,7 @@ size_t ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentL
   size_t packet_player_enchant_options(pdef::Stream &stream, const pdef::proto::packet_player_enchant_options &obj) {
     size_t len = 0;
     len += stream.sizeOfVarInt(obj.options.size()); /*1.3*/
-    for (const auto &v2 : obj.options) {
+    for (const auto &v2 : obj.options) { /*3.2*/
       size_t len_151 = pdef::proto::size::EnchantOption(stream, v2); EXPECT_OR_BAIL(len_151); len += len_151; /**/ /*4.4*/
     }
     PDEF_SIZE_DBG; return len;
@@ -8581,7 +8581,7 @@ size_t ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentL
   size_t packet_item_stack_request(pdef::Stream &stream, const pdef::proto::packet_item_stack_request &obj) {
     size_t len = 0;
     len += stream.sizeOfVarInt(obj.requests.size()); /*1.3*/
-    for (const auto &v2 : obj.requests) {
+    for (const auto &v2 : obj.requests) { /*3.2*/
       size_t len_152 = pdef::proto::size::ItemStackRequest(stream, v2); EXPECT_OR_BAIL(len_152); len += len_152; /**/ /*4.4*/
     }
     PDEF_SIZE_DBG; return len;
@@ -8600,17 +8600,17 @@ size_t ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentL
     if (obj.type.legs) type_val |= 4;
     if (obj.type.feet) type_val |= 8;
     len += 1; /*type^: bitflags*/ /*4.1*/
-    const pdef::proto::packet_player_armor_damage::type_t &type = obj.type; /*4.7*/
-    if (type.head == true) { /*8.2*/
+    const pdef::proto::packet_player_armor_damage::type_t &V_type = obj.type; /*4.7*/
+    if (V_type.head == true) { /*8.2*/
       len += stream.sizeOfZigZagVarInt(obj.helmet_damage); /*0.2*/
     }
-    if (type.chest == true) { /*8.2*/
+    if (V_type.chest == true) { /*8.2*/
       len += stream.sizeOfZigZagVarInt(obj.chestplate_damage); /*0.2*/
     }
-    if (type.legs == true) { /*8.2*/
+    if (V_type.legs == true) { /*8.2*/
       len += stream.sizeOfZigZagVarInt(obj.leggings_damage); /*0.2*/
     }
-    if (type.feet == true) { /*8.2*/
+    if (V_type.feet == true) { /*8.2*/
       len += stream.sizeOfZigZagVarInt(obj.boots_damage); /*0.2*/
     }
     PDEF_SIZE_DBG; return len;
@@ -8625,7 +8625,7 @@ size_t ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentL
     size_t len = 0;
     len += stream.sizeOfVarInt64(obj.player_id); /*0.2*/
     len += stream.sizeOfVarInt(obj.emote_pieces.size()); /*1.3*/
-    for (const auto &v2 : obj.emote_pieces) {
+    for (const auto &v2 : obj.emote_pieces) { /*3.2*/
       len += 8; /*0.2*/
     }
     PDEF_SIZE_DBG; return len;
@@ -8672,7 +8672,7 @@ size_t ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentL
     len += obj.controller.length(); /*controller: pstring*/ /*4.1*/
     len += 4; /*0.2*/
     len += stream.sizeOfVarInt(obj.runtime_entity_ids.size()); /*1.3*/
-    for (const auto &v2 : obj.runtime_entity_ids) {
+    for (const auto &v2 : obj.runtime_entity_ids) { /*3.2*/
       len += stream.sizeOfVarInt64(v2); /*0.2*/
     }
     PDEF_SIZE_DBG; return len;
@@ -8688,7 +8688,7 @@ size_t ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentL
   size_t packet_player_fog(pdef::Stream &stream, const pdef::proto::packet_player_fog &obj) {
     size_t len = 0;
     len += stream.sizeOfVarInt(obj.stack.size()); /*1.3*/
-    for (const auto &v2 : obj.stack) {
+    for (const auto &v2 : obj.stack) { /*3.2*/
       len += stream.sizeOfVarInt(v2.length());
       len += v2.length(); /*: pstring*/ /*4.1*/
     }
@@ -8717,9 +8717,9 @@ size_t ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentL
   }
   size_t packet_debug_renderer(pdef::Stream &stream, const pdef::proto::packet_debug_renderer &obj) {
     size_t len = 0;
-    const pdef::proto::packet_debug_renderer::Type &type = obj.type; /*0.3*/
+    const pdef::proto::packet_debug_renderer::Type &V_type = obj.type; /*0.3*/
     len += 4; /*type^: li32*/ /*7.0*/
-    switch (type) { /*8.0*/
+    switch (V_type) { /*8.0*/
       case pdef::proto::packet_debug_renderer::Type::Clear: { /*8.5*/
         break;
       } /*8.7*/
@@ -8801,11 +8801,11 @@ size_t ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentL
     len += stream.sizeOfZigZagVarInt(obj.y); /*0.2*/
     len += stream.sizeOfZigZagVarInt(obj.z); /*0.2*/
     len += stream.sizeOfVarInt(obj.blocks.size()); /*1.3*/
-    for (const auto &v2 : obj.blocks) {
+    for (const auto &v2 : obj.blocks) { /*3.2*/
       size_t len_160 = pdef::proto::size::BlockUpdate(stream, v2); EXPECT_OR_BAIL(len_160); len += len_160; /**/ /*4.4*/
     }
     len += stream.sizeOfVarInt(obj.extra.size()); /*1.3*/
-    for (const auto &v2 : obj.extra) {
+    for (const auto &v2 : obj.extra) { /*3.2*/
       size_t len_161 = pdef::proto::size::BlockUpdate(stream, v2); EXPECT_OR_BAIL(len_161); len += len_161; /**/ /*4.4*/
     }
     PDEF_SIZE_DBG; return len;
@@ -8823,9 +8823,9 @@ size_t SubChunkEntryWithoutCaching(pdef::Stream &stream, const pdef::proto::SubC
     len += 1; /*result: u8*/ /*7.0*/
     len += stream.sizeOfVarInt(obj.payload.size());
     len += obj.payload.size(); /*payload: buffer*/ /*4.1*/
-    const pdef::proto::SubChunkEntryWithoutCaching::HeightmapType &heightmap_type = obj.heightmap_type; /*0.3*/
+    const pdef::proto::SubChunkEntryWithoutCaching::HeightmapType &V_heightmap_type = obj.heightmap_type; /*0.3*/
     len += 1; /*heightmap_type^: u8*/ /*7.0*/
-    switch (heightmap_type) { /*8.0*/
+    switch (V_heightmap_type) { /*8.0*/
       case pdef::proto::SubChunkEntryWithoutCaching::HeightmapType::HasData: { /*8.5*/
         len += 256; /*heightmap: buffer*/ /*4.1*/
         break;
@@ -8839,9 +8839,9 @@ size_t SubChunkEntryWithCaching(pdef::Stream &stream, const pdef::proto::SubChun
     len += 1; /*0.2*/
     len += 1; /*0.2*/
     len += 1; /*0.2*/
-    const pdef::proto::SubChunkEntryWithCaching::Result &result = obj.result; /*0.3*/
+    const pdef::proto::SubChunkEntryWithCaching::Result &V_result = obj.result; /*0.3*/
     len += 1; /*result^: u8*/ /*7.0*/
-    switch (result) { /*8.0*/
+    switch (V_result) { /*8.0*/
       case pdef::proto::SubChunkEntryWithCaching::Result::SuccessAllAir: { /*8.5*/
         break;
       } /*8.7*/
@@ -8851,9 +8851,9 @@ size_t SubChunkEntryWithCaching(pdef::Stream &stream, const pdef::proto::SubChun
         break;
       } /*8.7*/
     } /*8.8*/
-    const pdef::proto::SubChunkEntryWithCaching::HeightmapType &heightmap_type = obj.heightmap_type; /*0.3*/
+    const pdef::proto::SubChunkEntryWithCaching::HeightmapType &V_heightmap_type = obj.heightmap_type; /*0.3*/
     len += 1; /*heightmap_type^: u8*/ /*7.0*/
-    switch (heightmap_type) { /*8.0*/
+    switch (V_heightmap_type) { /*8.0*/
       case pdef::proto::SubChunkEntryWithCaching::HeightmapType::HasData: { /*8.5*/
         len += 256; /*heightmap: buffer*/ /*4.1*/
         break;
@@ -8865,14 +8865,14 @@ size_t SubChunkEntryWithCaching(pdef::Stream &stream, const pdef::proto::SubChun
 }
   size_t packet_subchunk(pdef::Stream &stream, const pdef::proto::packet_subchunk &obj) {
     size_t len = 0;
-    const bool &cache_enabled = obj.cache_enabled; /*0.1*/
+    const bool &V_cache_enabled = obj.cache_enabled; /*0.1*/
     len += stream.sizeOfZigZagVarInt(obj.dimension); /*0.2*/
     size_t len_162 = pdef::proto::size::vec3i(stream, obj.origin); EXPECT_OR_BAIL(len_162); len += len_162; /*origin*/ /*4.4*/
-    if (cache_enabled == true) { /*8.1*/
+    if (V_cache_enabled == true) { /*8.1*/
       len += 4; /*2.4*/
       for (const auto &v : obj.entries_SubChunkEntryWithCaching) { size_t len_163 = pdef::proto::size::SubChunkEntryWithCaching(stream, v); EXPECT_OR_BAIL(len_163); len += len_163; } /*2.5*/
     }
-    else if (cache_enabled == false) { /*8.1*/
+    else if (V_cache_enabled == false) { /*8.1*/
       len += 4; /*2.4*/
       for (const auto &v : obj.entries_SubChunkEntryWithoutCaching) { size_t len_164 = pdef::proto::size::SubChunkEntryWithoutCaching(stream, v); EXPECT_OR_BAIL(len_164); len += len_164; } /*2.5*/
     }
@@ -8993,9 +8993,9 @@ size_t SubChunkEntryWithCaching(pdef::Stream &stream, const pdef::proto::SubChun
   }
   size_t mcpe_packet(pdef::Stream &stream, const pdef::proto::mcpe_packet &obj) {
     size_t len = 0;
-    const pdef::proto::mcpe_packet::Name &name = obj.name; /*0.3*/
+    const pdef::proto::mcpe_packet::Name &V_name = obj.name; /*0.3*/
     len += stream.sizeOfVarInt((int&)obj.name); /*name^: varint*/ /*7.0*/
-    switch (name) { /*8.0*/
+    switch (V_name) { /*8.0*/
       case pdef::proto::mcpe_packet::Name::Login: { /*8.5*/
         EXPECT_OR_BAIL(obj.params_packet_login); size_t len_166 = pdef::proto::size::packet_login(stream, *obj.params_packet_login); EXPECT_OR_BAIL(len_166); len += len_166; /*params_packet_login*/ /*4.4*/
         break;
@@ -10014,9 +10014,9 @@ bool ResourcePackIdVersions(pdef::Stream &stream, const pdef::proto::ResourcePac
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.name.length());
     WRITE_OR_BAIL(writeString, obj.name); /*name: pstring*/ /*4.2*/
     WRITE_OR_BAIL(writeBool, (bool)obj.editable); /*0.4*/
-    const pdef::proto::GameRule::Type &type = obj.type; /*0.3*/
+    const pdef::proto::GameRule::Type &V_type = obj.type; /*0.3*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)(int&)obj.type); /*7.1*/
-    switch (type) { /*8.0*/
+    switch (V_type) { /*8.0*/
       case pdef::proto::GameRule::Type::Bool: { /*8.5*/
         WRITE_OR_BAIL(writeBool, (bool)obj.value_bool); /*0.4*/
         break;
@@ -10057,9 +10057,9 @@ bool Itemstates(pdef::Stream &stream, const pdef::proto::Itemstates &obj, bool a
 }
   bool ItemExtraDataWithBlockingTick(pdef::Stream &stream, const pdef::proto::ItemExtraDataWithBlockingTick &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::proto::size::ItemExtraDataWithBlockingTick(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const pdef::proto::ItemExtraDataWithBlockingTick::HasNbt &has_nbt = obj.has_nbt; /*0.3*/
+    const pdef::proto::ItemExtraDataWithBlockingTick::HasNbt &V_has_nbt = obj.has_nbt; /*0.3*/
     WRITE_OR_BAIL(writeUShortLE, (uint16_t)(uint16_t&)obj.has_nbt); /*7.1*/
-    switch (has_nbt) { /*8.0*/
+    switch (V_has_nbt) { /*8.0*/
       case pdef::proto::ItemExtraDataWithBlockingTick::HasNbt::True: { /*8.5*/
         const pdef::proto::ItemExtraDataWithBlockingTick::Nbt &v2 = *obj.nbt; /*8.5*/
           WRITE_OR_BAIL(writeUByte, (uint8_t)v2.version); /*0.4*/
@@ -10083,9 +10083,9 @@ bool Itemstates(pdef::Stream &stream, const pdef::proto::Itemstates &obj, bool a
   }
   bool ItemExtraDataWithoutBlockingTick(pdef::Stream &stream, const pdef::proto::ItemExtraDataWithoutBlockingTick &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::proto::size::ItemExtraDataWithoutBlockingTick(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const pdef::proto::ItemExtraDataWithoutBlockingTick::HasNbt &has_nbt = obj.has_nbt; /*0.3*/
+    const pdef::proto::ItemExtraDataWithoutBlockingTick::HasNbt &V_has_nbt = obj.has_nbt; /*0.3*/
     WRITE_OR_BAIL(writeUShortLE, (uint16_t)(uint16_t&)obj.has_nbt); /*7.1*/
-    switch (has_nbt) { /*8.0*/
+    switch (V_has_nbt) { /*8.0*/
       case pdef::proto::ItemExtraDataWithoutBlockingTick::HasNbt::True: { /*8.5*/
         const pdef::proto::ItemExtraDataWithoutBlockingTick::Nbt &v2 = *obj.nbt; /*8.5*/
           WRITE_OR_BAIL(writeUByte, (uint8_t)v2.version); /*0.4*/
@@ -10108,15 +10108,15 @@ bool Itemstates(pdef::Stream &stream, const pdef::proto::Itemstates &obj, bool a
   }
   bool ItemLegacy(pdef::Stream &stream, const pdef::proto::ItemLegacy &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::proto::size::ItemLegacy(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const int &network_id = obj.network_id; /*0.1*/
+    const int &V_network_id = obj.network_id; /*0.1*/
     WRITE_OR_BAIL(writeZigZagVarInt, (int)obj.network_id); /*0.4*/
-    if (network_id == 0) { /*8.2*/
+    if (V_network_id == 0) { /*8.2*/
     }
     else {
         WRITE_OR_BAIL(writeUShortLE, (uint16_t)obj.count); /*0.4*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.metadata); /*0.4*/
         WRITE_OR_BAIL(writeZigZagVarInt, (int)obj.block_runtime_id); /*0.4*/
-        if (network_id == pdef::proto::ShieldItemID) { /*8.4*/
+        if (V_network_id == pdef::proto::ShieldItemID) { /*8.4*/
           WRITE_OR_BAIL(writeByte, (int8_t)obj.extra__ShieldItemID); /*0.4*/
         }
         else {
@@ -10127,22 +10127,22 @@ bool Itemstates(pdef::Stream &stream, const pdef::proto::Itemstates &obj, bool a
   }
   bool Item(pdef::Stream &stream, const pdef::proto::Item &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::proto::size::Item(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const int &network_id = obj.network_id; /*0.1*/
+    const int &V_network_id = obj.network_id; /*0.1*/
     WRITE_OR_BAIL(writeZigZagVarInt, (int)obj.network_id); /*0.4*/
-    if (network_id == 0) { /*8.2*/
+    if (V_network_id == 0) { /*8.2*/
     }
     else {
         WRITE_OR_BAIL(writeUShortLE, (uint16_t)obj.count); /*0.4*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.metadata); /*0.4*/
-        const uint8_t &has_stack_id = obj.has_stack_id; /*0.1*/
+        const uint8_t &V_has_stack_id = obj.has_stack_id; /*0.1*/
         WRITE_OR_BAIL(writeUByte, (uint8_t)obj.has_stack_id); /*0.4*/
-        if (has_stack_id == 0) { /*8.2*/
+        if (V_has_stack_id == 0) { /*8.2*/
         }
         else {
           WRITE_OR_BAIL(writeZigZagVarInt, (int)obj.stack_id); /*0.4*/
         }
         WRITE_OR_BAIL(writeZigZagVarInt, (int)obj.block_runtime_id); /*0.4*/
-        if (network_id == pdef::proto::ShieldItemID) { /*8.4*/
+        if (V_network_id == pdef::proto::ShieldItemID) { /*8.4*/
           WRITE_OR_BAIL(writeByte, (int8_t)obj.extra__ShieldItemID); /*0.4*/
         }
         else {
@@ -10180,11 +10180,11 @@ bool Itemstates(pdef::Stream &stream, const pdef::proto::Itemstates &obj, bool a
   }
 bool MetadataDictionary(pdef::Stream &stream, const pdef::proto::MetadataDictionary &obj, bool allocate = true) {
   if (allocate) { auto writeSize = pdef::proto::size::MetadataDictionary(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const pdef::proto::MetadataDictionary::Key &key = obj.key; /*0.3*/
+    const pdef::proto::MetadataDictionary::Key &V_key = obj.key; /*0.3*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)(int&)obj.key); /*7.1*/
-    const pdef::proto::MetadataDictionary::Type &type = obj.type; /*0.3*/
+    const pdef::proto::MetadataDictionary::Type &V_type = obj.type; /*0.3*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)(int&)obj.type); /*7.1*/
-    switch (key) { /*8.0*/
+    switch (V_key) { /*8.0*/
       case pdef::proto::MetadataDictionary::Key::Flags: { /*8.5*/
         int64_t value_MetadataFlags1_val = 0;
         value_MetadataFlags1_val |= (int64_t)obj.value_MetadataFlags1.onfire << 0;
@@ -10302,7 +10302,7 @@ bool MetadataDictionary(pdef::Stream &stream, const pdef::proto::MetadataDiction
         break;
       } /*8.7*/
       default: { /*8.3*/
-        switch (type) { /*8.0*/
+        switch (V_type) { /*8.0*/
           case pdef::proto::MetadataDictionary::Type::Byte: { /*8.5*/
             WRITE_OR_BAIL(writeByte, (int8_t)obj.value_i8); /*0.4*/
             break;
@@ -10403,9 +10403,9 @@ bool PlayerAttributes(pdef::Stream &stream, const pdef::proto::PlayerAttributes 
   }
 bool TransactionActions(pdef::Stream &stream, const pdef::proto::TransactionActions &obj, bool allocate = true) {
   if (allocate) { auto writeSize = pdef::proto::size::TransactionActions(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const pdef::proto::TransactionActions::SourceType &source_type = obj.source_type; /*0.3*/
+    const pdef::proto::TransactionActions::SourceType &V_source_type = obj.source_type; /*0.3*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)(int&)obj.source_type); /*7.1*/
-    switch (source_type) { /*8.0*/
+    switch (V_source_type) { /*8.0*/
       case pdef::proto::TransactionActions::SourceType::Container: { /*8.5*/
           WRITE_OR_BAIL(writeUnsignedVarInt, (int)(int&)obj.inventory_id); /*7.1*/
         break;
@@ -10431,9 +10431,9 @@ bool TransactionActions(pdef::Stream &stream, const pdef::proto::TransactionActi
 }
   bool TransactionLegacy(pdef::Stream &stream, const pdef::proto::TransactionLegacy &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::proto::size::TransactionLegacy(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const int &legacy_request_id = obj.legacy_request_id; /*0.1*/
+    const int &V_legacy_request_id = obj.legacy_request_id; /*0.1*/
     WRITE_OR_BAIL(writeZigZagVarInt, (int)obj.legacy_request_id); /*0.4*/
-    if (legacy_request_id == 0) { /*8.2*/
+    if (V_legacy_request_id == 0) { /*8.2*/
     }
     else {
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.legacy_transactions.size()); /*1.4*/
@@ -10450,11 +10450,11 @@ bool TransactionActions(pdef::Stream &stream, const pdef::proto::TransactionActi
   bool Transaction(pdef::Stream &stream, const pdef::proto::Transaction &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::proto::size::Transaction(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
     pdef::proto::encode::TransactionLegacy(stream, obj.legacy); /*TransactionLegacy*/ /*4.5*/
-    const pdef::proto::Transaction::TransactionType &transaction_type = obj.transaction_type; /*0.3*/
+    const pdef::proto::Transaction::TransactionType &V_transaction_type = obj.transaction_type; /*0.3*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)(int&)obj.transaction_type); /*7.1*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.actions.size()); /*2.1*/
     for (const auto &v : obj.actions) { pdef::proto::encode::TransactionActions(stream, v); } /*2.2*/
-    switch (transaction_type) { /*8.0*/
+    switch (V_transaction_type) { /*8.0*/
       case pdef::proto::Transaction::TransactionType::Normal: { /*8.5*/
         break;
       } /*8.7*/
@@ -10489,9 +10489,9 @@ bool TransactionActions(pdef::Stream &stream, const pdef::proto::TransactionActi
   }
   bool RecipeIngredient(pdef::Stream &stream, const pdef::proto::RecipeIngredient &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::proto::size::RecipeIngredient(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const int &network_id = obj.network_id; /*0.1*/
+    const int &V_network_id = obj.network_id; /*0.1*/
     WRITE_OR_BAIL(writeZigZagVarInt, (int)obj.network_id); /*0.4*/
-    if (network_id == 0) { /*8.2*/
+    if (V_network_id == 0) { /*8.2*/
     }
     else {
         WRITE_OR_BAIL(writeZigZagVarInt, (int)obj.network_data); /*0.4*/
@@ -10518,9 +10518,9 @@ bool PotionContainerChangeRecipes(pdef::Stream &stream, const pdef::proto::Potio
 }
 bool Recipes(pdef::Stream &stream, const pdef::proto::Recipes &obj, bool allocate = true) {
   if (allocate) { auto writeSize = pdef::proto::size::Recipes(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const pdef::proto::Recipes::Type &type = obj.type; /*0.3*/
+    const pdef::proto::Recipes::Type &V_type = obj.type; /*0.3*/
     WRITE_OR_BAIL(writeZigZagVarInt, (int)(int&)obj.type); /*7.1*/
-    switch (type) { /*8.0*/
+    switch (V_type) { /*8.0*/
       case pdef::proto::Recipes::Type::Shapeless: { /*8.5*/
         const pdef::proto::Recipes::RecipeShapelessOrShulkerBoxOrShapelessChemistry &v2 = *obj.recipe_shapeless_or_shulker_box_or_shapeless_chemistry; /*8.5*/
           WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.recipe_id.length());
@@ -10582,12 +10582,12 @@ bool Recipes(pdef::Stream &stream, const pdef::proto::Recipes &obj, bool allocat
         const pdef::proto::Recipes::RecipeShapedOrShapedChemistry &v2 = *obj.recipe_shaped_or_shaped_chemistry; /*8.5*/
           WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.recipe_id.length());
           WRITE_OR_BAIL(writeString, v2.recipe_id); /*recipe_id: pstring*/ /*4.2*/
-          const int &width = v2.width; /*0.1*/
+          const int &V_width = v2.width; /*0.1*/
           WRITE_OR_BAIL(writeZigZagVarInt, (int)v2.width); /*0.4*/
-          const int &height = v2.height; /*0.1*/
+          const int &V_height = v2.height; /*0.1*/
           WRITE_OR_BAIL(writeZigZagVarInt, (int)v2.height); /*0.4*/
           for (const auto &v : v2.input) { /*5.1*/
-            WRITE_OR_BAIL(writeZigZagVarInt, (int)height); /*5.4*/
+            WRITE_OR_BAIL(writeZigZagVarInt, (int)V_height); /*5.4*/
             for (const auto &v : v) { /*5.10*/
               pdef::proto::encode::RecipeIngredient(stream, v); /*RecipeIngredient*/ /*4.5*/
             }
@@ -10607,12 +10607,12 @@ bool Recipes(pdef::Stream &stream, const pdef::proto::Recipes &obj, bool allocat
         const pdef::proto::Recipes::RecipeShapedOrShapedChemistry &v2 = *obj.recipe_shaped_or_shaped_chemistry; /*8.5*/
           WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.recipe_id.length());
           WRITE_OR_BAIL(writeString, v2.recipe_id); /*recipe_id: pstring*/ /*4.2*/
-          const int &width = v2.width; /*0.1*/
+          const int &V_width = v2.width; /*0.1*/
           WRITE_OR_BAIL(writeZigZagVarInt, (int)v2.width); /*0.4*/
-          const int &height = v2.height; /*0.1*/
+          const int &V_height = v2.height; /*0.1*/
           WRITE_OR_BAIL(writeZigZagVarInt, (int)v2.height); /*0.4*/
           for (const auto &v : v2.input) { /*5.1*/
-            WRITE_OR_BAIL(writeZigZagVarInt, (int)height); /*5.4*/
+            WRITE_OR_BAIL(writeZigZagVarInt, (int)V_height); /*5.4*/
             for (const auto &v : v) { /*5.10*/
               pdef::proto::encode::RecipeIngredient(stream, v); /*RecipeIngredient*/ /*4.5*/
             }
@@ -10724,11 +10724,11 @@ bool Recipes(pdef::Stream &stream, const pdef::proto::Recipes &obj, bool allocat
   }
   bool PlayerRecords(pdef::Stream &stream, const pdef::proto::PlayerRecords &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::proto::size::PlayerRecords(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const pdef::proto::PlayerRecords::Type &type = obj.type; /*0.3*/
+    const pdef::proto::PlayerRecords::Type &V_type = obj.type; /*0.3*/
     WRITE_OR_BAIL(writeUByte, (uint8_t)(uint8_t&)obj.type); /*7.1*/
-    const int &records_count = obj.records_count; /*0.1*/
+    const int &V_records_count = obj.records_count; /*0.1*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.records_count); /*0.4*/
-    switch (type) { /*8.0*/
+    switch (V_type) { /*8.0*/
       case pdef::proto::PlayerRecords::Type::Add: { /*8.5*/
         const pdef::proto::PlayerRecords::RecordsAdd &v2 = *obj.records_add; /*8.5*/
           WRITE_OR_BAIL(writeULongBE, (uint64_t)v2.uuid); /*0.4*/
@@ -10752,7 +10752,7 @@ bool Recipes(pdef::Stream &stream, const pdef::proto::Recipes &obj, bool allocat
       } /*8.7*/
       default: break; /*avoid unhandled case warning*/
     } /*8.8*/
-    switch (type) { /*8.0*/
+    switch (V_type) { /*8.0*/
       case pdef::proto::PlayerRecords::Type::Add: { /*8.5*/
         for (const auto &v4 : obj.verified) { /*3.1*/
           WRITE_OR_BAIL(writeBool, (bool)v4); /*0.4*/
@@ -10802,9 +10802,9 @@ bool Recipes(pdef::Stream &stream, const pdef::proto::Recipes &obj, bool allocat
     WRITE_OR_BAIL(writeZigZagVarInt, (int)obj.request_id); /*0.4*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.actions.size()); /*1.4*/
     for (const auto &v2 : obj.actions) { /*5.20*/
-      const pdef::proto::ItemStackRequest::Actions::TypeId &type_id = v2.type_id; /*0.3*/
+      const pdef::proto::ItemStackRequest::Actions::TypeId &V_type_id = v2.type_id; /*0.3*/
       WRITE_OR_BAIL(writeUByte, (uint8_t)(uint8_t&)v2.type_id); /*7.1*/
-      switch (type_id) { /*8.0*/
+      switch (V_type_id) { /*8.0*/
         case pdef::proto::ItemStackRequest::Actions::TypeId::Take: { /*8.5*/
             WRITE_OR_BAIL(writeUByte, (uint8_t)v2.count); /*0.4*/
             pdef::proto::encode::StackRequestSlotInfo(stream, *v2.source); /*StackRequestSlotInfo*/ /*4.5*/
@@ -10903,10 +10903,10 @@ bool Recipes(pdef::Stream &stream, const pdef::proto::Recipes &obj, bool allocat
   }
 bool ItemStackResponses(pdef::Stream &stream, const pdef::proto::ItemStackResponses &obj, bool allocate = true) {
   if (allocate) { auto writeSize = pdef::proto::size::ItemStackResponses(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const pdef::proto::ItemStackResponses::Status &status = obj.status; /*0.3*/
+    const pdef::proto::ItemStackResponses::Status &V_status = obj.status; /*0.3*/
     WRITE_OR_BAIL(writeUByte, (uint8_t)(uint8_t&)obj.status); /*7.1*/
     WRITE_OR_BAIL(writeZigZagVarInt, (int)obj.request_id); /*0.4*/
-    switch (status) { /*8.0*/
+    switch (V_status) { /*8.0*/
       case pdef::proto::ItemStackResponses::Status::Ok: { /*8.5*/
           WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.containers.size()); /*1.4*/
           for (const auto &v5 : obj.containers) { /*5.20*/
@@ -10937,12 +10937,12 @@ bool ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentLis
 }
   bool CommandOrigin(pdef::Stream &stream, const pdef::proto::CommandOrigin &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::proto::size::CommandOrigin(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const pdef::proto::CommandOrigin::Type &type = obj.type; /*0.3*/
+    const pdef::proto::CommandOrigin::Type &V_type = obj.type; /*0.3*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)(int&)obj.type); /*7.1*/
     WRITE_OR_BAIL(writeULongBE, (uint64_t)obj.uuid); /*0.4*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.request_id.length());
     WRITE_OR_BAIL(writeString, obj.request_id); /*request_id: pstring*/ /*4.2*/
-    switch (type) { /*8.0*/
+    switch (V_type) { /*8.0*/
       case pdef::proto::CommandOrigin::Type::DevConsole: { /*8.5*/
         const pdef::proto::CommandOrigin::PlayerEntityId &v2 = *obj.player_entity_id; /*8.5*/
           WRITE_OR_BAIL(writeZigZagVarLong, (int64_t)v2.player_entity_id); /*0.4*/
@@ -10959,16 +10959,16 @@ bool ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentLis
   }
   bool TrackedObject(pdef::Stream &stream, const pdef::proto::TrackedObject &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::proto::size::TrackedObject(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const pdef::proto::TrackedObject::Type &type = obj.type; /*0.3*/
+    const pdef::proto::TrackedObject::Type &V_type = obj.type; /*0.3*/
     WRITE_OR_BAIL(writeIntLE, (int32_t)(int32_t&)obj.type); /*7.1*/
-    switch (type) { /*8.0*/
+    switch (V_type) { /*8.0*/
       case pdef::proto::TrackedObject::Type::Entity: { /*8.5*/
         WRITE_OR_BAIL(writeZigZagVarLong, (int64_t)obj.entity_unique_id); /*0.4*/
         break;
       } /*8.7*/
       default: break; /*avoid unhandled case warning*/
     } /*8.8*/
-    switch (type) { /*8.0*/
+    switch (V_type) { /*8.0*/
       case pdef::proto::TrackedObject::Type::Block: { /*8.5*/
         pdef::proto::encode::BlockCoordinates(stream, *obj.block_position); /*BlockCoordinates*/ /*4.5*/
         break;
@@ -11113,10 +11113,10 @@ bool ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentLis
   }
   bool packet_text(pdef::Stream &stream, const pdef::proto::packet_text &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::proto::size::packet_text(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const pdef::proto::packet_text::Type &type = obj.type; /*0.3*/
+    const pdef::proto::packet_text::Type &V_type = obj.type; /*0.3*/
     WRITE_OR_BAIL(writeUByte, (uint8_t)(uint8_t&)obj.type); /*7.1*/
     WRITE_OR_BAIL(writeBool, (bool)obj.needs_translation); /*0.4*/
-    switch (type) { /*8.0*/
+    switch (V_type) { /*8.0*/
       case pdef::proto::packet_text::Type::Chat: { /*8.5*/
           WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.source_name.length());
           WRITE_OR_BAIL(writeString, obj.source_name); /*source_name: pstring*/ /*4.2*/
@@ -11382,11 +11382,11 @@ bool ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentLis
     WRITE_OR_BAIL(writeFloatLE, (float)obj.pitch); /*0.4*/
     WRITE_OR_BAIL(writeFloatLE, (float)obj.yaw); /*0.4*/
     WRITE_OR_BAIL(writeFloatLE, (float)obj.head_yaw); /*0.4*/
-    const pdef::proto::packet_move_player::Mode &mode = obj.mode; /*0.3*/
+    const pdef::proto::packet_move_player::Mode &V_mode = obj.mode; /*0.3*/
     WRITE_OR_BAIL(writeUByte, (uint8_t)(uint8_t&)obj.mode); /*7.1*/
     WRITE_OR_BAIL(writeBool, (bool)obj.on_ground); /*0.4*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.ridden_runtime_id); /*0.4*/
-    switch (mode) { /*8.0*/
+    switch (V_mode) { /*8.0*/
       case pdef::proto::packet_move_player::Mode::Teleport: { /*8.5*/
         const pdef::proto::packet_move_player::Teleport &v2 = *obj.teleport; /*8.5*/
           WRITE_OR_BAIL(writeIntLE, (int32_t)(int32_t&)v2.cause); /*7.1*/
@@ -11507,10 +11507,10 @@ bool ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentLis
   }
   bool packet_interact(pdef::Stream &stream, const pdef::proto::packet_interact &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::proto::size::packet_interact(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const pdef::proto::packet_interact::ActionId &action_id = obj.action_id; /*0.3*/
+    const pdef::proto::packet_interact::ActionId &V_action_id = obj.action_id; /*0.3*/
     WRITE_OR_BAIL(writeUByte, (uint8_t)(uint8_t&)obj.action_id); /*7.1*/
     WRITE_OR_BAIL(writeUnsignedVarLong, (int64_t)obj.target_entity_id); /*0.4*/
-    switch (action_id) { /*8.0*/
+    switch (V_action_id) { /*8.0*/
       case pdef::proto::packet_interact::ActionId::MouseOverEntity: { /*8.5*/
         pdef::proto::encode::vec3f(stream, *obj.position); /*vec3f*/ /*4.5*/
         break;
@@ -11589,10 +11589,10 @@ bool ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentLis
   }
   bool packet_animate(pdef::Stream &stream, const pdef::proto::packet_animate &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::proto::size::packet_animate(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const pdef::proto::packet_animate::ActionId &action_id = obj.action_id; /*0.3*/
+    const pdef::proto::packet_animate::ActionId &V_action_id = obj.action_id; /*0.3*/
     WRITE_OR_BAIL(writeZigZagVarInt, (int)(int&)obj.action_id); /*7.1*/
     WRITE_OR_BAIL(writeUnsignedVarLong, (int64_t)obj.runtime_entity_id); /*0.4*/
-    switch (action_id) { /*8.0*/
+    switch (V_action_id) { /*8.0*/
       case pdef::proto::packet_animate::ActionId::RowRight: { /*8.5*/
           WRITE_OR_BAIL(writeFloatLE, (float)obj.boat_rowing_time); /*0.4*/
         break;
@@ -11742,14 +11742,14 @@ bool ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentLis
     if (allocate) { auto writeSize = pdef::proto::size::packet_level_chunk(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
     WRITE_OR_BAIL(writeZigZagVarInt, (int)obj.x); /*0.4*/
     WRITE_OR_BAIL(writeZigZagVarInt, (int)obj.z); /*0.4*/
-    const int &sub_chunk_count = obj.sub_chunk_count; /*0.1*/
+    const int &V_sub_chunk_count = obj.sub_chunk_count; /*0.1*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.sub_chunk_count); /*0.4*/
-    if (sub_chunk_count == -2) { /*8.2*/
+    if (V_sub_chunk_count == -2) { /*8.2*/
       WRITE_OR_BAIL(writeUShortLE, (uint16_t)obj.highest_subchunk_count); /*0.4*/
     }
-    const bool &cache_enabled = obj.cache_enabled; /*0.1*/
+    const bool &V_cache_enabled = obj.cache_enabled; /*0.1*/
     WRITE_OR_BAIL(writeBool, (bool)obj.cache_enabled); /*0.4*/
-    if (cache_enabled == true) { /*8.1*/
+    if (V_cache_enabled == true) { /*8.1*/
         const pdef::proto::packet_level_chunk::Blobs &v2 = *obj.blobs; /*8.5*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.hashes.size()); /*1.4*/
         for (const auto &v4 : v2.hashes) { /*3.1*/
@@ -11815,19 +11815,19 @@ bool ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentLis
     update_flags_val |= (int)obj.update_flags.decoration << 2;
     update_flags_val |= (int)obj.update_flags.initialisation << 3;
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)update_flags_val) /*update_flags: bitflags*/ /*4.2*/
-    const pdef::proto::packet_clientbound_map_item_data::update_flags_t &update_flags = obj.update_flags; /*4.7*/
+    const pdef::proto::packet_clientbound_map_item_data::update_flags_t &V_update_flags = obj.update_flags; /*4.7*/
     WRITE_OR_BAIL(writeUByte, (uint8_t)obj.dimension); /*0.4*/
     WRITE_OR_BAIL(writeBool, (bool)obj.locked); /*0.4*/
-    if (update_flags.initialisation == true) { /*8.2*/
+    if (V_update_flags.initialisation == true) { /*8.2*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.included_in.size()); /*1.4*/
       for (const auto &v3 : obj.included_in) { /*3.1*/
         WRITE_OR_BAIL(writeZigZagVarLong, (int64_t)v3); /*0.4*/
       }
     }
-    if ((update_flags.initialisation || update_flags.decoration || update_flags.texture) == true) { /*8.2*/
+    if ((V_update_flags.initialisation || V_update_flags.decoration || V_update_flags.texture) == true) { /*8.2*/
       WRITE_OR_BAIL(writeUByte, (uint8_t)obj.scale); /*0.4*/
     }
-    if (update_flags.decoration == true) { /*8.2*/
+    if (V_update_flags.decoration == true) { /*8.2*/
         const pdef::proto::packet_clientbound_map_item_data::Tracked &v2 = *obj.tracked; /*8.5*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.objects.size()); /*1.4*/
         for (const auto &v4 : v2.objects) { /*3.1*/
@@ -11838,7 +11838,7 @@ bool ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentLis
           pdef::proto::encode::MapDecoration(stream, v4); /*MapDecoration*/ /*4.5*/
         }
     }
-    if (update_flags.texture == true) { /*8.2*/
+    if (V_update_flags.texture == true) { /*8.2*/
         const pdef::proto::packet_clientbound_map_item_data::Texture &v2 = *obj.texture; /*8.5*/
         WRITE_OR_BAIL(writeZigZagVarInt, (int)v2.width); /*0.4*/
         WRITE_OR_BAIL(writeZigZagVarInt, (int)v2.height); /*0.4*/
@@ -11888,9 +11888,9 @@ bool ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentLis
   bool packet_boss_event(pdef::Stream &stream, const pdef::proto::packet_boss_event &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::proto::size::packet_boss_event(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
     WRITE_OR_BAIL(writeZigZagVarLong, (int64_t)obj.boss_entity_id); /*0.4*/
-    const pdef::proto::packet_boss_event::Type &type = obj.type; /*0.3*/
+    const pdef::proto::packet_boss_event::Type &V_type = obj.type; /*0.3*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)(int&)obj.type); /*7.1*/
-    switch (type) { /*8.0*/
+    switch (V_type) { /*8.0*/
       case pdef::proto::packet_boss_event::Type::ShowBar: { /*8.5*/
           WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.title.length());
           WRITE_OR_BAIL(writeString, obj.title); /*title: pstring*/ /*4.2*/
@@ -11944,9 +11944,9 @@ bool ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentLis
   }
   bool packet_available_commands(pdef::Stream &stream, const pdef::proto::packet_available_commands &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::proto::size::packet_available_commands(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const int &values_len = obj.values_len; /*0.1*/
+    const int &V_values_len = obj.values_len; /*0.1*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.values_len); /*0.4*/
-    pdef::proto::packet_available_commands::_EnumType _enum_type; if (values_len <= 0xff) { _enum_type = pdef::proto::packet_available_commands::_EnumType::Byte; } else if (values_len <= 0xffff) { _enum_type = pdef::proto::packet_available_commands::_EnumType::Short; } else { _enum_type = pdef::proto::packet_available_commands::_EnumType::Int; } /*_enum_type: enum_size_based_on_values_len*/ /*4.2*/
+    pdef::proto::packet_available_commands::_EnumType V__enum_type; if (V_values_len <= 0xff) { V__enum_type = pdef::proto::packet_available_commands::_EnumType::Byte; } else if (V_values_len <= 0xffff) { V__enum_type = pdef::proto::packet_available_commands::_EnumType::Short; } else { V__enum_type = pdef::proto::packet_available_commands::_EnumType::Int; } /*_enum_type: enum_size_based_on_values_len*/ /*4.2*/
     for (const auto &v2 : obj.enum_values) { /*3.1*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.length());
       WRITE_OR_BAIL(writeString, v2); /*: pstring*/ /*4.2*/
@@ -11960,13 +11960,13 @@ bool ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentLis
     for (const auto &v2 : obj.enums) { /*5.20*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.name.length());
       WRITE_OR_BAIL(writeString, v2.name); /*name: pstring*/ /*4.2*/
-      if (_enum_type == pdef::proto::packet_available_commands::_EnumType::Byte) { /*8.5*/
+      if (V__enum_type == pdef::proto::packet_available_commands::_EnumType::Byte) { /*8.5*/
         WRITE_OR_BAIL(writeUByte, (uint8_t)v2.values_u8); /*0.4*/
       }
-      else if (_enum_type == pdef::proto::packet_available_commands::_EnumType::Short) { /*8.5*/
+      else if (V__enum_type == pdef::proto::packet_available_commands::_EnumType::Short) { /*8.5*/
         WRITE_OR_BAIL(writeUShortLE, (uint16_t)v2.values_lu16); /*0.4*/
       }
-      else if (_enum_type == pdef::proto::packet_available_commands::_EnumType::Int) { /*8.5*/
+      else if (V__enum_type == pdef::proto::packet_available_commands::_EnumType::Int) { /*8.5*/
         WRITE_OR_BAIL(writeUIntLE, (uint32_t)v2.values_lu32); /*0.4*/
       }
     }
@@ -12029,15 +12029,15 @@ bool ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentLis
   }
   bool packet_command_block_update(pdef::Stream &stream, const pdef::proto::packet_command_block_update &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::proto::size::packet_command_block_update(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const bool &is_block = obj.is_block; /*0.1*/
+    const bool &V_is_block = obj.is_block; /*0.1*/
     WRITE_OR_BAIL(writeBool, (bool)obj.is_block); /*0.4*/
-    if (is_block == true) { /*8.1*/
+    if (V_is_block == true) { /*8.1*/
         pdef::proto::encode::BlockCoordinates(stream, *obj.position); /*BlockCoordinates*/ /*4.5*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)(int&)obj.mode); /*7.1*/
         WRITE_OR_BAIL(writeBool, (bool)obj.needs_redstone); /*0.4*/
         WRITE_OR_BAIL(writeBool, (bool)obj.conditional); /*0.4*/
     }
-    else if (is_block == false) { /*8.1*/
+    else if (V_is_block == false) { /*8.1*/
         WRITE_OR_BAIL(writeUnsignedVarLong, (int64_t)obj.minecart_entity_runtime_id); /*0.4*/
     }
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.command.length());
@@ -12054,7 +12054,7 @@ bool ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentLis
   bool packet_command_output(pdef::Stream &stream, const pdef::proto::packet_command_output &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::proto::size::packet_command_output(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
     pdef::proto::encode::CommandOrigin(stream, obj.origin); /*CommandOrigin*/ /*4.5*/
-    const pdef::proto::packet_command_output::OutputType &output_type = obj.output_type; /*0.3*/
+    const pdef::proto::packet_command_output::OutputType &V_output_type = obj.output_type; /*0.3*/
     WRITE_OR_BAIL(writeByte, (int8_t)(int8_t&)obj.output_type); /*7.1*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.success_count); /*0.4*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.output.size()); /*1.4*/
@@ -12068,7 +12068,7 @@ bool ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentLis
         WRITE_OR_BAIL(writeString, v3); /*: pstring*/ /*4.2*/
       }
     }
-    switch (output_type) { /*8.0*/
+    switch (V_output_type) { /*8.0*/
       case pdef::proto::packet_command_output::OutputType::DataSet: { /*8.5*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.data_set.length());
         WRITE_OR_BAIL(writeString, obj.data_set); /*data_set: pstring*/ /*4.2*/
@@ -12235,10 +12235,10 @@ bool ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentLis
   }
   bool packet_book_edit(pdef::Stream &stream, const pdef::proto::packet_book_edit &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::proto::size::packet_book_edit(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const pdef::proto::packet_book_edit::Type &type = obj.type; /*0.3*/
+    const pdef::proto::packet_book_edit::Type &V_type = obj.type; /*0.3*/
     WRITE_OR_BAIL(writeUByte, (uint8_t)(uint8_t&)obj.type); /*7.1*/
     WRITE_OR_BAIL(writeUByte, (uint8_t)obj.slot); /*0.4*/
-    switch (type) { /*8.0*/
+    switch (V_type) { /*8.0*/
       case pdef::proto::packet_book_edit::Type::ReplacePage: { /*8.5*/
           WRITE_OR_BAIL(writeUByte, (uint8_t)obj.page_number); /*0.4*/
           WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.text.length());
@@ -12360,7 +12360,7 @@ bool ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentLis
   }
   bool packet_set_score(pdef::Stream &stream, const pdef::proto::packet_set_score &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::proto::size::packet_set_score(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const pdef::proto::packet_set_score::Action &action = obj.action; /*0.3*/
+    const pdef::proto::packet_set_score::Action &V_action = obj.action; /*0.3*/
     WRITE_OR_BAIL(writeUByte, (uint8_t)(uint8_t&)obj.action); /*7.1*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.entries.size()); /*1.4*/
     for (const auto &v2 : obj.entries) { /*5.20*/
@@ -12368,11 +12368,11 @@ bool ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentLis
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.objective_name.length());
       WRITE_OR_BAIL(writeString, v2.objective_name); /*objective_name: pstring*/ /*4.2*/
       WRITE_OR_BAIL(writeIntLE, (int32_t)v2.score); /*0.4*/
-      switch (action) { /*8.0*/
+      switch (V_action) { /*8.0*/
         case pdef::proto::packet_set_score::Action::Change: { /*8.5*/
-            const pdef::proto::packet_set_score::Entries::EntryType &entry_type = v2.entry_type; /*0.3*/
+            const pdef::proto::packet_set_score::Entries::EntryType &V_entry_type = v2.entry_type; /*0.3*/
             WRITE_OR_BAIL(writeByte, (int8_t)(int8_t&)v2.entry_type); /*7.1*/
-            switch (entry_type) { /*8.0*/
+            switch (V_entry_type) { /*8.0*/
               case pdef::proto::packet_set_score::Entries::EntryType::Player: { /*8.5*/
                 WRITE_OR_BAIL(writeZigZagVarLong, (int64_t)v2.entity_unique_id); /*0.4*/
                 break;
@@ -12383,7 +12383,7 @@ bool ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentLis
               } /*8.7*/
               default: break; /*avoid unhandled case warning*/
             } /*8.8*/
-            switch (entry_type) { /*8.0*/
+            switch (V_entry_type) { /*8.0*/
               case pdef::proto::packet_set_score::Entries::EntryType::FakePlayer: { /*8.5*/
                 WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.custom_name.length());
                 WRITE_OR_BAIL(writeString, v2.custom_name); /*custom_name: pstring*/ /*4.2*/
@@ -12435,35 +12435,35 @@ bool ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentLis
     if (obj.flags.teleport) flags_val |= 128;
     if (obj.flags.force_move) flags_val |= 256;
     WRITE_OR_BAIL(writeUShortLE, (uint16_t)flags_val) /*flags: bitflags*/ /*4.2*/
-    const pdef::proto::packet_move_entity_delta::flags_t &flags = obj.flags; /*4.7*/
-    if (flags.has_x == true) { /*8.2*/
+    const pdef::proto::packet_move_entity_delta::flags_t &V_flags = obj.flags; /*4.7*/
+    if (V_flags.has_x == true) { /*8.2*/
       WRITE_OR_BAIL(writeFloatLE, (float)obj.x); /*0.4*/
     }
-    if (flags.has_y == true) { /*8.2*/
+    if (V_flags.has_y == true) { /*8.2*/
       WRITE_OR_BAIL(writeFloatLE, (float)obj.y); /*0.4*/
     }
-    if (flags.has_z == true) { /*8.2*/
+    if (V_flags.has_z == true) { /*8.2*/
       WRITE_OR_BAIL(writeFloatLE, (float)obj.z); /*0.4*/
     }
-    if (flags.has_rot_x == true) { /*8.2*/
+    if (V_flags.has_rot_x == true) { /*8.2*/
       WRITE_OR_BAIL(writeUByte, (uint8_t)obj.rot_x); /*0.4*/
     }
-    if (flags.has_rot_y == true) { /*8.2*/
+    if (V_flags.has_rot_y == true) { /*8.2*/
       WRITE_OR_BAIL(writeUByte, (uint8_t)obj.rot_y); /*0.4*/
     }
-    if (flags.has_rot_z == true) { /*8.2*/
+    if (V_flags.has_rot_z == true) { /*8.2*/
       WRITE_OR_BAIL(writeUByte, (uint8_t)obj.rot_z); /*0.4*/
     }
     return true;
   }
   bool packet_set_scoreboard_identity(pdef::Stream &stream, const pdef::proto::packet_set_scoreboard_identity &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::proto::size::packet_set_scoreboard_identity(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const pdef::proto::packet_set_scoreboard_identity::Action &action = obj.action; /*0.3*/
+    const pdef::proto::packet_set_scoreboard_identity::Action &V_action = obj.action; /*0.3*/
     WRITE_OR_BAIL(writeByte, (int8_t)(int8_t&)obj.action); /*7.1*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.entries.size()); /*1.4*/
     for (const auto &v2 : obj.entries) { /*5.20*/
       WRITE_OR_BAIL(writeZigZagVarLong, (int64_t)v2.scoreboard_id); /*0.4*/
-      switch (action) { /*8.0*/
+      switch (V_action) { /*8.0*/
         case pdef::proto::packet_set_scoreboard_identity::Action::RegisterIdentity: { /*8.5*/
           WRITE_OR_BAIL(writeZigZagVarLong, (int64_t)v2.entity_unique_id); /*0.4*/
           break;
@@ -12616,9 +12616,9 @@ bool ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentLis
     if (allocate) { auto writeSize = pdef::proto::size::packet_structure_template_data_export_response(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.name.length());
     WRITE_OR_BAIL(writeString, obj.name); /*name: pstring*/ /*4.2*/
-    const bool &success = obj.success; /*0.1*/
+    const bool &V_success = obj.success; /*0.1*/
     WRITE_OR_BAIL(writeBool, (bool)obj.success); /*0.4*/
-    if (success == true) { /*8.1*/
+    if (V_success == true) { /*8.1*/
       WRITE_OR_BAIL(writeByte, (int8_t)obj.nbt); /*0.4*/
     }
     WRITE_OR_BAIL(writeUByte, (uint8_t)(uint8_t&)obj.response_type); /*7.1*/
@@ -12631,9 +12631,9 @@ bool ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentLis
   }
   bool packet_client_cache_blob_status(pdef::Stream &stream, const pdef::proto::packet_client_cache_blob_status &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::proto::size::packet_client_cache_blob_status(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const int &misses = obj.misses; /*0.1*/
+    const int &V_misses = obj.misses; /*0.1*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.misses); /*0.4*/
-    const int &haves = obj.haves; /*0.1*/
+    const int &V_haves = obj.haves; /*0.1*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.haves); /*0.4*/
     for (const auto &v2 : obj.missing) { /*3.1*/
       WRITE_OR_BAIL(writeULongLE, (uint64_t)v2); /*0.4*/
@@ -12663,23 +12663,23 @@ bool ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentLis
     WRITE_OR_BAIL(writeString, obj.post_process_filter); /*post_process_filter: pstring*/ /*4.2*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.screenshot_border_path.length());
     WRITE_OR_BAIL(writeString, obj.screenshot_border_path); /*screenshot_border_path: pstring*/ /*4.2*/
-    const bool &has_agent_capabilities = obj.has_agent_capabilities; /*0.1*/
+    const bool &V_has_agent_capabilities = obj.has_agent_capabilities; /*0.1*/
     WRITE_OR_BAIL(writeBool, (bool)obj.has_agent_capabilities); /*0.4*/
-    if (has_agent_capabilities == true) { /*8.1*/
+    if (V_has_agent_capabilities == true) { /*8.1*/
         const pdef::proto::packet_education_settings::AgentCapabilities &v2 = *obj.agent_capabilities; /*8.5*/
         WRITE_OR_BAIL(writeBool, (bool)v2.has); /*0.4*/
         WRITE_OR_BAIL(writeBool, (bool)v2.can_modify_blocks); /*0.4*/
     }
-    const bool &HasOverrideURI = obj.HasOverrideURI; /*0.1*/
+    const bool &V_HasOverrideURI = obj.HasOverrideURI; /*0.1*/
     WRITE_OR_BAIL(writeBool, (bool)obj.HasOverrideURI); /*0.4*/
-    if (HasOverrideURI == true) { /*8.1*/
+    if (V_HasOverrideURI == true) { /*8.1*/
       WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.OverrideURI.length());
       WRITE_OR_BAIL(writeString, obj.OverrideURI); /*OverrideURI: pstring*/ /*4.2*/
     }
     WRITE_OR_BAIL(writeBool, (bool)obj.HasQuiz); /*0.4*/
-    const bool &has_external_link_settings = obj.has_external_link_settings; /*0.1*/
+    const bool &V_has_external_link_settings = obj.has_external_link_settings; /*0.1*/
     WRITE_OR_BAIL(writeBool, (bool)obj.has_external_link_settings); /*0.4*/
-    if (has_external_link_settings == true) { /*8.1*/
+    if (V_has_external_link_settings == true) { /*8.1*/
         const pdef::proto::packet_education_settings::ExternalLinkSettings &v2 = *obj.external_link_settings; /*8.5*/
         WRITE_OR_BAIL(writeBool, (bool)v2.has); /*0.4*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.url.length());
@@ -12772,12 +12772,12 @@ bool ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentLis
     input_data_val |= (int64_t)obj.input_data.block_action << 35;
     input_data_val |= (int64_t)obj.input_data.item_stack_request << 36;
     WRITE_OR_BAIL(writeUnsignedVarLong, (int64_t)input_data_val) /*input_data: bitflags*/ /*4.2*/
-    const pdef::proto::packet_player_auth_input::input_data_t &input_data = obj.input_data; /*4.7*/
+    const pdef::proto::packet_player_auth_input::input_data_t &V_input_data = obj.input_data; /*4.7*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)(int&)obj.input_mode); /*7.1*/
-    const pdef::proto::packet_player_auth_input::PlayMode &play_mode = obj.play_mode; /*0.3*/
+    const pdef::proto::packet_player_auth_input::PlayMode &V_play_mode = obj.play_mode; /*0.3*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)(int&)obj.play_mode); /*7.1*/
     WRITE_OR_BAIL(writeZigZagVarInt, (int)(int&)obj.interaction_model); /*7.1*/
-    switch (play_mode) { /*8.0*/
+    switch (V_play_mode) { /*8.0*/
       case pdef::proto::packet_player_auth_input::PlayMode::Reality: { /*8.5*/
         pdef::proto::encode::vec3f(stream, *obj.gaze_direction); /*vec3f*/ /*4.5*/
         break;
@@ -12786,38 +12786,38 @@ bool ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentLis
     } /*8.8*/
     WRITE_OR_BAIL(writeUnsignedVarLong, (int64_t)obj.tick); /*0.4*/
     pdef::proto::encode::vec3f(stream, obj.delta); /*vec3f*/ /*4.5*/
-    if (input_data.item_interact == true) { /*8.2*/
+    if (V_input_data.item_interact == true) { /*8.2*/
         const pdef::proto::packet_player_auth_input::Transaction &v2 = *obj.transaction; /*8.5*/
         pdef::proto::encode::TransactionLegacy(stream, v2.legacy); /*TransactionLegacy*/ /*4.5*/
         WRITE_OR_BAIL(writeUnsignedVarInt, (int)v2.actions.size()); /*2.1*/
         for (const auto &v : v2.actions) { pdef::proto::encode::TransactionActions(stream, v); } /*2.2*/
         pdef::proto::encode::TransactionUseItem(stream, v2.data); /*TransactionUseItem*/ /*4.5*/
     }
-    if (input_data.item_stack_request == true) { /*8.2*/
+    if (V_input_data.item_stack_request == true) { /*8.2*/
       pdef::proto::encode::ItemStackRequest(stream, *obj.item_stack_request); /*ItemStackRequest*/ /*4.5*/
     }
-    if (input_data.block_action == true) { /*8.2*/
+    if (V_input_data.block_action == true) { /*8.2*/
       WRITE_OR_BAIL(writeZigZagVarInt, (int)obj.block_action.size()); /*1.4*/
       for (const auto &v3 : obj.block_action) { /*5.20*/
-        const pdef::proto::packet_player_auth_input::BlockAction::Action &action = v3.action; /*0.3*/
+        const pdef::proto::packet_player_auth_input::BlockAction::Action &V_action = v3.action; /*0.3*/
         WRITE_OR_BAIL(writeZigZagVarInt, (int)(int&)v3.action); /*7.1*/
-        if (action == pdef::proto::packet_player_auth_input::BlockAction::Action::StartBreak) { /*8.5*/
+        if (V_action == pdef::proto::packet_player_auth_input::BlockAction::Action::StartBreak) { /*8.5*/
             pdef::proto::encode::vec3i(stream, *v3.position); /*vec3i*/ /*4.5*/
             WRITE_OR_BAIL(writeZigZagVarInt, (int)v3.face); /*0.4*/
         }
-        else if (action == pdef::proto::packet_player_auth_input::BlockAction::Action::AbortBreak) { /*8.5*/
+        else if (V_action == pdef::proto::packet_player_auth_input::BlockAction::Action::AbortBreak) { /*8.5*/
             pdef::proto::encode::vec3i(stream, *v3.position); /*vec3i*/ /*4.5*/
             WRITE_OR_BAIL(writeZigZagVarInt, (int)v3.face); /*0.4*/
         }
-        else if (action == pdef::proto::packet_player_auth_input::BlockAction::Action::CrackBreak) { /*8.5*/
+        else if (V_action == pdef::proto::packet_player_auth_input::BlockAction::Action::CrackBreak) { /*8.5*/
             pdef::proto::encode::vec3i(stream, *v3.position); /*vec3i*/ /*4.5*/
             WRITE_OR_BAIL(writeZigZagVarInt, (int)v3.face); /*0.4*/
         }
-        else if (action == pdef::proto::packet_player_auth_input::BlockAction::Action::PredictBreak) { /*8.5*/
+        else if (V_action == pdef::proto::packet_player_auth_input::BlockAction::Action::PredictBreak) { /*8.5*/
             pdef::proto::encode::vec3i(stream, *v3.position); /*vec3i*/ /*4.5*/
             WRITE_OR_BAIL(writeZigZagVarInt, (int)v3.face); /*0.4*/
         }
-        else if (action == pdef::proto::packet_player_auth_input::BlockAction::Action::ContinueBreak) { /*8.5*/
+        else if (V_action == pdef::proto::packet_player_auth_input::BlockAction::Action::ContinueBreak) { /*8.5*/
             pdef::proto::encode::vec3i(stream, *v3.position); /*vec3i*/ /*4.5*/
             WRITE_OR_BAIL(writeZigZagVarInt, (int)v3.face); /*0.4*/
         }
@@ -12864,17 +12864,17 @@ bool ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentLis
     if (obj.type.legs) type_val |= 4;
     if (obj.type.feet) type_val |= 8;
     WRITE_OR_BAIL(writeUByte, (uint8_t)type_val) /*type: bitflags*/ /*4.2*/
-    const pdef::proto::packet_player_armor_damage::type_t &type = obj.type; /*4.7*/
-    if (type.head == true) { /*8.2*/
+    const pdef::proto::packet_player_armor_damage::type_t &V_type = obj.type; /*4.7*/
+    if (V_type.head == true) { /*8.2*/
       WRITE_OR_BAIL(writeZigZagVarInt, (int)obj.helmet_damage); /*0.4*/
     }
-    if (type.chest == true) { /*8.2*/
+    if (V_type.chest == true) { /*8.2*/
       WRITE_OR_BAIL(writeZigZagVarInt, (int)obj.chestplate_damage); /*0.4*/
     }
-    if (type.legs == true) { /*8.2*/
+    if (V_type.legs == true) { /*8.2*/
       WRITE_OR_BAIL(writeZigZagVarInt, (int)obj.leggings_damage); /*0.4*/
     }
-    if (type.feet == true) { /*8.2*/
+    if (V_type.feet == true) { /*8.2*/
       WRITE_OR_BAIL(writeZigZagVarInt, (int)obj.boots_damage); /*0.4*/
     }
     return true;
@@ -12981,9 +12981,9 @@ bool ItemComponentList(pdef::Stream &stream, const pdef::proto::ItemComponentLis
   }
   bool packet_debug_renderer(pdef::Stream &stream, const pdef::proto::packet_debug_renderer &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::proto::size::packet_debug_renderer(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const pdef::proto::packet_debug_renderer::Type &type = obj.type; /*0.3*/
+    const pdef::proto::packet_debug_renderer::Type &V_type = obj.type; /*0.3*/
     WRITE_OR_BAIL(writeIntLE, (int32_t)(int32_t&)obj.type); /*7.1*/
-    switch (type) { /*8.0*/
+    switch (V_type) { /*8.0*/
       case pdef::proto::packet_debug_renderer::Type::Clear: { /*8.5*/
         break;
       } /*8.7*/
@@ -13087,9 +13087,9 @@ bool SubChunkEntryWithoutCaching(pdef::Stream &stream, const pdef::proto::SubChu
     WRITE_OR_BAIL(writeUByte, (uint8_t)(uint8_t&)obj.result); /*7.1*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)obj.payload.size());
     WRITE_OR_BAIL(writeBuffer, obj.payload); /*payload: buffer*/ /*4.2*/
-    const pdef::proto::SubChunkEntryWithoutCaching::HeightmapType &heightmap_type = obj.heightmap_type; /*0.3*/
+    const pdef::proto::SubChunkEntryWithoutCaching::HeightmapType &V_heightmap_type = obj.heightmap_type; /*0.3*/
     WRITE_OR_BAIL(writeUByte, (uint8_t)(uint8_t&)obj.heightmap_type); /*7.1*/
-    switch (heightmap_type) { /*8.0*/
+    switch (V_heightmap_type) { /*8.0*/
       case pdef::proto::SubChunkEntryWithoutCaching::HeightmapType::HasData: { /*8.5*/
         WRITE_OR_BAIL(writeBuffer, obj.heightmap); /*heightmap: buffer*/ /*4.2*/
         break;
@@ -13103,9 +13103,9 @@ bool SubChunkEntryWithCaching(pdef::Stream &stream, const pdef::proto::SubChunkE
     WRITE_OR_BAIL(writeByte, (int8_t)obj.dx); /*0.4*/
     WRITE_OR_BAIL(writeByte, (int8_t)obj.dy); /*0.4*/
     WRITE_OR_BAIL(writeByte, (int8_t)obj.dz); /*0.4*/
-    const pdef::proto::SubChunkEntryWithCaching::Result &result = obj.result; /*0.3*/
+    const pdef::proto::SubChunkEntryWithCaching::Result &V_result = obj.result; /*0.3*/
     WRITE_OR_BAIL(writeUByte, (uint8_t)(uint8_t&)obj.result); /*7.1*/
-    switch (result) { /*8.0*/
+    switch (V_result) { /*8.0*/
       case pdef::proto::SubChunkEntryWithCaching::Result::SuccessAllAir: { /*8.5*/
         break;
       } /*8.7*/
@@ -13115,9 +13115,9 @@ bool SubChunkEntryWithCaching(pdef::Stream &stream, const pdef::proto::SubChunkE
         break;
       } /*8.7*/
     } /*8.8*/
-    const pdef::proto::SubChunkEntryWithCaching::HeightmapType &heightmap_type = obj.heightmap_type; /*0.3*/
+    const pdef::proto::SubChunkEntryWithCaching::HeightmapType &V_heightmap_type = obj.heightmap_type; /*0.3*/
     WRITE_OR_BAIL(writeUByte, (uint8_t)(uint8_t&)obj.heightmap_type); /*7.1*/
-    switch (heightmap_type) { /*8.0*/
+    switch (V_heightmap_type) { /*8.0*/
       case pdef::proto::SubChunkEntryWithCaching::HeightmapType::HasData: { /*8.5*/
         WRITE_OR_BAIL(writeBuffer, obj.heightmap); /*heightmap: buffer*/ /*4.2*/
         break;
@@ -13129,15 +13129,15 @@ bool SubChunkEntryWithCaching(pdef::Stream &stream, const pdef::proto::SubChunkE
 }
   bool packet_subchunk(pdef::Stream &stream, const pdef::proto::packet_subchunk &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::proto::size::packet_subchunk(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const bool &cache_enabled = obj.cache_enabled; /*0.1*/
+    const bool &V_cache_enabled = obj.cache_enabled; /*0.1*/
     WRITE_OR_BAIL(writeBool, (bool)obj.cache_enabled); /*0.4*/
     WRITE_OR_BAIL(writeZigZagVarInt, (int)obj.dimension); /*0.4*/
     pdef::proto::encode::vec3i(stream, obj.origin); /*vec3i*/ /*4.5*/
-    if (cache_enabled == true) { /*8.1*/
+    if (V_cache_enabled == true) { /*8.1*/
       WRITE_OR_BAIL(writeUIntLE, (uint32_t)obj.entries_SubChunkEntryWithCaching.size()); /*2.1*/
       for (const auto &v : obj.entries_SubChunkEntryWithCaching) { pdef::proto::encode::SubChunkEntryWithCaching(stream, v); } /*2.2*/
     }
-    else if (cache_enabled == false) { /*8.1*/
+    else if (V_cache_enabled == false) { /*8.1*/
       WRITE_OR_BAIL(writeUIntLE, (uint32_t)obj.entries_SubChunkEntryWithoutCaching.size()); /*2.1*/
       for (const auto &v : obj.entries_SubChunkEntryWithoutCaching) { pdef::proto::encode::SubChunkEntryWithoutCaching(stream, v); } /*2.2*/
     }
@@ -13258,9 +13258,9 @@ bool SubChunkEntryWithCaching(pdef::Stream &stream, const pdef::proto::SubChunkE
   }
   bool mcpe_packet(pdef::Stream &stream, const pdef::proto::mcpe_packet &obj, bool allocate = true) {
     if (allocate) { auto writeSize = pdef::proto::size::mcpe_packet(stream, obj); if (!writeSize) return false; stream.reserve(writeSize); }
-    const pdef::proto::mcpe_packet::Name &name = obj.name; /*0.3*/
+    const pdef::proto::mcpe_packet::Name &V_name = obj.name; /*0.3*/
     WRITE_OR_BAIL(writeUnsignedVarInt, (int)(int&)obj.name); /*7.1*/
-    switch (name) { /*8.0*/
+    switch (V_name) { /*8.0*/
       case pdef::proto::mcpe_packet::Name::Login: { /*8.5*/
         pdef::proto::encode::packet_login(stream, *obj.params_packet_login); /*packet_login*/ /*4.5*/
         break;
@@ -14275,8 +14275,8 @@ bool ResourcePackIdVersions(pdef::Stream &stream, pdef::proto::ResourcePackIdVer
     if (!stream.readString(obj.name, name_strlen)) return false; /*name: pstring*/ /*4.3*/
     READ_OR_BAIL(readBool, (bool&)obj.editable); /*0.5*/
     READ_OR_BAIL(readUnsignedVarInt, (int&)obj.type); /*7.2*/
-    const pdef::proto::GameRule::Type &type = obj.type; /*0.7*/
-    switch (type) { /*8.0*/
+    const pdef::proto::GameRule::Type &V_type = obj.type; /*0.7*/
+    switch (V_type) { /*8.0*/
       case pdef::proto::GameRule::Type::Bool: { /*8.5*/
         READ_OR_BAIL(readBool, (bool&)obj.value_bool); /*0.5*/
         break;
@@ -14313,8 +14313,8 @@ bool Itemstates(pdef::Stream &stream, pdef::proto::Itemstates &obj) {
 }
   bool ItemExtraDataWithBlockingTick(pdef::Stream &stream, pdef::proto::ItemExtraDataWithBlockingTick &obj) {
     READ_OR_BAIL(readUShortLE, (uint16_t&)obj.has_nbt); /*7.2*/
-    const pdef::proto::ItemExtraDataWithBlockingTick::HasNbt &has_nbt = obj.has_nbt; /*0.7*/
-    switch (has_nbt) { /*8.0*/
+    const pdef::proto::ItemExtraDataWithBlockingTick::HasNbt &V_has_nbt = obj.has_nbt; /*0.7*/
+    switch (V_has_nbt) { /*8.0*/
       case pdef::proto::ItemExtraDataWithBlockingTick::HasNbt::True: { /*8.5*/
          obj.nbt = {}; pdef::proto::ItemExtraDataWithBlockingTick::Nbt &v2 = *obj.nbt; /*8.4*/
           READ_OR_BAIL(readUByte, v2.version); /*0.5*/
@@ -14325,14 +14325,14 @@ bool Itemstates(pdef::Stream &stream, pdef::proto::Itemstates &obj) {
     } /*8.8*/
     int32_t can_place_on_len; READ_OR_BAIL(readIntLE, can_place_on_len); /*1.5*/
     obj.can_place_on.resize(can_place_on_len); /*1.6*/
-    for (int i = 0; i < can_place_on_len; i++) {
+    for (int i = 0; i < can_place_on_len; i++) { /*3.3*/
       auto &v2 = obj.can_place_on[i]; /*3.4*/
       int16_t _strlen; READ_OR_BAIL(readShortLE, _strlen);
       if (!stream.readString(v2, _strlen)) return false; /*: pstring*/ /*4.3*/
     }
     int32_t can_destroy_len; READ_OR_BAIL(readIntLE, can_destroy_len); /*1.5*/
     obj.can_destroy.resize(can_destroy_len); /*1.6*/
-    for (int i = 0; i < can_destroy_len; i++) {
+    for (int i = 0; i < can_destroy_len; i++) { /*3.3*/
       auto &v2 = obj.can_destroy[i]; /*3.4*/
       int16_t _strlen; READ_OR_BAIL(readShortLE, _strlen);
       if (!stream.readString(v2, _strlen)) return false; /*: pstring*/ /*4.3*/
@@ -14342,8 +14342,8 @@ bool Itemstates(pdef::Stream &stream, pdef::proto::Itemstates &obj) {
   }
   bool ItemExtraDataWithoutBlockingTick(pdef::Stream &stream, pdef::proto::ItemExtraDataWithoutBlockingTick &obj) {
     READ_OR_BAIL(readUShortLE, (uint16_t&)obj.has_nbt); /*7.2*/
-    const pdef::proto::ItemExtraDataWithoutBlockingTick::HasNbt &has_nbt = obj.has_nbt; /*0.7*/
-    switch (has_nbt) { /*8.0*/
+    const pdef::proto::ItemExtraDataWithoutBlockingTick::HasNbt &V_has_nbt = obj.has_nbt; /*0.7*/
+    switch (V_has_nbt) { /*8.0*/
       case pdef::proto::ItemExtraDataWithoutBlockingTick::HasNbt::True: { /*8.5*/
          obj.nbt = {}; pdef::proto::ItemExtraDataWithoutBlockingTick::Nbt &v2 = *obj.nbt; /*8.4*/
           READ_OR_BAIL(readUByte, v2.version); /*0.5*/
@@ -14354,14 +14354,14 @@ bool Itemstates(pdef::Stream &stream, pdef::proto::Itemstates &obj) {
     } /*8.8*/
     int32_t can_place_on_len; READ_OR_BAIL(readIntLE, can_place_on_len); /*1.5*/
     obj.can_place_on.resize(can_place_on_len); /*1.6*/
-    for (int i = 0; i < can_place_on_len; i++) {
+    for (int i = 0; i < can_place_on_len; i++) { /*3.3*/
       auto &v2 = obj.can_place_on[i]; /*3.4*/
       int16_t _strlen; READ_OR_BAIL(readShortLE, _strlen);
       if (!stream.readString(v2, _strlen)) return false; /*: pstring*/ /*4.3*/
     }
     int32_t can_destroy_len; READ_OR_BAIL(readIntLE, can_destroy_len); /*1.5*/
     obj.can_destroy.resize(can_destroy_len); /*1.6*/
-    for (int i = 0; i < can_destroy_len; i++) {
+    for (int i = 0; i < can_destroy_len; i++) { /*3.3*/
       auto &v2 = obj.can_destroy[i]; /*3.4*/
       int16_t _strlen; READ_OR_BAIL(readShortLE, _strlen);
       if (!stream.readString(v2, _strlen)) return false; /*: pstring*/ /*4.3*/
@@ -14370,14 +14370,14 @@ bool Itemstates(pdef::Stream &stream, pdef::proto::Itemstates &obj) {
   }
   bool ItemLegacy(pdef::Stream &stream, pdef::proto::ItemLegacy &obj) {
     READ_OR_BAIL(readZigZagVarInt, obj.network_id); /*0.5*/
-    int &network_id = obj.network_id; /*0.6*/
-    if (network_id == 0) { /*8.2*/
+    int &V_network_id = obj.network_id; /*0.6*/
+    if (V_network_id == 0) { /*8.2*/
     }
     else {
         READ_OR_BAIL(readUShortLE, obj.count); /*0.5*/
         READ_OR_BAIL(readUnsignedVarInt, obj.metadata); /*0.5*/
         READ_OR_BAIL(readZigZagVarInt, obj.block_runtime_id); /*0.5*/
-        if (network_id == pdef::proto::ShieldItemID) { /*8.4*/
+        if (V_network_id == pdef::proto::ShieldItemID) { /*8.4*/
           READ_OR_BAIL(readByte, obj.extra__ShieldItemID); /*0.5*/
         }
         else {
@@ -14388,21 +14388,21 @@ bool Itemstates(pdef::Stream &stream, pdef::proto::Itemstates &obj) {
   }
   bool Item(pdef::Stream &stream, pdef::proto::Item &obj) {
     READ_OR_BAIL(readZigZagVarInt, obj.network_id); /*0.5*/
-    int &network_id = obj.network_id; /*0.6*/
-    if (network_id == 0) { /*8.2*/
+    int &V_network_id = obj.network_id; /*0.6*/
+    if (V_network_id == 0) { /*8.2*/
     }
     else {
         READ_OR_BAIL(readUShortLE, obj.count); /*0.5*/
         READ_OR_BAIL(readUnsignedVarInt, obj.metadata); /*0.5*/
         READ_OR_BAIL(readUByte, obj.has_stack_id); /*0.5*/
-        uint8_t &has_stack_id = obj.has_stack_id; /*0.6*/
-        if (has_stack_id == 0) { /*8.2*/
+        uint8_t &V_has_stack_id = obj.has_stack_id; /*0.6*/
+        if (V_has_stack_id == 0) { /*8.2*/
         }
         else {
           READ_OR_BAIL(readZigZagVarInt, obj.stack_id); /*0.5*/
         }
         READ_OR_BAIL(readZigZagVarInt, obj.block_runtime_id); /*0.5*/
-        if (network_id == pdef::proto::ShieldItemID) { /*8.4*/
+        if (V_network_id == pdef::proto::ShieldItemID) { /*8.4*/
           READ_OR_BAIL(readByte, obj.extra__ShieldItemID); /*0.5*/
         }
         else {
@@ -14436,10 +14436,10 @@ bool Itemstates(pdef::Stream &stream, pdef::proto::Itemstates &obj) {
   }
 bool MetadataDictionary(pdef::Stream &stream, pdef::proto::MetadataDictionary &obj) {
     READ_OR_BAIL(readUnsignedVarInt, (int&)obj.key); /*7.2*/
-    const pdef::proto::MetadataDictionary::Key &key = obj.key; /*0.7*/
+    const pdef::proto::MetadataDictionary::Key &V_key = obj.key; /*0.7*/
     READ_OR_BAIL(readUnsignedVarInt, (int&)obj.type); /*7.2*/
-    const pdef::proto::MetadataDictionary::Type &type = obj.type; /*0.7*/
-    switch (key) { /*8.0*/
+    const pdef::proto::MetadataDictionary::Type &V_type = obj.type; /*0.7*/
+    switch (V_key) { /*8.0*/
       case pdef::proto::MetadataDictionary::Key::Flags: { /*8.5*/
         int64_t value_MetadataFlags1_val;
         READ_OR_BAIL(readZigZagVarLong, value_MetadataFlags1_val);
@@ -14557,7 +14557,7 @@ bool MetadataDictionary(pdef::Stream &stream, pdef::proto::MetadataDictionary &o
         break;
       } /*8.7*/
       default: { /*8.3*/
-        switch (type) { /*8.0*/
+        switch (V_type) { /*8.0*/
           case pdef::proto::MetadataDictionary::Type::Byte: { /*8.5*/
             READ_OR_BAIL(readByte, obj.value_i8); /*0.5*/
             break;
@@ -14652,8 +14652,8 @@ bool PlayerAttributes(pdef::Stream &stream, pdef::proto::PlayerAttributes &obj) 
   }
 bool TransactionActions(pdef::Stream &stream, pdef::proto::TransactionActions &obj) {
     READ_OR_BAIL(readUnsignedVarInt, (int&)obj.source_type); /*7.2*/
-    const pdef::proto::TransactionActions::SourceType &source_type = obj.source_type; /*0.7*/
-    switch (source_type) { /*8.0*/
+    const pdef::proto::TransactionActions::SourceType &V_source_type = obj.source_type; /*0.7*/
+    switch (V_source_type) { /*8.0*/
       case pdef::proto::TransactionActions::SourceType::Container: { /*8.5*/
           READ_OR_BAIL(readUnsignedVarInt, (int&)obj.inventory_id); /*7.2*/
         break;
@@ -14679,8 +14679,8 @@ bool TransactionActions(pdef::Stream &stream, pdef::proto::TransactionActions &o
 }
   bool TransactionLegacy(pdef::Stream &stream, pdef::proto::TransactionLegacy &obj) {
     READ_OR_BAIL(readZigZagVarInt, obj.legacy_request_id); /*0.5*/
-    int &legacy_request_id = obj.legacy_request_id; /*0.6*/
-    if (legacy_request_id == 0) { /*8.2*/
+    int &V_legacy_request_id = obj.legacy_request_id; /*0.6*/
+    if (V_legacy_request_id == 0) { /*8.2*/
     }
     else {
       int legacy_transactions_len; READ_OR_BAIL(readUnsignedVarInt, legacy_transactions_len); /*1.5*/
@@ -14701,12 +14701,12 @@ bool TransactionActions(pdef::Stream &stream, pdef::proto::TransactionActions &o
   bool Transaction(pdef::Stream &stream, pdef::proto::Transaction &obj) {
     pdef::proto::decode::TransactionLegacy(stream, obj.legacy); /*obj*/ /*4.6*/
     READ_OR_BAIL(readUnsignedVarInt, (int&)obj.transaction_type); /*7.2*/
-    const pdef::proto::Transaction::TransactionType &transaction_type = obj.transaction_type; /*0.7*/
+    const pdef::proto::Transaction::TransactionType &V_transaction_type = obj.transaction_type; /*0.7*/
     int actions_len; /*2.3*/
     READ_OR_BAIL(readUnsignedVarInt, actions_len); /*2.6*/
     obj.actions.resize(actions_len); /*2.7*/
     for (int i = 0; i < actions_len; i++) { pdef::proto::decode::TransactionActions(stream, obj.actions[i]); } /*2.8*/
-    switch (transaction_type) { /*8.0*/
+    switch (V_transaction_type) { /*8.0*/
       case pdef::proto::Transaction::TransactionType::Normal: { /*8.5*/
         break;
       } /*8.7*/
@@ -14741,8 +14741,8 @@ bool TransactionActions(pdef::Stream &stream, pdef::proto::TransactionActions &o
   }
   bool RecipeIngredient(pdef::Stream &stream, pdef::proto::RecipeIngredient &obj) {
     READ_OR_BAIL(readZigZagVarInt, obj.network_id); /*0.5*/
-    int &network_id = obj.network_id; /*0.6*/
-    if (network_id == 0) { /*8.2*/
+    int &V_network_id = obj.network_id; /*0.6*/
+    if (V_network_id == 0) { /*8.2*/
     }
     else {
         READ_OR_BAIL(readZigZagVarInt, obj.network_data); /*0.5*/
@@ -14767,21 +14767,21 @@ bool PotionContainerChangeRecipes(pdef::Stream &stream, pdef::proto::PotionConta
 }
 bool Recipes(pdef::Stream &stream, pdef::proto::Recipes &obj) {
     READ_OR_BAIL(readZigZagVarInt, (int&)obj.type); /*7.2*/
-    const pdef::proto::Recipes::Type &type = obj.type; /*0.7*/
-    switch (type) { /*8.0*/
+    const pdef::proto::Recipes::Type &V_type = obj.type; /*0.7*/
+    switch (V_type) { /*8.0*/
       case pdef::proto::Recipes::Type::Shapeless: { /*8.5*/
          obj.recipe_shapeless_or_shulker_box_or_shapeless_chemistry = {}; pdef::proto::Recipes::RecipeShapelessOrShulkerBoxOrShapelessChemistry &v2 = *obj.recipe_shapeless_or_shulker_box_or_shapeless_chemistry; /*8.4*/
           int recipe_id_strlen; READ_OR_BAIL(readUnsignedVarInt, recipe_id_strlen);
           if (!stream.readString(v2.recipe_id, recipe_id_strlen)) return false; /*recipe_id: pstring*/ /*4.3*/
           int input_len; READ_OR_BAIL(readUnsignedVarInt, input_len); /*1.5*/
           v2.input.resize(input_len); /*1.6*/
-          for (int i = 0; i < input_len; i++) {
+          for (int i = 0; i < input_len; i++) { /*3.3*/
             auto &v5 = v2.input[i]; /*3.4*/
             pdef::proto::decode::RecipeIngredient(stream, v5); /*v5*/ /*4.6*/
           }
           int output_len; READ_OR_BAIL(readUnsignedVarInt, output_len); /*1.5*/
           v2.output.resize(output_len); /*1.6*/
-          for (int i = 0; i < output_len; i++) {
+          for (int i = 0; i < output_len; i++) { /*3.3*/
             auto &v5 = v2.output[i]; /*3.4*/
             pdef::proto::decode::ItemLegacy(stream, v5); /*v5*/ /*4.6*/
           }
@@ -14798,13 +14798,13 @@ bool Recipes(pdef::Stream &stream, pdef::proto::Recipes &obj) {
           if (!stream.readString(v2.recipe_id, recipe_id_strlen)) return false; /*recipe_id: pstring*/ /*4.3*/
           int input_len; READ_OR_BAIL(readUnsignedVarInt, input_len); /*1.5*/
           v2.input.resize(input_len); /*1.6*/
-          for (int i = 0; i < input_len; i++) {
+          for (int i = 0; i < input_len; i++) { /*3.3*/
             auto &v5 = v2.input[i]; /*3.4*/
             pdef::proto::decode::RecipeIngredient(stream, v5); /*v5*/ /*4.6*/
           }
           int output_len; READ_OR_BAIL(readUnsignedVarInt, output_len); /*1.5*/
           v2.output.resize(output_len); /*1.6*/
-          for (int i = 0; i < output_len; i++) {
+          for (int i = 0; i < output_len; i++) { /*3.3*/
             auto &v5 = v2.output[i]; /*3.4*/
             pdef::proto::decode::ItemLegacy(stream, v5); /*v5*/ /*4.6*/
           }
@@ -14821,13 +14821,13 @@ bool Recipes(pdef::Stream &stream, pdef::proto::Recipes &obj) {
           if (!stream.readString(v2.recipe_id, recipe_id_strlen)) return false; /*recipe_id: pstring*/ /*4.3*/
           int input_len; READ_OR_BAIL(readUnsignedVarInt, input_len); /*1.5*/
           v2.input.resize(input_len); /*1.6*/
-          for (int i = 0; i < input_len; i++) {
+          for (int i = 0; i < input_len; i++) { /*3.3*/
             auto &v5 = v2.input[i]; /*3.4*/
             pdef::proto::decode::RecipeIngredient(stream, v5); /*v5*/ /*4.6*/
           }
           int output_len; READ_OR_BAIL(readUnsignedVarInt, output_len); /*1.5*/
           v2.output.resize(output_len); /*1.6*/
-          for (int i = 0; i < output_len; i++) {
+          for (int i = 0; i < output_len; i++) { /*3.3*/
             auto &v5 = v2.output[i]; /*3.4*/
             pdef::proto::decode::ItemLegacy(stream, v5); /*v5*/ /*4.6*/
           }
@@ -14843,21 +14843,21 @@ bool Recipes(pdef::Stream &stream, pdef::proto::Recipes &obj) {
           int recipe_id_strlen; READ_OR_BAIL(readUnsignedVarInt, recipe_id_strlen);
           if (!stream.readString(v2.recipe_id, recipe_id_strlen)) return false; /*recipe_id: pstring*/ /*4.3*/
           READ_OR_BAIL(readZigZagVarInt, v2.width); /*0.5*/
-          int &width = v2.width; /*0.6*/
+          int &V_width = v2.width; /*0.6*/
           READ_OR_BAIL(readZigZagVarInt, v2.height); /*0.5*/
-          int &height = v2.height; /*0.6*/
-          v2.input.resize(width); /*1.6*/
-          for (int i = 0; i < width; i++) { /*5.2*/
+          int &V_height = v2.height; /*0.6*/
+          v2.input.resize(V_width); /*1.6*/
+          for (int i = 0; i < V_width; i++) { /*5.2*/
             int input_len2; READ_OR_BAIL(readZigZagVarInt, input_len2); /*5.5*/
             v2.input[i].resize(input_len2); /*5.10*/
-            for (int j = 0; j < height; j++) { /*5.11*/
+            for (int j = 0; j < V_height; j++) { /*5.11*/
               auto &v = v2.input[i][j]; /*5.15*/
               pdef::proto::decode::RecipeIngredient(stream, v); /*v*/ /*4.6*/
             }
           }
           int output_len; READ_OR_BAIL(readUnsignedVarInt, output_len); /*1.5*/
           v2.output.resize(output_len); /*1.6*/
-          for (int i = 0; i < output_len; i++) {
+          for (int i = 0; i < output_len; i++) { /*3.3*/
             auto &v5 = v2.output[i]; /*3.4*/
             pdef::proto::decode::ItemLegacy(stream, v5); /*v5*/ /*4.6*/
           }
@@ -14873,21 +14873,21 @@ bool Recipes(pdef::Stream &stream, pdef::proto::Recipes &obj) {
           int recipe_id_strlen; READ_OR_BAIL(readUnsignedVarInt, recipe_id_strlen);
           if (!stream.readString(v2.recipe_id, recipe_id_strlen)) return false; /*recipe_id: pstring*/ /*4.3*/
           READ_OR_BAIL(readZigZagVarInt, v2.width); /*0.5*/
-          int &width = v2.width; /*0.6*/
+          int &V_width = v2.width; /*0.6*/
           READ_OR_BAIL(readZigZagVarInt, v2.height); /*0.5*/
-          int &height = v2.height; /*0.6*/
-          v2.input.resize(width); /*1.6*/
-          for (int i = 0; i < width; i++) { /*5.2*/
+          int &V_height = v2.height; /*0.6*/
+          v2.input.resize(V_width); /*1.6*/
+          for (int i = 0; i < V_width; i++) { /*5.2*/
             int input_len2; READ_OR_BAIL(readZigZagVarInt, input_len2); /*5.5*/
             v2.input[i].resize(input_len2); /*5.10*/
-            for (int j = 0; j < height; j++) { /*5.11*/
+            for (int j = 0; j < V_height; j++) { /*5.11*/
               auto &v = v2.input[i][j]; /*5.15*/
               pdef::proto::decode::RecipeIngredient(stream, v); /*v*/ /*4.6*/
             }
           }
           int output_len; READ_OR_BAIL(readUnsignedVarInt, output_len); /*1.5*/
           v2.output.resize(output_len); /*1.6*/
-          for (int i = 0; i < output_len; i++) {
+          for (int i = 0; i < output_len; i++) { /*3.3*/
             auto &v5 = v2.output[i]; /*3.4*/
             pdef::proto::decode::ItemLegacy(stream, v5); /*v5*/ /*4.6*/
           }
@@ -14985,7 +14985,7 @@ bool Recipes(pdef::Stream &stream, pdef::proto::Recipes &obj) {
       if (!stream.readString(v2.piece_type, piece_type_strlen)) return false; /*piece_type: pstring*/ /*4.3*/
       int32_t colors_len; READ_OR_BAIL(readIntLE, colors_len); /*1.5*/
       v2.colors.resize(colors_len); /*1.6*/
-      for (int i = 0; i < colors_len; i++) {
+      for (int i = 0; i < colors_len; i++) { /*3.3*/
         auto &v3 = v2.colors[i]; /*3.4*/
         int _strlen; READ_OR_BAIL(readUnsignedVarInt, _strlen);
         if (!stream.readString(v3, _strlen)) return false; /*: pstring*/ /*4.3*/
@@ -14999,10 +14999,10 @@ bool Recipes(pdef::Stream &stream, pdef::proto::Recipes &obj) {
   }
   bool PlayerRecords(pdef::Stream &stream, pdef::proto::PlayerRecords &obj) {
     READ_OR_BAIL(readUByte, (uint8_t&)obj.type); /*7.2*/
-    const pdef::proto::PlayerRecords::Type &type = obj.type; /*0.7*/
+    const pdef::proto::PlayerRecords::Type &V_type = obj.type; /*0.7*/
     READ_OR_BAIL(readUnsignedVarInt, obj.records_count); /*0.5*/
-    int &records_count = obj.records_count; /*0.6*/
-    switch (type) { /*8.0*/
+    int &V_records_count = obj.records_count; /*0.6*/
+    switch (V_type) { /*8.0*/
       case pdef::proto::PlayerRecords::Type::Add: { /*8.5*/
          obj.records_add = {}; pdef::proto::PlayerRecords::RecordsAdd &v2 = *obj.records_add; /*8.4*/
           READ_OR_BAIL(readULongBE, v2.uuid); /*0.5*/
@@ -15026,10 +15026,10 @@ bool Recipes(pdef::Stream &stream, pdef::proto::Recipes &obj) {
       } /*8.7*/
       default: break; /*avoid unhandled case warning*/
     } /*8.8*/
-    switch (type) { /*8.0*/
+    switch (V_type) { /*8.0*/
       case pdef::proto::PlayerRecords::Type::Add: { /*8.5*/
-        obj.verified.resize(records_count); /*1.6*/
-        for (int i = 0; i < records_count; i++) {
+        obj.verified.resize(V_records_count); /*1.6*/
+        for (int i = 0; i < V_records_count; i++) { /*3.3*/
           auto &v4 = obj.verified[i]; /*3.4*/
           READ_OR_BAIL(readBool, (bool&)v4); /*0.5*/
         }
@@ -15049,19 +15049,19 @@ bool Recipes(pdef::Stream &stream, pdef::proto::Recipes &obj) {
     READ_OR_BAIL(readIntLE, obj.slot_flags); /*0.5*/
     int equip_enchants_len; READ_OR_BAIL(readUnsignedVarInt, equip_enchants_len); /*1.5*/
     obj.equip_enchants.resize(equip_enchants_len); /*1.6*/
-    for (int i = 0; i < equip_enchants_len; i++) {
+    for (int i = 0; i < equip_enchants_len; i++) { /*3.3*/
       auto &v2 = obj.equip_enchants[i]; /*3.4*/
       pdef::proto::decode::Enchant(stream, v2); /*v2*/ /*4.6*/
     }
     int held_enchants_len; READ_OR_BAIL(readUnsignedVarInt, held_enchants_len); /*1.5*/
     obj.held_enchants.resize(held_enchants_len); /*1.6*/
-    for (int i = 0; i < held_enchants_len; i++) {
+    for (int i = 0; i < held_enchants_len; i++) { /*3.3*/
       auto &v2 = obj.held_enchants[i]; /*3.4*/
       pdef::proto::decode::Enchant(stream, v2); /*v2*/ /*4.6*/
     }
     int self_enchants_len; READ_OR_BAIL(readUnsignedVarInt, self_enchants_len); /*1.5*/
     obj.self_enchants.resize(self_enchants_len); /*1.6*/
-    for (int i = 0; i < self_enchants_len; i++) {
+    for (int i = 0; i < self_enchants_len; i++) { /*3.3*/
       auto &v2 = obj.self_enchants[i]; /*3.4*/
       pdef::proto::decode::Enchant(stream, v2); /*v2*/ /*4.6*/
     }
@@ -15083,8 +15083,8 @@ bool Recipes(pdef::Stream &stream, pdef::proto::Recipes &obj) {
     for (int i = 0; i < actions_len; i++) { /*5*/
       pdef::proto::ItemStackRequest::Actions &v2 = obj.actions[i]; /*5.23*/
       READ_OR_BAIL(readUByte, (uint8_t&)v2.type_id); /*7.2*/
-      const pdef::proto::ItemStackRequest::Actions::TypeId &type_id = v2.type_id; /*0.7*/
-      switch (type_id) { /*8.0*/
+      const pdef::proto::ItemStackRequest::Actions::TypeId &V_type_id = v2.type_id; /*0.7*/
+      switch (V_type_id) { /*8.0*/
         case pdef::proto::ItemStackRequest::Actions::TypeId::Take: { /*8.5*/
             READ_OR_BAIL(readUByte, v2.count); /*0.5*/
             v2.source = {}; pdef::proto::decode::StackRequestSlotInfo(stream, *v2.source); /*v2*/ /*4.6*/
@@ -15166,7 +15166,7 @@ bool Recipes(pdef::Stream &stream, pdef::proto::Recipes &obj) {
         case pdef::proto::ItemStackRequest::Actions::TypeId::ResultsDeprecated: { /*8.5*/
             int result_items_len; READ_OR_BAIL(readUnsignedVarInt, result_items_len); /*1.5*/
             v2.result_items.resize(result_items_len); /*1.6*/
-            for (int i = 0; i < result_items_len; i++) {
+            for (int i = 0; i < result_items_len; i++) { /*3.3*/
               auto &v6 = v2.result_items[i]; /*3.4*/
               pdef::proto::decode::ItemLegacy(stream, v6); /*v6*/ /*4.6*/
             }
@@ -15178,7 +15178,7 @@ bool Recipes(pdef::Stream &stream, pdef::proto::Recipes &obj) {
     }
     int custom_names_len; READ_OR_BAIL(readUnsignedVarInt, custom_names_len); /*1.5*/
     obj.custom_names.resize(custom_names_len); /*1.6*/
-    for (int i = 0; i < custom_names_len; i++) {
+    for (int i = 0; i < custom_names_len; i++) { /*3.3*/
       auto &v2 = obj.custom_names[i]; /*3.4*/
       int _strlen; READ_OR_BAIL(readUnsignedVarInt, _strlen);
       if (!stream.readString(v2, _strlen)) return false; /*: pstring*/ /*4.3*/
@@ -15187,9 +15187,9 @@ bool Recipes(pdef::Stream &stream, pdef::proto::Recipes &obj) {
   }
 bool ItemStackResponses(pdef::Stream &stream, pdef::proto::ItemStackResponses &obj) {
     READ_OR_BAIL(readUByte, (uint8_t&)obj.status); /*7.2*/
-    const pdef::proto::ItemStackResponses::Status &status = obj.status; /*0.7*/
+    const pdef::proto::ItemStackResponses::Status &V_status = obj.status; /*0.7*/
     READ_OR_BAIL(readZigZagVarInt, obj.request_id); /*0.5*/
-    switch (status) { /*8.0*/
+    switch (V_status) { /*8.0*/
       case pdef::proto::ItemStackResponses::Status::Ok: { /*8.5*/
           int containers_len; READ_OR_BAIL(readUnsignedVarInt, containers_len); /*1.5*/
           obj.containers.resize(containers_len); /*1.6*/
@@ -15223,11 +15223,11 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
 }
   bool CommandOrigin(pdef::Stream &stream, pdef::proto::CommandOrigin &obj) {
     READ_OR_BAIL(readUnsignedVarInt, (int&)obj.type); /*7.2*/
-    const pdef::proto::CommandOrigin::Type &type = obj.type; /*0.7*/
+    const pdef::proto::CommandOrigin::Type &V_type = obj.type; /*0.7*/
     READ_OR_BAIL(readULongBE, obj.uuid); /*0.5*/
     int request_id_strlen; READ_OR_BAIL(readUnsignedVarInt, request_id_strlen);
     if (!stream.readString(obj.request_id, request_id_strlen)) return false; /*request_id: pstring*/ /*4.3*/
-    switch (type) { /*8.0*/
+    switch (V_type) { /*8.0*/
       case pdef::proto::CommandOrigin::Type::DevConsole: { /*8.5*/
          obj.player_entity_id = {}; pdef::proto::CommandOrigin::PlayerEntityId &v2 = *obj.player_entity_id; /*8.4*/
           READ_OR_BAIL(readZigZagVarLong, v2.player_entity_id); /*0.5*/
@@ -15244,15 +15244,15 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
   }
   bool TrackedObject(pdef::Stream &stream, pdef::proto::TrackedObject &obj) {
     READ_OR_BAIL(readIntLE, (int32_t&)obj.type); /*7.2*/
-    const pdef::proto::TrackedObject::Type &type = obj.type; /*0.7*/
-    switch (type) { /*8.0*/
+    const pdef::proto::TrackedObject::Type &V_type = obj.type; /*0.7*/
+    switch (V_type) { /*8.0*/
       case pdef::proto::TrackedObject::Type::Entity: { /*8.5*/
         READ_OR_BAIL(readZigZagVarLong, obj.entity_unique_id); /*0.5*/
         break;
       } /*8.7*/
       default: break; /*avoid unhandled case warning*/
     } /*8.8*/
-    switch (type) { /*8.0*/
+    switch (V_type) { /*8.0*/
       case pdef::proto::TrackedObject::Type::Block: { /*8.5*/
         obj.block_position = {}; pdef::proto::decode::BlockCoordinates(stream, *obj.block_position); /*obj*/ /*4.6*/
         break;
@@ -15374,7 +15374,7 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
     if (!stream.readString(obj.game_version, game_version_strlen)) return false; /*game_version: pstring*/ /*4.3*/
     int32_t experiments_len; READ_OR_BAIL(readIntLE, experiments_len); /*1.5*/
     obj.experiments.resize(experiments_len); /*1.6*/
-    for (int i = 0; i < experiments_len; i++) {
+    for (int i = 0; i < experiments_len; i++) { /*3.3*/
       auto &v2 = obj.experiments[i]; /*3.4*/
       pdef::proto::decode::Experiment(stream, v2); /*v2*/ /*4.6*/
     }
@@ -15385,7 +15385,7 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
     READ_OR_BAIL(readUByte, (uint8_t&)obj.response_status); /*7.2*/
     int16_t resourcepackids_len; READ_OR_BAIL(readShortLE, resourcepackids_len); /*1.5*/
     obj.resourcepackids.resize(resourcepackids_len); /*1.6*/
-    for (int i = 0; i < resourcepackids_len; i++) {
+    for (int i = 0; i < resourcepackids_len; i++) { /*3.3*/
       auto &v2 = obj.resourcepackids[i]; /*3.4*/
       int _strlen; READ_OR_BAIL(readUnsignedVarInt, _strlen);
       if (!stream.readString(v2, _strlen)) return false; /*: pstring*/ /*4.3*/
@@ -15394,9 +15394,9 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
   }
   bool packet_text(pdef::Stream &stream, pdef::proto::packet_text &obj) {
     READ_OR_BAIL(readUByte, (uint8_t&)obj.type); /*7.2*/
-    const pdef::proto::packet_text::Type &type = obj.type; /*0.7*/
+    const pdef::proto::packet_text::Type &V_type = obj.type; /*0.7*/
     READ_OR_BAIL(readBool, (bool&)obj.needs_translation); /*0.5*/
-    switch (type) { /*8.0*/
+    switch (V_type) { /*8.0*/
       case pdef::proto::packet_text::Type::Chat: { /*8.5*/
           int source_name_strlen; READ_OR_BAIL(readUnsignedVarInt, source_name_strlen);
           if (!stream.readString(obj.source_name, source_name_strlen)) return false; /*source_name: pstring*/ /*4.3*/
@@ -15448,7 +15448,7 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
           if (!stream.readString(obj.message, message_strlen)) return false; /*message: pstring*/ /*4.3*/
           int parameters_len; READ_OR_BAIL(readUnsignedVarInt, parameters_len); /*1.5*/
           obj.parameters.resize(parameters_len); /*1.6*/
-          for (int i = 0; i < parameters_len; i++) {
+          for (int i = 0; i < parameters_len; i++) { /*3.3*/
             auto &v5 = obj.parameters[i]; /*3.4*/
             int _strlen; READ_OR_BAIL(readUnsignedVarInt, _strlen);
             if (!stream.readString(v5, _strlen)) return false; /*: pstring*/ /*4.3*/
@@ -15460,7 +15460,7 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
           if (!stream.readString(obj.message, message_strlen)) return false; /*message: pstring*/ /*4.3*/
           int parameters_len; READ_OR_BAIL(readUnsignedVarInt, parameters_len); /*1.5*/
           obj.parameters.resize(parameters_len); /*1.6*/
-          for (int i = 0; i < parameters_len; i++) {
+          for (int i = 0; i < parameters_len; i++) { /*3.3*/
             auto &v5 = obj.parameters[i]; /*3.4*/
             int _strlen; READ_OR_BAIL(readUnsignedVarInt, _strlen);
             if (!stream.readString(v5, _strlen)) return false; /*: pstring*/ /*4.3*/
@@ -15472,7 +15472,7 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
           if (!stream.readString(obj.message, message_strlen)) return false; /*message: pstring*/ /*4.3*/
           int parameters_len; READ_OR_BAIL(readUnsignedVarInt, parameters_len); /*1.5*/
           obj.parameters.resize(parameters_len); /*1.6*/
-          for (int i = 0; i < parameters_len; i++) {
+          for (int i = 0; i < parameters_len; i++) { /*3.3*/
             auto &v5 = obj.parameters[i]; /*3.4*/
             int _strlen; READ_OR_BAIL(readUnsignedVarInt, _strlen);
             if (!stream.readString(v5, _strlen)) return false; /*: pstring*/ /*4.3*/
@@ -15523,13 +15523,13 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
     READ_OR_BAIL(readBool, (bool&)obj.is_texturepacks_required); /*0.5*/
     int gamerules_len; READ_OR_BAIL(readUnsignedVarInt, gamerules_len); /*1.5*/
     obj.gamerules.resize(gamerules_len); /*1.6*/
-    for (int i = 0; i < gamerules_len; i++) {
+    for (int i = 0; i < gamerules_len; i++) { /*3.3*/
       auto &v2 = obj.gamerules[i]; /*3.4*/
       pdef::proto::decode::GameRule(stream, v2); /*v2*/ /*4.6*/
     }
     int32_t experiments_len; READ_OR_BAIL(readIntLE, experiments_len); /*1.5*/
     obj.experiments.resize(experiments_len); /*1.6*/
-    for (int i = 0; i < experiments_len; i++) {
+    for (int i = 0; i < experiments_len; i++) { /*3.3*/
       auto &v2 = obj.experiments[i]; /*3.4*/
       pdef::proto::decode::Experiment(stream, v2); /*v2*/ /*4.6*/
     }
@@ -15609,7 +15609,7 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
     READ_OR_BAIL(readLongLE, obj.user_id); /*0.5*/
     int links_len; READ_OR_BAIL(readUnsignedVarInt, links_len); /*1.5*/
     obj.links.resize(links_len); /*1.6*/
-    for (int i = 0; i < links_len; i++) {
+    for (int i = 0; i < links_len; i++) { /*3.3*/
       auto &v2 = obj.links[i]; /*3.4*/
       pdef::proto::decode::Link(stream, v2); /*v2*/ /*4.6*/
     }
@@ -15638,7 +15638,7 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
     for (int i = 0; i < metadata_len; i++) { pdef::proto::decode::MetadataDictionary(stream, obj.metadata[i]); } /*2.8*/
     int links_len; READ_OR_BAIL(readUnsignedVarInt, links_len); /*1.5*/
     obj.links.resize(links_len); /*1.6*/
-    for (int i = 0; i < links_len; i++) {
+    for (int i = 0; i < links_len; i++) { /*3.3*/
       auto &v2 = obj.links[i]; /*3.4*/
       pdef::proto::decode::Link(stream, v2); /*v2*/ /*4.6*/
     }
@@ -15680,10 +15680,10 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
     READ_OR_BAIL(readFloatLE, obj.yaw); /*0.5*/
     READ_OR_BAIL(readFloatLE, obj.head_yaw); /*0.5*/
     READ_OR_BAIL(readUByte, (uint8_t&)obj.mode); /*7.2*/
-    const pdef::proto::packet_move_player::Mode &mode = obj.mode; /*0.7*/
+    const pdef::proto::packet_move_player::Mode &V_mode = obj.mode; /*0.7*/
     READ_OR_BAIL(readBool, (bool&)obj.on_ground); /*0.5*/
     READ_OR_BAIL(readUnsignedVarInt, obj.ridden_runtime_id); /*0.5*/
-    switch (mode) { /*8.0*/
+    switch (V_mode) { /*8.0*/
       case pdef::proto::packet_move_player::Mode::Teleport: { /*8.5*/
          obj.teleport = {}; pdef::proto::packet_move_player::Teleport &v2 = *obj.teleport; /*8.4*/
           READ_OR_BAIL(readIntLE, (int32_t&)v2.cause); /*7.2*/
@@ -15793,9 +15793,9 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
   }
   bool packet_interact(pdef::Stream &stream, pdef::proto::packet_interact &obj) {
     READ_OR_BAIL(readUByte, (uint8_t&)obj.action_id); /*7.2*/
-    const pdef::proto::packet_interact::ActionId &action_id = obj.action_id; /*0.7*/
+    const pdef::proto::packet_interact::ActionId &V_action_id = obj.action_id; /*0.7*/
     READ_OR_BAIL(readUnsignedVarLong, obj.target_entity_id); /*0.5*/
-    switch (action_id) { /*8.0*/
+    switch (V_action_id) { /*8.0*/
       case pdef::proto::packet_interact::ActionId::MouseOverEntity: { /*8.5*/
         obj.position = {}; pdef::proto::decode::vec3f(stream, *obj.position); /*obj*/ /*4.6*/
         break;
@@ -15867,9 +15867,9 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
   }
   bool packet_animate(pdef::Stream &stream, pdef::proto::packet_animate &obj) {
     READ_OR_BAIL(readZigZagVarInt, (int&)obj.action_id); /*7.2*/
-    const pdef::proto::packet_animate::ActionId &action_id = obj.action_id; /*0.7*/
+    const pdef::proto::packet_animate::ActionId &V_action_id = obj.action_id; /*0.7*/
     READ_OR_BAIL(readUnsignedVarLong, obj.runtime_entity_id); /*0.5*/
-    switch (action_id) { /*8.0*/
+    switch (V_action_id) { /*8.0*/
       case pdef::proto::packet_animate::ActionId::RowRight: { /*8.5*/
           READ_OR_BAIL(readFloatLE, obj.boat_rowing_time); /*0.5*/
         break;
@@ -15910,7 +15910,7 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
     READ_OR_BAIL(readUnsignedVarInt, (int&)obj.window_id); /*7.2*/
     int input_len; READ_OR_BAIL(readUnsignedVarInt, input_len); /*1.5*/
     obj.input.resize(input_len); /*1.6*/
-    for (int i = 0; i < input_len; i++) {
+    for (int i = 0; i < input_len; i++) { /*3.3*/
       auto &v2 = obj.input[i]; /*3.4*/
       pdef::proto::decode::Item(stream, v2); /*v2*/ /*4.6*/
     }
@@ -15943,7 +15943,7 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
     for (int i = 0; i < potion_container_recipes_len; i++) { pdef::proto::decode::PotionContainerChangeRecipes(stream, obj.potion_container_recipes[i]); } /*2.8*/
     int material_reducers_len; READ_OR_BAIL(readUnsignedVarInt, material_reducers_len); /*1.5*/
     obj.material_reducers.resize(material_reducers_len); /*1.6*/
-    for (int i = 0; i < material_reducers_len; i++) {
+    for (int i = 0; i < material_reducers_len; i++) { /*3.3*/
       auto &v2 = obj.material_reducers[i]; /*3.4*/
       pdef::proto::decode::MaterialReducer(stream, v2); /*v2*/ /*4.6*/
     }
@@ -15956,13 +15956,13 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
     READ_OR_BAIL(readULongBE, obj.recipe_id); /*0.5*/
     int input_len; READ_OR_BAIL(readUnsignedVarInt, input_len); /*1.5*/
     obj.input.resize(input_len); /*1.6*/
-    for (int i = 0; i < input_len; i++) {
+    for (int i = 0; i < input_len; i++) { /*3.3*/
       auto &v2 = obj.input[i]; /*3.4*/
       pdef::proto::decode::Item(stream, v2); /*v2*/ /*4.6*/
     }
     int result_len; READ_OR_BAIL(readUnsignedVarInt, result_len); /*1.5*/
     obj.result.resize(result_len); /*1.6*/
-    for (int i = 0; i < result_len; i++) {
+    for (int i = 0; i < result_len; i++) { /*3.3*/
       auto &v2 = obj.result[i]; /*3.4*/
       pdef::proto::decode::Item(stream, v2); /*v2*/ /*4.6*/
     }
@@ -16020,17 +16020,17 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
     READ_OR_BAIL(readZigZagVarInt, obj.x); /*0.5*/
     READ_OR_BAIL(readZigZagVarInt, obj.z); /*0.5*/
     READ_OR_BAIL(readUnsignedVarInt, obj.sub_chunk_count); /*0.5*/
-    int &sub_chunk_count = obj.sub_chunk_count; /*0.6*/
-    if (sub_chunk_count == -2) { /*8.2*/
+    int &V_sub_chunk_count = obj.sub_chunk_count; /*0.6*/
+    if (V_sub_chunk_count == -2) { /*8.2*/
       READ_OR_BAIL(readUShortLE, obj.highest_subchunk_count); /*0.5*/
     }
     READ_OR_BAIL(readBool, (bool&)obj.cache_enabled); /*0.5*/
-    bool &cache_enabled = obj.cache_enabled; /*0.6*/
-    if (cache_enabled == true) { /*8.1*/
+    bool &V_cache_enabled = obj.cache_enabled; /*0.6*/
+    if (V_cache_enabled == true) { /*8.1*/
          obj.blobs = {}; pdef::proto::packet_level_chunk::Blobs &v2 = *obj.blobs; /*8.4*/
         int hashes_len; READ_OR_BAIL(readUnsignedVarInt, hashes_len); /*1.5*/
         v2.hashes.resize(hashes_len); /*1.6*/
-        for (int i = 0; i < hashes_len; i++) {
+        for (int i = 0; i < hashes_len; i++) { /*3.3*/
           auto &v4 = v2.hashes[i]; /*3.4*/
           READ_OR_BAIL(readULongLE, v4); /*0.5*/
         }
@@ -16084,36 +16084,36 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
     obj.update_flags.texture = update_flags_val & ((int)1 << 1);
     obj.update_flags.decoration = update_flags_val & ((int)1 << 2);
     obj.update_flags.initialisation = update_flags_val & ((int)1 << 3); /*update_flags: bitflags*/ /*4.3*/
-    pdef::proto::packet_clientbound_map_item_data::update_flags_t &update_flags = obj.update_flags; /*4.8*/
+    pdef::proto::packet_clientbound_map_item_data::update_flags_t &V_update_flags = obj.update_flags; /*4.8*/
     READ_OR_BAIL(readUByte, obj.dimension); /*0.5*/
     READ_OR_BAIL(readBool, (bool&)obj.locked); /*0.5*/
-    if (update_flags.initialisation == true) { /*8.2*/
+    if (V_update_flags.initialisation == true) { /*8.2*/
       int included_in_len; READ_OR_BAIL(readUnsignedVarInt, included_in_len); /*1.5*/
       obj.included_in.resize(included_in_len); /*1.6*/
-      for (int i = 0; i < included_in_len; i++) {
+      for (int i = 0; i < included_in_len; i++) { /*3.3*/
         auto &v3 = obj.included_in[i]; /*3.4*/
         READ_OR_BAIL(readZigZagVarLong, v3); /*0.5*/
       }
     }
-    if ((update_flags.initialisation || update_flags.decoration || update_flags.texture) == true) { /*8.2*/
+    if ((V_update_flags.initialisation || V_update_flags.decoration || V_update_flags.texture) == true) { /*8.2*/
       READ_OR_BAIL(readUByte, obj.scale); /*0.5*/
     }
-    if (update_flags.decoration == true) { /*8.2*/
+    if (V_update_flags.decoration == true) { /*8.2*/
          obj.tracked = {}; pdef::proto::packet_clientbound_map_item_data::Tracked &v2 = *obj.tracked; /*8.4*/
         int objects_len; READ_OR_BAIL(readUnsignedVarInt, objects_len); /*1.5*/
         v2.objects.resize(objects_len); /*1.6*/
-        for (int i = 0; i < objects_len; i++) {
+        for (int i = 0; i < objects_len; i++) { /*3.3*/
           auto &v4 = v2.objects[i]; /*3.4*/
           pdef::proto::decode::TrackedObject(stream, v4); /*v4*/ /*4.6*/
         }
         int decorations_len; READ_OR_BAIL(readUnsignedVarInt, decorations_len); /*1.5*/
         v2.decorations.resize(decorations_len); /*1.6*/
-        for (int i = 0; i < decorations_len; i++) {
+        for (int i = 0; i < decorations_len; i++) { /*3.3*/
           auto &v4 = v2.decorations[i]; /*3.4*/
           pdef::proto::decode::MapDecoration(stream, v4); /*v4*/ /*4.6*/
         }
     }
-    if (update_flags.texture == true) { /*8.2*/
+    if (V_update_flags.texture == true) { /*8.2*/
          obj.texture = {}; pdef::proto::packet_clientbound_map_item_data::Texture &v2 = *obj.texture; /*8.4*/
         READ_OR_BAIL(readZigZagVarInt, v2.width); /*0.5*/
         READ_OR_BAIL(readZigZagVarInt, v2.height); /*0.5*/
@@ -16121,7 +16121,7 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
         READ_OR_BAIL(readZigZagVarInt, v2.y_offset); /*0.5*/
         int pixels_len; READ_OR_BAIL(readUnsignedVarInt, pixels_len); /*1.5*/
         v2.pixels.resize(pixels_len); /*1.6*/
-        for (int i = 0; i < pixels_len; i++) {
+        for (int i = 0; i < pixels_len; i++) { /*3.3*/
           auto &v4 = v2.pixels[i]; /*3.4*/
           READ_OR_BAIL(readUnsignedVarInt, v4); /*0.5*/
         }
@@ -16147,7 +16147,7 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
   bool packet_game_rules_changed(pdef::Stream &stream, pdef::proto::packet_game_rules_changed &obj) {
     int rules_len; READ_OR_BAIL(readUnsignedVarInt, rules_len); /*1.5*/
     obj.rules.resize(rules_len); /*1.6*/
-    for (int i = 0; i < rules_len; i++) {
+    for (int i = 0; i < rules_len; i++) { /*3.3*/
       auto &v2 = obj.rules[i]; /*3.4*/
       pdef::proto::decode::GameRule(stream, v2); /*v2*/ /*4.6*/
     }
@@ -16161,8 +16161,8 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
   bool packet_boss_event(pdef::Stream &stream, pdef::proto::packet_boss_event &obj) {
     READ_OR_BAIL(readZigZagVarLong, obj.boss_entity_id); /*0.5*/
     READ_OR_BAIL(readUnsignedVarInt, (int&)obj.type); /*7.2*/
-    const pdef::proto::packet_boss_event::Type &type = obj.type; /*0.7*/
-    switch (type) { /*8.0*/
+    const pdef::proto::packet_boss_event::Type &V_type = obj.type; /*0.7*/
+    switch (V_type) { /*8.0*/
       case pdef::proto::packet_boss_event::Type::ShowBar: { /*8.5*/
           int title_strlen; READ_OR_BAIL(readUnsignedVarInt, title_strlen);
           if (!stream.readString(obj.title, title_strlen)) return false; /*title: pstring*/ /*4.3*/
@@ -16215,17 +16215,17 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
   }
   bool packet_available_commands(pdef::Stream &stream, pdef::proto::packet_available_commands &obj) {
     READ_OR_BAIL(readUnsignedVarInt, obj.values_len); /*0.5*/
-    int &values_len = obj.values_len; /*0.6*/
-    pdef::proto::packet_available_commands::_EnumType _enum_type; if (values_len <= 0xff) { _enum_type = pdef::proto::packet_available_commands::_EnumType::Byte; } else if (values_len <= 0xffff) { _enum_type = pdef::proto::packet_available_commands::_EnumType::Short; } else { _enum_type = pdef::proto::packet_available_commands::_EnumType::Int; } /*_enum_type: enum_size_based_on_values_len*/ /*4.3*/
-    obj.enum_values.resize(values_len); /*1.6*/
-    for (int i = 0; i < values_len; i++) {
+    int &V_values_len = obj.values_len; /*0.6*/
+    pdef::proto::packet_available_commands::_EnumType V__enum_type; if (V_values_len <= 0xff) { V__enum_type = pdef::proto::packet_available_commands::_EnumType::Byte; } else if (V_values_len <= 0xffff) { V__enum_type = pdef::proto::packet_available_commands::_EnumType::Short; } else { V__enum_type = pdef::proto::packet_available_commands::_EnumType::Int; } /*_enum_type: enum_size_based_on_values_len*/ /*4.3*/
+    obj.enum_values.resize(V_values_len); /*1.6*/
+    for (int i = 0; i < V_values_len; i++) { /*3.3*/
       auto &v2 = obj.enum_values[i]; /*3.4*/
       int _strlen; READ_OR_BAIL(readUnsignedVarInt, _strlen);
       if (!stream.readString(v2, _strlen)) return false; /*: pstring*/ /*4.3*/
     }
     int suffixes_len; READ_OR_BAIL(readUnsignedVarInt, suffixes_len); /*1.5*/
     obj.suffixes.resize(suffixes_len); /*1.6*/
-    for (int i = 0; i < suffixes_len; i++) {
+    for (int i = 0; i < suffixes_len; i++) { /*3.3*/
       auto &v2 = obj.suffixes[i]; /*3.4*/
       int _strlen; READ_OR_BAIL(readUnsignedVarInt, _strlen);
       if (!stream.readString(v2, _strlen)) return false; /*: pstring*/ /*4.3*/
@@ -16236,13 +16236,13 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
       pdef::proto::packet_available_commands::Enums &v2 = obj.enums[i]; /*5.23*/
       int name_strlen; READ_OR_BAIL(readUnsignedVarInt, name_strlen);
       if (!stream.readString(v2.name, name_strlen)) return false; /*name: pstring*/ /*4.3*/
-      if (_enum_type == pdef::proto::packet_available_commands::_EnumType::Byte) { /*8.5*/
+      if (V__enum_type == pdef::proto::packet_available_commands::_EnumType::Byte) { /*8.5*/
         READ_OR_BAIL(readUByte, v2.values_u8); /*0.5*/
       }
-      else if (_enum_type == pdef::proto::packet_available_commands::_EnumType::Short) { /*8.5*/
+      else if (V__enum_type == pdef::proto::packet_available_commands::_EnumType::Short) { /*8.5*/
         READ_OR_BAIL(readUShortLE, v2.values_lu16); /*0.5*/
       }
-      else if (_enum_type == pdef::proto::packet_available_commands::_EnumType::Int) { /*8.5*/
+      else if (V__enum_type == pdef::proto::packet_available_commands::_EnumType::Int) { /*8.5*/
         READ_OR_BAIL(readUIntLE, v2.values_lu32); /*0.5*/
       }
     }
@@ -16288,7 +16288,7 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
       if (!stream.readString(v2.name, name_strlen)) return false; /*name: pstring*/ /*4.3*/
       int values_len; READ_OR_BAIL(readUnsignedVarInt, values_len); /*1.5*/
       v2.values.resize(values_len); /*1.6*/
-      for (int i = 0; i < values_len; i++) {
+      for (int i = 0; i < values_len; i++) { /*3.3*/
         auto &v3 = v2.values[i]; /*3.4*/
         int _strlen; READ_OR_BAIL(readUnsignedVarInt, _strlen);
         if (!stream.readString(v3, _strlen)) return false; /*: pstring*/ /*4.3*/
@@ -16318,14 +16318,14 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
   }
   bool packet_command_block_update(pdef::Stream &stream, pdef::proto::packet_command_block_update &obj) {
     READ_OR_BAIL(readBool, (bool&)obj.is_block); /*0.5*/
-    bool &is_block = obj.is_block; /*0.6*/
-    if (is_block == true) { /*8.1*/
+    bool &V_is_block = obj.is_block; /*0.6*/
+    if (V_is_block == true) { /*8.1*/
         obj.position = {}; pdef::proto::decode::BlockCoordinates(stream, *obj.position); /*obj*/ /*4.6*/
         READ_OR_BAIL(readUnsignedVarInt, (int&)obj.mode); /*7.2*/
         READ_OR_BAIL(readBool, (bool&)obj.needs_redstone); /*0.5*/
         READ_OR_BAIL(readBool, (bool&)obj.conditional); /*0.5*/
     }
-    else if (is_block == false) { /*8.1*/
+    else if (V_is_block == false) { /*8.1*/
         READ_OR_BAIL(readUnsignedVarLong, obj.minecart_entity_runtime_id); /*0.5*/
     }
     int command_strlen; READ_OR_BAIL(readUnsignedVarInt, command_strlen);
@@ -16342,7 +16342,7 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
   bool packet_command_output(pdef::Stream &stream, pdef::proto::packet_command_output &obj) {
     pdef::proto::decode::CommandOrigin(stream, obj.origin); /*obj*/ /*4.6*/
     READ_OR_BAIL(readByte, (int8_t&)obj.output_type); /*7.2*/
-    const pdef::proto::packet_command_output::OutputType &output_type = obj.output_type; /*0.7*/
+    const pdef::proto::packet_command_output::OutputType &V_output_type = obj.output_type; /*0.7*/
     READ_OR_BAIL(readUnsignedVarInt, obj.success_count); /*0.5*/
     int output_len; READ_OR_BAIL(readUnsignedVarInt, output_len); /*1.5*/
     obj.output.resize(output_len); /*1.6*/
@@ -16353,13 +16353,13 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
       if (!stream.readString(v2.message_id, message_id_strlen)) return false; /*message_id: pstring*/ /*4.3*/
       int parameters_len; READ_OR_BAIL(readUnsignedVarInt, parameters_len); /*1.5*/
       v2.parameters.resize(parameters_len); /*1.6*/
-      for (int i = 0; i < parameters_len; i++) {
+      for (int i = 0; i < parameters_len; i++) { /*3.3*/
         auto &v3 = v2.parameters[i]; /*3.4*/
         int _strlen; READ_OR_BAIL(readUnsignedVarInt, _strlen);
         if (!stream.readString(v3, _strlen)) return false; /*: pstring*/ /*4.3*/
       }
     }
-    switch (output_type) { /*8.0*/
+    switch (V_output_type) { /*8.0*/
       case pdef::proto::packet_command_output::OutputType::DataSet: { /*8.5*/
         int data_set_strlen; READ_OR_BAIL(readUnsignedVarInt, data_set_strlen);
         if (!stream.readString(obj.data_set, data_set_strlen)) return false; /*data_set: pstring*/ /*4.3*/
@@ -16477,7 +16477,7 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
   bool packet_purchase_receipt(pdef::Stream &stream, pdef::proto::packet_purchase_receipt &obj) {
     int receipts_len; READ_OR_BAIL(readUnsignedVarInt, receipts_len); /*1.5*/
     obj.receipts.resize(receipts_len); /*1.6*/
-    for (int i = 0; i < receipts_len; i++) {
+    for (int i = 0; i < receipts_len; i++) { /*3.3*/
       auto &v2 = obj.receipts[i]; /*3.4*/
       int _strlen; READ_OR_BAIL(readUnsignedVarInt, _strlen);
       if (!stream.readString(v2, _strlen)) return false; /*: pstring*/ /*4.3*/
@@ -16509,9 +16509,9 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
   }
   bool packet_book_edit(pdef::Stream &stream, pdef::proto::packet_book_edit &obj) {
     READ_OR_BAIL(readUByte, (uint8_t&)obj.type); /*7.2*/
-    const pdef::proto::packet_book_edit::Type &type = obj.type; /*0.7*/
+    const pdef::proto::packet_book_edit::Type &V_type = obj.type; /*0.7*/
     READ_OR_BAIL(readUByte, obj.slot); /*0.5*/
-    switch (type) { /*8.0*/
+    switch (V_type) { /*8.0*/
       case pdef::proto::packet_book_edit::Type::ReplacePage: { /*8.5*/
           READ_OR_BAIL(readUByte, obj.page_number); /*0.5*/
           int text_strlen; READ_OR_BAIL(readUnsignedVarInt, text_strlen);
@@ -16623,7 +16623,7 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
   }
   bool packet_set_score(pdef::Stream &stream, pdef::proto::packet_set_score &obj) {
     READ_OR_BAIL(readUByte, (uint8_t&)obj.action); /*7.2*/
-    const pdef::proto::packet_set_score::Action &action = obj.action; /*0.7*/
+    const pdef::proto::packet_set_score::Action &V_action = obj.action; /*0.7*/
     int entries_len; READ_OR_BAIL(readUnsignedVarInt, entries_len); /*1.5*/
     obj.entries.resize(entries_len); /*1.6*/
     for (int i = 0; i < entries_len; i++) { /*5*/
@@ -16632,11 +16632,11 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
       int objective_name_strlen; READ_OR_BAIL(readUnsignedVarInt, objective_name_strlen);
       if (!stream.readString(v2.objective_name, objective_name_strlen)) return false; /*objective_name: pstring*/ /*4.3*/
       READ_OR_BAIL(readIntLE, v2.score); /*0.5*/
-      switch (action) { /*8.0*/
+      switch (V_action) { /*8.0*/
         case pdef::proto::packet_set_score::Action::Change: { /*8.5*/
             READ_OR_BAIL(readByte, (int8_t&)v2.entry_type); /*7.2*/
-            const pdef::proto::packet_set_score::Entries::EntryType &entry_type = v2.entry_type; /*0.7*/
-            switch (entry_type) { /*8.0*/
+            const pdef::proto::packet_set_score::Entries::EntryType &V_entry_type = v2.entry_type; /*0.7*/
+            switch (V_entry_type) { /*8.0*/
               case pdef::proto::packet_set_score::Entries::EntryType::Player: { /*8.5*/
                 READ_OR_BAIL(readZigZagVarLong, v2.entity_unique_id); /*0.5*/
                 break;
@@ -16647,7 +16647,7 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
               } /*8.7*/
               default: break; /*avoid unhandled case warning*/
             } /*8.8*/
-            switch (entry_type) { /*8.0*/
+            switch (V_entry_type) { /*8.0*/
               case pdef::proto::packet_set_score::Entries::EntryType::FakePlayer: { /*8.5*/
                 int custom_name_strlen; READ_OR_BAIL(readUnsignedVarInt, custom_name_strlen);
                 if (!stream.readString(v2.custom_name, custom_name_strlen)) return false; /*custom_name: pstring*/ /*4.3*/
@@ -16696,36 +16696,36 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
     obj.flags.on_ground = (flags_val & 64) == 64;
     obj.flags.teleport = (flags_val & 128) == 128;
     obj.flags.force_move = (flags_val & 256) == 256; /*flags: bitflags*/ /*4.3*/
-    pdef::proto::packet_move_entity_delta::flags_t &flags = obj.flags; /*4.8*/
-    if (flags.has_x == true) { /*8.2*/
+    pdef::proto::packet_move_entity_delta::flags_t &V_flags = obj.flags; /*4.8*/
+    if (V_flags.has_x == true) { /*8.2*/
       READ_OR_BAIL(readFloatLE, obj.x); /*0.5*/
     }
-    if (flags.has_y == true) { /*8.2*/
+    if (V_flags.has_y == true) { /*8.2*/
       READ_OR_BAIL(readFloatLE, obj.y); /*0.5*/
     }
-    if (flags.has_z == true) { /*8.2*/
+    if (V_flags.has_z == true) { /*8.2*/
       READ_OR_BAIL(readFloatLE, obj.z); /*0.5*/
     }
-    if (flags.has_rot_x == true) { /*8.2*/
+    if (V_flags.has_rot_x == true) { /*8.2*/
       READ_OR_BAIL(readUByte, obj.rot_x); /*0.5*/
     }
-    if (flags.has_rot_y == true) { /*8.2*/
+    if (V_flags.has_rot_y == true) { /*8.2*/
       READ_OR_BAIL(readUByte, obj.rot_y); /*0.5*/
     }
-    if (flags.has_rot_z == true) { /*8.2*/
+    if (V_flags.has_rot_z == true) { /*8.2*/
       READ_OR_BAIL(readUByte, obj.rot_z); /*0.5*/
     }
     return true;
   }
   bool packet_set_scoreboard_identity(pdef::Stream &stream, pdef::proto::packet_set_scoreboard_identity &obj) {
     READ_OR_BAIL(readByte, (int8_t&)obj.action); /*7.2*/
-    const pdef::proto::packet_set_scoreboard_identity::Action &action = obj.action; /*0.7*/
+    const pdef::proto::packet_set_scoreboard_identity::Action &V_action = obj.action; /*0.7*/
     int entries_len; READ_OR_BAIL(readUnsignedVarInt, entries_len); /*1.5*/
     obj.entries.resize(entries_len); /*1.6*/
     for (int i = 0; i < entries_len; i++) { /*5*/
       pdef::proto::packet_set_scoreboard_identity::Entries &v2 = obj.entries[i]; /*5.23*/
       READ_OR_BAIL(readZigZagVarLong, v2.scoreboard_id); /*0.5*/
-      switch (action) { /*8.0*/
+      switch (V_action) { /*8.0*/
         case pdef::proto::packet_set_scoreboard_identity::Action::RegisterIdentity: { /*8.5*/
           READ_OR_BAIL(readZigZagVarLong, v2.entity_unique_id); /*0.5*/
           break;
@@ -16744,7 +16744,7 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
     if (!stream.readString(obj.enum_type, enum_type_strlen)) return false; /*enum_type: pstring*/ /*4.3*/
     int options_len; READ_OR_BAIL(readUnsignedVarInt, options_len); /*1.5*/
     obj.options.resize(options_len); /*1.6*/
-    for (int i = 0; i < options_len; i++) {
+    for (int i = 0; i < options_len; i++) { /*3.3*/
       auto &v2 = obj.options[i]; /*3.4*/
       int _strlen; READ_OR_BAIL(readUnsignedVarInt, _strlen);
       if (!stream.readString(v2, _strlen)) return false; /*: pstring*/ /*4.3*/
@@ -16860,8 +16860,8 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
     int name_strlen; READ_OR_BAIL(readUnsignedVarInt, name_strlen);
     if (!stream.readString(obj.name, name_strlen)) return false; /*name: pstring*/ /*4.3*/
     READ_OR_BAIL(readBool, (bool&)obj.success); /*0.5*/
-    bool &success = obj.success; /*0.6*/
-    if (success == true) { /*8.1*/
+    bool &V_success = obj.success; /*0.6*/
+    if (V_success == true) { /*8.1*/
       READ_OR_BAIL(readByte, obj.nbt); /*0.5*/
     }
     READ_OR_BAIL(readUByte, (uint8_t&)obj.response_type); /*7.2*/
@@ -16873,16 +16873,16 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
   }
   bool packet_client_cache_blob_status(pdef::Stream &stream, pdef::proto::packet_client_cache_blob_status &obj) {
     READ_OR_BAIL(readUnsignedVarInt, obj.misses); /*0.5*/
-    int &misses = obj.misses; /*0.6*/
+    int &V_misses = obj.misses; /*0.6*/
     READ_OR_BAIL(readUnsignedVarInt, obj.haves); /*0.5*/
-    int &haves = obj.haves; /*0.6*/
-    obj.missing.resize(misses); /*1.6*/
-    for (int i = 0; i < misses; i++) {
+    int &V_haves = obj.haves; /*0.6*/
+    obj.missing.resize(V_misses); /*1.6*/
+    for (int i = 0; i < V_misses; i++) { /*3.3*/
       auto &v2 = obj.missing[i]; /*3.4*/
       READ_OR_BAIL(readULongLE, v2); /*0.5*/
     }
-    obj.have.resize(haves); /*1.6*/
-    for (int i = 0; i < haves; i++) {
+    obj.have.resize(V_haves); /*1.6*/
+    for (int i = 0; i < V_haves; i++) { /*3.3*/
       auto &v2 = obj.have[i]; /*3.4*/
       READ_OR_BAIL(readULongLE, v2); /*0.5*/
     }
@@ -16891,7 +16891,7 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
   bool packet_client_cache_miss_response(pdef::Stream &stream, pdef::proto::packet_client_cache_miss_response &obj) {
     int blobs_len; READ_OR_BAIL(readUnsignedVarInt, blobs_len); /*1.5*/
     obj.blobs.resize(blobs_len); /*1.6*/
-    for (int i = 0; i < blobs_len; i++) {
+    for (int i = 0; i < blobs_len; i++) { /*3.3*/
       auto &v2 = obj.blobs[i]; /*3.4*/
       pdef::proto::decode::Blob(stream, v2); /*v2*/ /*4.6*/
     }
@@ -16909,22 +16909,22 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
     int screenshot_border_path_strlen; READ_OR_BAIL(readUnsignedVarInt, screenshot_border_path_strlen);
     if (!stream.readString(obj.screenshot_border_path, screenshot_border_path_strlen)) return false; /*screenshot_border_path: pstring*/ /*4.3*/
     READ_OR_BAIL(readBool, (bool&)obj.has_agent_capabilities); /*0.5*/
-    bool &has_agent_capabilities = obj.has_agent_capabilities; /*0.6*/
-    if (has_agent_capabilities == true) { /*8.1*/
+    bool &V_has_agent_capabilities = obj.has_agent_capabilities; /*0.6*/
+    if (V_has_agent_capabilities == true) { /*8.1*/
          obj.agent_capabilities = {}; pdef::proto::packet_education_settings::AgentCapabilities &v2 = *obj.agent_capabilities; /*8.4*/
         READ_OR_BAIL(readBool, (bool&)v2.has); /*0.5*/
         READ_OR_BAIL(readBool, (bool&)v2.can_modify_blocks); /*0.5*/
     }
     READ_OR_BAIL(readBool, (bool&)obj.HasOverrideURI); /*0.5*/
-    bool &HasOverrideURI = obj.HasOverrideURI; /*0.6*/
-    if (HasOverrideURI == true) { /*8.1*/
+    bool &V_HasOverrideURI = obj.HasOverrideURI; /*0.6*/
+    if (V_HasOverrideURI == true) { /*8.1*/
       int OverrideURI_strlen; READ_OR_BAIL(readUnsignedVarInt, OverrideURI_strlen);
       if (!stream.readString(obj.OverrideURI, OverrideURI_strlen)) return false; /*OverrideURI: pstring*/ /*4.3*/
     }
     READ_OR_BAIL(readBool, (bool&)obj.HasQuiz); /*0.5*/
     READ_OR_BAIL(readBool, (bool&)obj.has_external_link_settings); /*0.5*/
-    bool &has_external_link_settings = obj.has_external_link_settings; /*0.6*/
-    if (has_external_link_settings == true) { /*8.1*/
+    bool &V_has_external_link_settings = obj.has_external_link_settings; /*0.6*/
+    if (V_has_external_link_settings == true) { /*8.1*/
          obj.external_link_settings = {}; pdef::proto::packet_education_settings::ExternalLinkSettings &v2 = *obj.external_link_settings; /*8.4*/
         READ_OR_BAIL(readBool, (bool&)v2.has); /*0.5*/
         int url_strlen; READ_OR_BAIL(readUnsignedVarInt, url_strlen);
@@ -17010,12 +17010,12 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
     obj.input_data.item_interact = input_data_val & ((int64_t)1 << 34);
     obj.input_data.block_action = input_data_val & ((int64_t)1 << 35);
     obj.input_data.item_stack_request = input_data_val & ((int64_t)1 << 36); /*input_data: bitflags*/ /*4.3*/
-    pdef::proto::packet_player_auth_input::input_data_t &input_data = obj.input_data; /*4.8*/
+    pdef::proto::packet_player_auth_input::input_data_t &V_input_data = obj.input_data; /*4.8*/
     READ_OR_BAIL(readUnsignedVarInt, (int&)obj.input_mode); /*7.2*/
     READ_OR_BAIL(readUnsignedVarInt, (int&)obj.play_mode); /*7.2*/
-    const pdef::proto::packet_player_auth_input::PlayMode &play_mode = obj.play_mode; /*0.7*/
+    const pdef::proto::packet_player_auth_input::PlayMode &V_play_mode = obj.play_mode; /*0.7*/
     READ_OR_BAIL(readZigZagVarInt, (int&)obj.interaction_model); /*7.2*/
-    switch (play_mode) { /*8.0*/
+    switch (V_play_mode) { /*8.0*/
       case pdef::proto::packet_player_auth_input::PlayMode::Reality: { /*8.5*/
         obj.gaze_direction = {}; pdef::proto::decode::vec3f(stream, *obj.gaze_direction); /*obj*/ /*4.6*/
         break;
@@ -17024,7 +17024,7 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
     } /*8.8*/
     READ_OR_BAIL(readUnsignedVarLong, obj.tick); /*0.5*/
     pdef::proto::decode::vec3f(stream, obj.delta); /*obj*/ /*4.6*/
-    if (input_data.item_interact == true) { /*8.2*/
+    if (V_input_data.item_interact == true) { /*8.2*/
          obj.transaction = {}; pdef::proto::packet_player_auth_input::Transaction &v2 = *obj.transaction; /*8.4*/
         pdef::proto::decode::TransactionLegacy(stream, v2.legacy); /*v2*/ /*4.6*/
         int actions_len; /*2.3*/
@@ -17033,33 +17033,33 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
         for (int i = 0; i < actions_len; i++) { pdef::proto::decode::TransactionActions(stream, v2.actions[i]); } /*2.8*/
         pdef::proto::decode::TransactionUseItem(stream, v2.data); /*v2*/ /*4.6*/
     }
-    if (input_data.item_stack_request == true) { /*8.2*/
+    if (V_input_data.item_stack_request == true) { /*8.2*/
       obj.item_stack_request = {}; pdef::proto::decode::ItemStackRequest(stream, *obj.item_stack_request); /*obj*/ /*4.6*/
     }
-    if (input_data.block_action == true) { /*8.2*/
+    if (V_input_data.block_action == true) { /*8.2*/
       int block_action_len; READ_OR_BAIL(readZigZagVarInt, block_action_len); /*1.5*/
       obj.block_action.resize(block_action_len); /*1.6*/
       for (int i = 0; i < block_action_len; i++) { /*5*/
         pdef::proto::packet_player_auth_input::BlockAction &v3 = obj.block_action[i]; /*5.23*/
         READ_OR_BAIL(readZigZagVarInt, (int&)v3.action); /*7.2*/
-        const pdef::proto::packet_player_auth_input::BlockAction::Action &action = v3.action; /*0.7*/
-        if (action == pdef::proto::packet_player_auth_input::BlockAction::Action::StartBreak) { /*8.5*/
+        const pdef::proto::packet_player_auth_input::BlockAction::Action &V_action = v3.action; /*0.7*/
+        if (V_action == pdef::proto::packet_player_auth_input::BlockAction::Action::StartBreak) { /*8.5*/
             v3.position = {}; pdef::proto::decode::vec3i(stream, *v3.position); /*v3*/ /*4.6*/
             READ_OR_BAIL(readZigZagVarInt, v3.face); /*0.5*/
         }
-        else if (action == pdef::proto::packet_player_auth_input::BlockAction::Action::AbortBreak) { /*8.5*/
+        else if (V_action == pdef::proto::packet_player_auth_input::BlockAction::Action::AbortBreak) { /*8.5*/
             v3.position = {}; pdef::proto::decode::vec3i(stream, *v3.position); /*v3*/ /*4.6*/
             READ_OR_BAIL(readZigZagVarInt, v3.face); /*0.5*/
         }
-        else if (action == pdef::proto::packet_player_auth_input::BlockAction::Action::CrackBreak) { /*8.5*/
+        else if (V_action == pdef::proto::packet_player_auth_input::BlockAction::Action::CrackBreak) { /*8.5*/
             v3.position = {}; pdef::proto::decode::vec3i(stream, *v3.position); /*v3*/ /*4.6*/
             READ_OR_BAIL(readZigZagVarInt, v3.face); /*0.5*/
         }
-        else if (action == pdef::proto::packet_player_auth_input::BlockAction::Action::PredictBreak) { /*8.5*/
+        else if (V_action == pdef::proto::packet_player_auth_input::BlockAction::Action::PredictBreak) { /*8.5*/
             v3.position = {}; pdef::proto::decode::vec3i(stream, *v3.position); /*v3*/ /*4.6*/
             READ_OR_BAIL(readZigZagVarInt, v3.face); /*0.5*/
         }
-        else if (action == pdef::proto::packet_player_auth_input::BlockAction::Action::ContinueBreak) { /*8.5*/
+        else if (V_action == pdef::proto::packet_player_auth_input::BlockAction::Action::ContinueBreak) { /*8.5*/
             v3.position = {}; pdef::proto::decode::vec3i(stream, *v3.position); /*v3*/ /*4.6*/
             READ_OR_BAIL(readZigZagVarInt, v3.face); /*0.5*/
         }
@@ -17080,7 +17080,7 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
   bool packet_player_enchant_options(pdef::Stream &stream, pdef::proto::packet_player_enchant_options &obj) {
     int options_len; READ_OR_BAIL(readUnsignedVarInt, options_len); /*1.5*/
     obj.options.resize(options_len); /*1.6*/
-    for (int i = 0; i < options_len; i++) {
+    for (int i = 0; i < options_len; i++) { /*3.3*/
       auto &v2 = obj.options[i]; /*3.4*/
       pdef::proto::decode::EnchantOption(stream, v2); /*v2*/ /*4.6*/
     }
@@ -17089,7 +17089,7 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
   bool packet_item_stack_request(pdef::Stream &stream, pdef::proto::packet_item_stack_request &obj) {
     int requests_len; READ_OR_BAIL(readUnsignedVarInt, requests_len); /*1.5*/
     obj.requests.resize(requests_len); /*1.6*/
-    for (int i = 0; i < requests_len; i++) {
+    for (int i = 0; i < requests_len; i++) { /*3.3*/
       auto &v2 = obj.requests[i]; /*3.4*/
       pdef::proto::decode::ItemStackRequest(stream, v2); /*v2*/ /*4.6*/
     }
@@ -17109,17 +17109,17 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
     obj.type.chest = (type_val & 2) == 2;
     obj.type.legs = (type_val & 4) == 4;
     obj.type.feet = (type_val & 8) == 8; /*type: bitflags*/ /*4.3*/
-    pdef::proto::packet_player_armor_damage::type_t &type = obj.type; /*4.8*/
-    if (type.head == true) { /*8.2*/
+    pdef::proto::packet_player_armor_damage::type_t &V_type = obj.type; /*4.8*/
+    if (V_type.head == true) { /*8.2*/
       READ_OR_BAIL(readZigZagVarInt, obj.helmet_damage); /*0.5*/
     }
-    if (type.chest == true) { /*8.2*/
+    if (V_type.chest == true) { /*8.2*/
       READ_OR_BAIL(readZigZagVarInt, obj.chestplate_damage); /*0.5*/
     }
-    if (type.legs == true) { /*8.2*/
+    if (V_type.legs == true) { /*8.2*/
       READ_OR_BAIL(readZigZagVarInt, obj.leggings_damage); /*0.5*/
     }
-    if (type.feet == true) { /*8.2*/
+    if (V_type.feet == true) { /*8.2*/
       READ_OR_BAIL(readZigZagVarInt, obj.boots_damage); /*0.5*/
     }
     return true;
@@ -17133,7 +17133,7 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
     READ_OR_BAIL(readUnsignedVarLong, obj.player_id); /*0.5*/
     int emote_pieces_len; READ_OR_BAIL(readUnsignedVarInt, emote_pieces_len); /*1.5*/
     obj.emote_pieces.resize(emote_pieces_len); /*1.6*/
-    for (int i = 0; i < emote_pieces_len; i++) {
+    for (int i = 0; i < emote_pieces_len; i++) { /*3.3*/
       auto &v2 = obj.emote_pieces[i]; /*3.4*/
       READ_OR_BAIL(readULongBE, v2); /*0.5*/
     }
@@ -17177,7 +17177,7 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
     READ_OR_BAIL(readFloatLE, obj.blend_out_time); /*0.5*/
     int runtime_entity_ids_len; READ_OR_BAIL(readUnsignedVarInt, runtime_entity_ids_len); /*1.5*/
     obj.runtime_entity_ids.resize(runtime_entity_ids_len); /*1.6*/
-    for (int i = 0; i < runtime_entity_ids_len; i++) {
+    for (int i = 0; i < runtime_entity_ids_len; i++) { /*3.3*/
       auto &v2 = obj.runtime_entity_ids[i]; /*3.4*/
       READ_OR_BAIL(readUnsignedVarLong, v2); /*0.5*/
     }
@@ -17193,7 +17193,7 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
   bool packet_player_fog(pdef::Stream &stream, pdef::proto::packet_player_fog &obj) {
     int stack_len; READ_OR_BAIL(readUnsignedVarInt, stack_len); /*1.5*/
     obj.stack.resize(stack_len); /*1.6*/
-    for (int i = 0; i < stack_len; i++) {
+    for (int i = 0; i < stack_len; i++) { /*3.3*/
       auto &v2 = obj.stack[i]; /*3.4*/
       int _strlen; READ_OR_BAIL(readUnsignedVarInt, _strlen);
       if (!stream.readString(v2, _strlen)) return false; /*: pstring*/ /*4.3*/
@@ -17222,8 +17222,8 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
   }
   bool packet_debug_renderer(pdef::Stream &stream, pdef::proto::packet_debug_renderer &obj) {
     READ_OR_BAIL(readIntLE, (int32_t&)obj.type); /*7.2*/
-    const pdef::proto::packet_debug_renderer::Type &type = obj.type; /*0.7*/
-    switch (type) { /*8.0*/
+    const pdef::proto::packet_debug_renderer::Type &V_type = obj.type; /*0.7*/
+    switch (V_type) { /*8.0*/
       case pdef::proto::packet_debug_renderer::Type::Clear: { /*8.5*/
         break;
       } /*8.7*/
@@ -17298,13 +17298,13 @@ bool ItemComponentList(pdef::Stream &stream, pdef::proto::ItemComponentList &obj
     READ_OR_BAIL(readZigZagVarInt, obj.z); /*0.5*/
     int blocks_len; READ_OR_BAIL(readUnsignedVarInt, blocks_len); /*1.5*/
     obj.blocks.resize(blocks_len); /*1.6*/
-    for (int i = 0; i < blocks_len; i++) {
+    for (int i = 0; i < blocks_len; i++) { /*3.3*/
       auto &v2 = obj.blocks[i]; /*3.4*/
       pdef::proto::decode::BlockUpdate(stream, v2); /*v2*/ /*4.6*/
     }
     int extra_len; READ_OR_BAIL(readUnsignedVarInt, extra_len); /*1.5*/
     obj.extra.resize(extra_len); /*1.6*/
-    for (int i = 0; i < extra_len; i++) {
+    for (int i = 0; i < extra_len; i++) { /*3.3*/
       auto &v2 = obj.extra[i]; /*3.4*/
       pdef::proto::decode::BlockUpdate(stream, v2); /*v2*/ /*4.6*/
     }
@@ -17321,8 +17321,8 @@ bool SubChunkEntryWithoutCaching(pdef::Stream &stream, pdef::proto::SubChunkEntr
     READ_OR_BAIL(readUByte, (uint8_t&)obj.result); /*7.2*/
     int payload_len; READ_OR_BAIL(readUnsignedVarInt, payload_len);if (!stream.readBuffer(obj.payload, payload_len)) return false; /*payload: buffer*/ /*4.3*/
     READ_OR_BAIL(readUByte, (uint8_t&)obj.heightmap_type); /*7.2*/
-    const pdef::proto::SubChunkEntryWithoutCaching::HeightmapType &heightmap_type = obj.heightmap_type; /*0.7*/
-    switch (heightmap_type) { /*8.0*/
+    const pdef::proto::SubChunkEntryWithoutCaching::HeightmapType &V_heightmap_type = obj.heightmap_type; /*0.7*/
+    switch (V_heightmap_type) { /*8.0*/
       case pdef::proto::SubChunkEntryWithoutCaching::HeightmapType::HasData: { /*8.5*/
         if (!stream.readBuffer(obj.heightmap, 256)) return false; /*heightmap: buffer*/ /*4.3*/
         break;
@@ -17336,8 +17336,8 @@ bool SubChunkEntryWithCaching(pdef::Stream &stream, pdef::proto::SubChunkEntryWi
     READ_OR_BAIL(readByte, obj.dy); /*0.5*/
     READ_OR_BAIL(readByte, obj.dz); /*0.5*/
     READ_OR_BAIL(readUByte, (uint8_t&)obj.result); /*7.2*/
-    const pdef::proto::SubChunkEntryWithCaching::Result &result = obj.result; /*0.7*/
-    switch (result) { /*8.0*/
+    const pdef::proto::SubChunkEntryWithCaching::Result &V_result = obj.result; /*0.7*/
+    switch (V_result) { /*8.0*/
       case pdef::proto::SubChunkEntryWithCaching::Result::SuccessAllAir: { /*8.5*/
         break;
       } /*8.7*/
@@ -17347,8 +17347,8 @@ bool SubChunkEntryWithCaching(pdef::Stream &stream, pdef::proto::SubChunkEntryWi
       } /*8.7*/
     } /*8.8*/
     READ_OR_BAIL(readUByte, (uint8_t&)obj.heightmap_type); /*7.2*/
-    const pdef::proto::SubChunkEntryWithCaching::HeightmapType &heightmap_type = obj.heightmap_type; /*0.7*/
-    switch (heightmap_type) { /*8.0*/
+    const pdef::proto::SubChunkEntryWithCaching::HeightmapType &V_heightmap_type = obj.heightmap_type; /*0.7*/
+    switch (V_heightmap_type) { /*8.0*/
       case pdef::proto::SubChunkEntryWithCaching::HeightmapType::HasData: { /*8.5*/
         if (!stream.readBuffer(obj.heightmap, 256)) return false; /*heightmap: buffer*/ /*4.3*/
         break;
@@ -17360,16 +17360,16 @@ bool SubChunkEntryWithCaching(pdef::Stream &stream, pdef::proto::SubChunkEntryWi
 }
   bool packet_subchunk(pdef::Stream &stream, pdef::proto::packet_subchunk &obj) {
     READ_OR_BAIL(readBool, (bool&)obj.cache_enabled); /*0.5*/
-    bool &cache_enabled = obj.cache_enabled; /*0.6*/
+    bool &V_cache_enabled = obj.cache_enabled; /*0.6*/
     READ_OR_BAIL(readZigZagVarInt, obj.dimension); /*0.5*/
     pdef::proto::decode::vec3i(stream, obj.origin); /*obj*/ /*4.6*/
-    if (cache_enabled == true) { /*8.1*/
+    if (V_cache_enabled == true) { /*8.1*/
       uint32_t entries_SubChunkEntryWithCaching_len; /*2.3*/
       READ_OR_BAIL(readUIntLE, entries_SubChunkEntryWithCaching_len); /*2.6*/
       obj.entries_SubChunkEntryWithCaching.resize(entries_SubChunkEntryWithCaching_len); /*2.7*/
       for (int i = 0; i < entries_SubChunkEntryWithCaching_len; i++) { pdef::proto::decode::SubChunkEntryWithCaching(stream, obj.entries_SubChunkEntryWithCaching[i]); } /*2.8*/
     }
-    else if (cache_enabled == false) { /*8.1*/
+    else if (V_cache_enabled == false) { /*8.1*/
       uint32_t entries_SubChunkEntryWithoutCaching_len; /*2.3*/
       READ_OR_BAIL(readUIntLE, entries_SubChunkEntryWithoutCaching_len); /*2.6*/
       obj.entries_SubChunkEntryWithoutCaching.resize(entries_SubChunkEntryWithoutCaching_len); /*2.7*/
@@ -17484,8 +17484,8 @@ bool SubChunkEntryWithCaching(pdef::Stream &stream, pdef::proto::SubChunkEntryWi
   }
   bool mcpe_packet(pdef::Stream &stream, pdef::proto::mcpe_packet &obj) {
     READ_OR_BAIL(readUnsignedVarInt, (int&)obj.name); /*7.2*/
-    const pdef::proto::mcpe_packet::Name &name = obj.name; /*0.7*/
-    switch (name) { /*8.0*/
+    const pdef::proto::mcpe_packet::Name &V_name = obj.name; /*0.7*/
+    switch (V_name) { /*8.0*/
       case pdef::proto::mcpe_packet::Name::Login: { /*8.5*/
         obj.params_packet_login = {}; pdef::proto::decode::packet_login(stream, *obj.params_packet_login); /*obj*/ /*4.6*/
         break;

--- a/examples/mcpe-protocol/main.js
+++ b/examples/mcpe-protocol/main.js
@@ -33,13 +33,13 @@ protodefCpp.compile({
         return s
       },
       read (args, [name], makeCallingCode) {
-        return `pdef::proto::packet_available_commands::_EnumType ${name}; if (values_len <= 0xff) { ${name} = pdef::proto::packet_available_commands::_EnumType::Byte; } else if (values_len <= 0xffff) { ${name} = pdef::proto::packet_available_commands::_EnumType::Short; } else { ${name} = pdef::proto::packet_available_commands::_EnumType::Int; }`
+        return `pdef::proto::packet_available_commands::_EnumType V_${name}; if (V_values_len <= 0xff) { V_${name} = pdef::proto::packet_available_commands::_EnumType::Byte; } else if (V_values_len <= 0xffff) { V_${name} = pdef::proto::packet_available_commands::_EnumType::Short; } else { V_${name} = pdef::proto::packet_available_commands::_EnumType::Int; }`
       },
       write (args, [name], makeCallingCode) {
-        return `pdef::proto::packet_available_commands::_EnumType ${name}; if (values_len <= 0xff) { ${name} = pdef::proto::packet_available_commands::_EnumType::Byte; } else if (values_len <= 0xffff) { ${name} = pdef::proto::packet_available_commands::_EnumType::Short; } else { ${name} = pdef::proto::packet_available_commands::_EnumType::Int; }`
+        return `pdef::proto::packet_available_commands::_EnumType V_${name}; if (V_values_len <= 0xff) { V_${name} = pdef::proto::packet_available_commands::_EnumType::Byte; } else if (V_values_len <= 0xffff) { V_${name} = pdef::proto::packet_available_commands::_EnumType::Short; } else { V_${name} = pdef::proto::packet_available_commands::_EnumType::Int; }`
       },
       size (args, [name], makeCallingCode) {
-        return `pdef::proto::packet_available_commands::_EnumType ${name}; if (values_len <= 0xff) { ${name} = pdef::proto::packet_available_commands::_EnumType::Byte; } else if (values_len <= 0xffff) { ${name} = pdef::proto::packet_available_commands::_EnumType::Short; } else { ${name} = pdef::proto::packet_available_commands::_EnumType::Int; }`
+        return `pdef::proto::packet_available_commands::_EnumType V_${name}; if (V_values_len <= 0xff) { V_${name} = pdef::proto::packet_available_commands::_EnumType::Byte; } else if (V_values_len <= 0xffff) { V_${name} = pdef::proto::packet_available_commands::_EnumType::Short; } else { V_${name} = pdef::proto::packet_available_commands::_EnumType::Int; }`
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test": "mocha --reporter spec --exit",
     "pretest": "npm run lint",
     "lint": "standard",
-    "fix": "standard --fix"
+    "fix": "standard --fix",
+    "mocha": "mocha --bail --exit"
   },
   "bin": {
     "protodef-cpp": "src/cli.js"


### PR DESCRIPTION
Variables that are added to the block scope (used inside switches/array conditions) are now prefixed with "V_" to avoid naming collisions.

Also improve switch handling with OR/AND conditions.